### PR TITLE
feat(sidebar): floating card shadow, session title, and 3-state sidebar

### DIFF
--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -1,5 +1,61 @@
 # Session Notes — Ghostties
 
+## Feb 26, 2026 (Evening)
+
+### 3-State Sidebar State Machine + Code Review + Design Review
+
+Implemented the full sidebar state machine (pinned/closed/overlay), ran a 6-agent code review, fixed all findings, and ran a design quality review with fixes.
+
+### Features Implemented
+
+1. **3-state sidebar state machine**: Replaced boolean `isSidebarVisible` with `SidebarMode` enum (`.pinned`, `.closed`, `.overlay`) across 4 files
+   - Traffic lights hidden when sidebar closed
+   - Hover-to-reveal overlay via NSTrackingArea (10pt left edge trigger)
+   - Centralized `transitionTo()` method with 8-step state transition
+   - Dual mutually-exclusive leading constraints for pinned vs overlay/closed
+   - Overlay z-ordering via `layer.zPosition`
+   - Window resign auto-dismisses overlay
+   - Backward-compatible persistence (old `sidebarVisible: Bool` → new `sidebarMode: SidebarMode`)
+
+2. **Code review remediation (6 findings)**: Fixed all P1/P2/P3 from 6-agent review
+   - P1-007: Added explicit `shadowPath` in `layout()` for GPU performance
+   - P1-008: Added `deinit` + `viewDidMoveToWindow` observer cleanup
+   - P1-009: Updated persistence tests for new `sidebarMode` API + 3 new tests (legacy migration, invalid raw value)
+   - P2-010: Toggle `isHidden` on NSVisualEffectViews when inactive (compositing fix)
+   - P2-011: Decode `SidebarMode` as raw `Int` then safe-construct (prevents data wipe on invalid value)
+   - P3-012: Simplified mouse handlers, cached titlebar text field, `.removeDuplicates()`, removed zone userInfo
+
+3. **Design quality review (score 79→85/100)**: Fixed 3 a11y warnings
+   - Added `.accessibilityLabel("Projects")` to sidebar ScrollView
+   - Added `.focusable()` to toolbar buttons
+   - Added reduced motion check (`accessibilityDisplayShouldReduceMotion`)
+
+4. **Solution docs**: Documented 3-state sidebar pattern and Codable enum hardening
+
+### Files Modified
+- `WorkspaceLayout.swift` — `SidebarMode` enum, `overlayTriggerWidth` constant
+- `WorkspacePersistence.swift` — `sidebarMode` replaces `sidebarVisible`, backward-compat decoding, raw Int hardening
+- `WorkspaceStore.swift` — `sidebarMode` property, overlay→closed on persist
+- `WorkspaceViewContainer.swift` — Full state machine rewrite with all review fixes
+- `WorkspacePersistenceTests.swift` — Updated API + 3 new tests
+- `WorkspaceSidebarView.swift` — a11y fixes (ScrollView label, focusable buttons)
+
+### New Files Created
+- `docs/solutions/architecture/sidebar-3-state-machine-overlay-pattern.md`
+- `docs/solutions/logic-errors/codable-enum-raw-value-wipes-state.md`
+- `todos/007-012` — 6 review finding files (all marked complete)
+
+### Commits
+- `ecb7f04` feat(sidebar): 3-state machine (pinned/closed/overlay) with review fixes
+- `25b5511` docs: add solution docs and mark review todos complete
+
+### Notes for Next Session
+- Design quality score: 85/100 (4 suggestions remain — all judgment calls)
+- App built and launches successfully
+- Manual testing checklist: pinned↔closed toggle, hover overlay trigger/dismiss, overlay→pinned promotion, window resign dismiss, dark mode, persistence round-trip
+
+---
+
 ## Feb 26, 2026
 
 ### Design Work — Paper

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -1,5 +1,41 @@
 # Session Notes — Ghostties
 
+## Feb 27, 2026
+
+### Terminal Card Refinement — Safe Area Fix, Shadow Tuning, Corner Rounding
+
+Refined the floating terminal card to match the Paper design (artboard Q3-0). Fixed the card not reaching the top of the window, tuned shadow opacity, and improved corner rounding.
+
+### Root Cause — Top Constraint Not Working
+
+`WorkspaceViewContainer.topAnchor` included ~28pt of safe area inset from the titlebar (even though `titlebarAppearsTransparent = true`). Changing the constraint constant from 8 to 2 had no visible effect because the safe area dominated. Override `safeAreaInsets` to return `NSEdgeInsetsZero` solved the problem — constraints now measure from the actual window edge.
+
+### Changes Made
+
+1. **Safe area override**: Added `override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }` to `WorkspaceViewContainer`
+2. **Shadow opacity**: Tuned from 0.15 → 0.2 (tested at 0.3, settled on 0.2 per design comparison)
+3. **Continuous corner rounding**: Added `.continuous` cornerCurve + explicit `maskedCorners` for all four corners
+4. **Design-verified padding**: Confirmed via Paper computed styles that design uses 8pt on all four sides (equal inset)
+
+### Files Modified
+- `WorkspaceViewContainer.swift` — safe area override, shadow opacity (0.15→0.2), corner curve/masking
+- `WorkspaceLayout.swift` — clarified comment that design uses 8pt on all four sides
+
+### Commits
+- `a8a4fece7` feat(sidebar): safe area fix, shadow tuning, and continuous corner rounding
+
+### Key Learnings
+- **NSView.topAnchor includes safe area**: With `.fullSizeContentView`, the safe area inset from the titlebar shifts `topAnchor` down. Override `safeAreaInsets` to zero when you need constraints to measure from the actual window edge.
+- **Design comparison workflow**: Used Paper `get_computed_styles` to extract exact measurements from design (padding, shadow, border radius) and matched implementation to those values.
+
+### Notes for Next Session
+- Terminal card now matches Paper design for padding, shadow, and corner rounding
+- Hover/open/close animation still needs refinement (noted but not started)
+- 7 manual testing findings from Feb 20-22 still pending
+- Fullscreen transitions and dark mode still need verification
+
+---
+
 ## Feb 26, 2026 (Late Night — Continued)
 
 ### Titlebar Arc-Style Alignment — Remove Accessory Inflation

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -1,5 +1,37 @@
 # Session Notes — Ghostties
 
+## Feb 26, 2026 (Late Night)
+
+### Titlebar Hiding — Force Base Terminal Nib
+
+Fixed the native macOS window titlebar that persisted in workspace mode despite multiple hiding attempts. The root cause was `macos-titlebar-style = tabs` in user config, which loaded `TitlebarTabsVenturaTerminalWindow` — a complex subclass with its own toolbar title rendering and titlebar background painting that overrode all standard NSWindow hiding APIs.
+
+### Investigation Trail (4 failed approaches → 1 solution)
+
+1. **KVO + isHidden on NSTextField** — macOS resets `isHidden` internally
+2. **alphaValue + async dispatch** — targeted wrong element (native NSTextField vs custom TerminalToolbar)
+3. **toolbar = nil** — removed "~" text but titlebar band remained (subclass paints `titlebarContainer.layer?.backgroundColor`)
+4. **Clear titlebar background** — `syncAppearance()` immediately repainted it
+5. **Force base "Terminal" nib** — bypasses the complex subclass entirely; `titleVisibility = .hidden` + `titlebarAppearsTransparent = true` work correctly on the base `TerminalWindow`
+
+### Files Modified
+- `TerminalController.swift` — `windowNibName` forced to "Terminal", added `configureWorkspaceTitlebar()`
+- `WorkspaceViewContainer.swift` — removed KVO title observer, cached text field, and title-hiding workarounds (-42 lines)
+
+### New Files Created
+- `docs/solutions/architecture/nib-window-subclass-titlebar-hiding.md` — full solution documentation
+
+### Commits
+- `509fc927f` fix(titlebar): force base Terminal nib to hide workspace titlebar
+
+### Notes for Next Session
+- Titlebar is now transparent with no visible title text
+- Sidebar state machine (pinned/closed/overlay) still working correctly
+- 7 manual testing findings from Feb 20-22 still pending
+- More workspace sidebar work remains
+
+---
+
 ## Feb 26, 2026 (Evening)
 
 ### 3-State Sidebar State Machine + Code Review + Design Review

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -29,11 +29,23 @@ Implemented all 5 phases of the sidebar visual polish plan to bring the sidebar 
 
 - `ProjectDisclosureRow.swift`, `SessionDetailView.swift`, `WorkspaceSidebarView.swift`, `WorkspaceLayout.swift`, `WorkspaceViewContainer.swift`
 
+### Commits
+
+- `119c635c2` feat(sidebar): visual polish — ghost characters, pixel chevrons, design parity
+
 ### Key Learnings
 
 - **Pixel art pattern**: GeometryReader + Path with grid array is reusable for both ghosts and chevrons
 - **Adaptive colors**: `Color(.secondaryLabelColor)` auto-adapts to dark/light; use WorkspaceLayout constants for custom themed values
 - **Hover state pattern**: `@State isHovered` + `.onHover { isHovered = $0 }` — extract to private struct when reused
+
+### Remaining Refinements (P2/P3 from code review)
+
+- Remove `GeometryReader` from `PixelChevronView` (fixed 8×8 size doesn't need it)
+- Use `@Environment(\.accessibilityReduceMotion)` instead of `NSWorkspace` call
+- Extract `SessionStatus.color` extension to deduplicate status color logic
+- Use adaptive `NSColor(name:dynamicProvider:)` to eliminate `colorScheme` ternaries
+- Rename `SessionDetailView.swift` → `SessionRow.swift` to match contents
 
 ---
 

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -1,5 +1,42 @@
 # Session Notes — Ghostties
 
+## Feb 27, 2026 (Session 2)
+
+### Sidebar Visual Polish — Ghost Characters, Pixel Chevrons, Design Parity
+
+Implemented all 5 phases of the sidebar visual polish plan to bring the sidebar to parity with Paper design mockups (artboards `1O-0` dark, `XX-0` light).
+
+### Changes Made
+
+1. **PixelChevronView** (new): Pixel-art chevron matching ghost aesthetic, 7×5 grid via Path, rotation animation gated on reduced motion
+2. **ProjectDisclosureRow**: Replaced SF Symbol chevron with PixelChevronView, added plus icon in header, hover states, expanded container background, Move Up/Down context menu
+3. **SessionRow**: Complete rewrite — ghost character on right side, themed active row background + shadow, hover feedback, 28pt height
+4. **WorkspaceSidebarView**: Toolbar hover states via ToolbarIconButton, empty state with ghost + add button
+5. **WorkspaceLayout**: Extracted shared color constants (expandedContainer, activeRow for dark/light)
+6. **WorkspaceViewContainer**: Reduced title label font size (13→11) and adjusted top constraint
+
+### Design Review Results
+
+- Initial implementation: 82/100
+- After 6 fixes (reduced motion, hit targets, adaptive colors, constants, grid spacing, hover): 88/100
+
+### New Files
+
+- `macos/Sources/Features/Ghostties/PixelChevronView.swift`
+- `docs/solutions/ui-bugs/sidebar-visual-polish-design-parity.md`
+
+### Files Modified
+
+- `ProjectDisclosureRow.swift`, `SessionDetailView.swift`, `WorkspaceSidebarView.swift`, `WorkspaceLayout.swift`, `WorkspaceViewContainer.swift`
+
+### Key Learnings
+
+- **Pixel art pattern**: GeometryReader + Path with grid array is reusable for both ghosts and chevrons
+- **Adaptive colors**: `Color(.secondaryLabelColor)` auto-adapts to dark/light; use WorkspaceLayout constants for custom themed values
+- **Hover state pattern**: `@State isHovered` + `.onHover { isHovered = $0 }` — extract to private struct when reused
+
+---
+
 ## Feb 27, 2026
 
 ### Terminal Card Refinement — Safe Area Fix, Shadow Tuning, Corner Rounding

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -1,5 +1,34 @@
 # Session Notes — Ghostties
 
+## Feb 26, 2026 (Late Night — Continued)
+
+### Titlebar Arc-Style Alignment — Remove Accessory Inflation
+
+Eliminated the visible titlebar band and aligned traffic lights with sidebar toolbar buttons, matching the Arc/Dia Browser pattern where the titlebar is invisible and content extends flush to the window chrome.
+
+### Root Cause
+
+Two `NSTitlebarAccessoryViewControllers` (resetZoom + update notification) added in `TerminalWindow.awakeFromNib()` inflated the titlebar from ~28pt to ~50-60pt. Additionally, missing `titlebarSeparatorStyle = .none` and missing `.ignoresSafeArea(.container, edges: .top)` on the SwiftUI sidebar.
+
+### Files Modified
+- `TerminalController.swift` — expanded `configureWorkspaceTitlebar()` with accessory removal loop + separator suppression
+- `WorkspaceSidebarView.swift` — added `.ignoresSafeArea(.container, edges: .top)` to root view
+
+### New Files Created
+- `docs/solutions/architecture/titlebar-accessory-inflation-arc-style-fix.md` — full solution documentation
+- `docs/plans/2026-02-26-fix-workspace-titlebar-arc-style-alignment-plan.md` — implementation plan
+
+### Commits
+- `024ae3bc1` fix(titlebar): remove accessory inflation for Arc-style invisible titlebar
+
+### Notes for Next Session
+- Titlebar is now fully invisible — traffic lights and sidebar buttons aligned
+- All 3 sidebar states (pinned/closed/overlay) render correctly
+- Remaining plan items: verify fullscreen transitions, confirm `syncAppearance()` doesn't revert, dark mode testing
+- 7 manual testing findings from Feb 20-22 still pending
+
+---
+
 ## Feb 26, 2026 (Late Night)
 
 ### Titlebar Hiding — Force Base Terminal Nib

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -1,5 +1,38 @@
 # Session Notes — Ghostties
 
+## Feb 27, 2026 (Session 3)
+
+### Title Styling Fix + Code Review Hardening
+
+Fixed terminal session title styling to match Paper design, then ran full code review and resolved all findings.
+
+### Title Styling (Design Parity)
+
+- Font size: 13pt → 11pt (matches Paper artboard Q3-0)
+- Top offset: `(titlebarSpacerHeight - 16) / 2` → `6pt` (matches 6px paddingBlock from design)
+
+### Code Review Findings Resolved
+
+**P2 — Important:**
+1. **Protect sidebarMode write access** — Made `WorkspaceStore.sidebarMode` `private(set)` with explicit `updateSidebarMode(_:)` method. Enforces unidirectional data flow at compile time.
+2. **Scope backgroundEffectView** — Constrained trailing edge to `sidebarHostingView.trailingAnchor` instead of full window width. Eliminates wasted vibrancy compositing behind the opaque terminal.
+3. **Thread-safe resolvedPaths cache** — Wrapped `SessionCoordinator._resolvedPaths` with `NSLock`. Eliminates undefined behavior from concurrent Dictionary mutation on detached tasks.
+
+**P3 — Nice-to-Have:**
+4. **Overlay transition debounce** — Added 0.25s `CACurrentMediaTime()` guard in `transitionTo()` to prevent rapid closed↔overlay oscillation near the hover boundary.
+5. **Double-layer overlay encode guard** — Added overlay→closed mapping in `State.encode(to:)` so the invariant is enforced at the encoding layer too.
+6. **Overlay persistence round-trip test** — New test verifying `.overlay` encodes as `.closed`.
+
+### Files Modified
+- `WorkspaceViewContainer.swift` — title font 13→11, top offset→6, backgroundEffectView scoped, transition debounce, updateSidebarMode call
+- `WorkspaceStore.swift` — `private(set) sidebarMode`, `updateSidebarMode(_:)` method
+- `WorkspacePersistence.swift` — overlay→closed guard in `encode(to:)`
+- `SessionCoordinator.swift` — NSLock-guarded `_resolvedPaths` cache
+- `WorkspacePersistenceTests.swift` — overlay persistence round-trip test
+
+### Commits
+- TBD (this session)
+
 ## Feb 27, 2026 (Session 2)
 
 ### Sidebar Visual Polish — Ghost Characters, Pixel Chevrons, Design Parity

--- a/docs/plans/2026-02-26-fix-workspace-titlebar-arc-style-alignment-plan.md
+++ b/docs/plans/2026-02-26-fix-workspace-titlebar-arc-style-alignment-plan.md
@@ -1,0 +1,184 @@
+---
+title: "fix: Workspace Titlebar Arc-Style Alignment"
+type: fix
+date: 2026-02-26
+---
+
+# fix: Workspace Titlebar Arc-Style Alignment
+
+## Overview
+
+Eliminate the visible titlebar band in workspace mode and align traffic lights with the sidebar toolbar buttons on the same horizontal line — matching the Arc/Dia Browser pattern where the titlebar is invisible and content extends flush to the window chrome.
+
+## Problem Statement
+
+The current implementation shows a visible titlebar band at the top of the window. Traffic lights sit in this band at the macOS default position, while the sidebar toolbar buttons (+, sidebar toggle) appear in a separate row below. The design (Paper artboard `Q3-0`) shows all of these on ONE horizontal line with no band.
+
+**Current state:** Title text and background are gone (from the nib fix in `509fc927f`), but the titlebar area still occupies extra vertical space.
+
+**Target state:** Zero visible titlebar — sidebar background extends flush to the window chrome, traffic lights and sidebar buttons share the same row.
+
+## Root Causes
+
+### 1. NSTitlebarAccessoryViewControllers inflate titlebar height
+
+The base `TerminalWindow.awakeFromNib()` adds two accessories that inflate the titlebar from ~28pt to ~50-60pt:
+
+```swift
+// TerminalWindow.swift:131-149
+resetZoomAccessory.layoutAttribute = .right
+addTitlebarAccessoryViewController(resetZoomAccessory)   // +height
+
+updateAccessory.layoutAttribute = .right
+addTitlebarAccessoryViewController(updateAccessory)       // +height
+```
+
+In workspace mode, the sidebar replaces these — they should be removed.
+
+### 2. Missing `titlebarSeparatorStyle = .none`
+
+The default separator style draws a hairline between the titlebar and content. Not set anywhere in the workspace flow. Only set in `TitlebarTabsVenturaTerminalWindow` (which we bypass).
+
+### 3. Potential safe area inset pushing SwiftUI content down
+
+With `.fullSizeContentView`, the window's safe area includes the titlebar height. If the sidebar's `NSHostingView` passes this safe area to SwiftUI, the `VStack` in `WorkspaceSidebarView` may be pushed down by the titlebar inset, creating a gap even though the frame extends to the top.
+
+Evidence: `TerminalView.swift:108` explicitly uses `.ignoresSafeArea(.container, edges: .top)` for hidden titlebar mode. The workspace sidebar does NOT have this modifier.
+
+## Proposed Solution
+
+Follow the Arc/Dia pattern: keep `.titled` + `.fullSizeContentView` for the window frame and traffic lights, but remove everything that inflates or decorates the titlebar.
+
+### Phase 1: Remove Titlebar Inflation
+
+**File:** `TerminalController.swift` — `configureWorkspaceTitlebar()`
+
+```swift
+private func configureWorkspaceTitlebar() {
+    guard let window else { return }
+
+    window.titleVisibility = .hidden
+    window.titlebarAppearsTransparent = true
+    window.titlebarSeparatorStyle = .none
+
+    // Remove titlebar accessories — the workspace sidebar replaces them.
+    // Without this, resetZoomAccessory and updateAccessory inflate the
+    // titlebar height, creating a visible band.
+    while !window.titlebarAccessoryViewControllers.isEmpty {
+        window.removeTitlebarAccessoryViewController(at: 0)
+    }
+}
+```
+
+- [x] Add `window.titlebarSeparatorStyle = .none`
+- [x] Remove all `NSTitlebarAccessoryViewControllers` in the loop
+
+### Phase 2: Safe Area Inset Fix
+
+**File:** `WorkspaceSidebarView.swift` — root body view
+
+```swift
+var body: some View {
+    VStack(spacing: 0) {
+        titlebarToolbar
+        ScrollView { ... }
+        Spacer(minLength: 0)
+    }
+    .background(.clear)
+    .ignoresSafeArea(.container, edges: .top)
+}
+```
+
+- [x] Add `.ignoresSafeArea(.container, edges: .top)` to the sidebar root view
+- [ ] Verify the `titlebarToolbar` starts at y=0 of the hosting view frame (no padding from safe area)
+
+### Phase 3: Verify Traffic Light Alignment
+
+With the inflated titlebar removed (standard ~28pt), the `titlebarSpacerHeight = 38` should provide correct alignment:
+
+- Traffic lights at macOS default: ~(7, 6) from window top
+- Traffic light vertical center: ~14pt from top
+- Sidebar toolbar buttons centered in 38pt: ~19pt from top
+
+If these are close enough (within 2-3pt), no repositioning needed. If visibly misaligned:
+
+- [ ] Adjust `WorkspaceLayout.titlebarSpacerHeight` to match the actual titlebar height
+- [ ] OR reposition traffic lights with `setFrameOrigin` (requires `NSWindow.didResizeNotification` observation for the macOS revert-on-resize bug)
+
+### Phase 4: Guard Against Reapplication
+
+macOS can reset titlebar properties during `syncAppearance`, fullscreen transitions, and title updates. The base `TerminalWindow.syncAppearance()` (line 433) does NOT touch titlebar properties, so this should be safe. But verify:
+
+- [ ] Confirm `titlebarAppearsTransparent` survives `syncAppearance` calls
+- [ ] Confirm accessories don't get re-added by any codepath
+- [ ] Test fullscreen enter/exit doesn't restore the band
+
+## Technical Considerations
+
+### What NOT to do (from institutional learnings)
+
+| Approach | Why it fails |
+|----------|-------------|
+| KVO observer on `window.title` to hide NSTextField | macOS resets `isHidden` internally |
+| `alphaValue = 0` on titlebar elements | Targets wrong elements, fragile |
+| Hide `NSTitlebarContainerView` entirely | Also hides traffic lights |
+| Clear `titlebarContainer.layer?.backgroundColor` | `syncAppearance()` repaints it |
+
+### The Arc/Dia recipe (what DOES work)
+
+```
+.titled + .fullSizeContentView + titlebarAppearsTransparent + titleVisibility(.hidden)
++ titlebarSeparatorStyle(.none) + NO accessories + NO toolbar
+= invisible titlebar with traffic lights at natural position
+```
+
+### Files to modify
+
+| File | Changes |
+|------|---------|
+| `TerminalController.swift` | Add `titlebarSeparatorStyle = .none`, remove accessories in `configureWorkspaceTitlebar()` |
+| `WorkspaceSidebarView.swift` | Add `.ignoresSafeArea(.container, edges: .top)` if needed |
+| `WorkspaceLayout.swift` | Adjust `titlebarSpacerHeight` if alignment is off (may not be needed) |
+
+### Files NOT modified
+
+| File | Why safe |
+|------|---------|
+| `TerminalWindow.swift` | Accessories are added in `awakeFromNib()` — we remove them afterward in the controller |
+| `WorkspaceViewContainer.swift` | Already has correct constraint setup; `.fullSizeContentView` already inserted |
+
+## Acceptance Criteria
+
+- [ ] No visible titlebar band in workspace mode (pinned, closed, and overlay states)
+- [ ] Traffic lights and sidebar toolbar buttons (+ and sidebar toggle) appear on the same horizontal line
+- [ ] Sidebar background extends flush to the window's top chrome edge
+- [ ] Session title label ("Front-end Swift UI") still centered in terminal card titlebar region
+- [ ] `Cmd+Shift+E` toggle still works correctly across all 3 states
+- [ ] Hover-to-reveal overlay still works
+- [ ] Fullscreen enter/exit doesn't break the titlebar
+- [ ] Dark mode renders correctly
+- [ ] App quit and relaunch restores state correctly
+
+## Verification
+
+```bash
+rm -rf macos/build && zig build run -Doptimize=ReleaseFast
+```
+
+1. Launch → confirm no band, traffic lights aligned with sidebar buttons
+2. Compare against Paper design (artboard `Q3-0`)
+3. `Cmd+Shift+E` → sidebar closes → traffic lights hide → terminal flush
+4. Hover left edge → overlay appears → traffic lights + sidebar aligned
+5. Enter/exit fullscreen → titlebar still correct
+6. Quit and relaunch → state preserved
+
+## References
+
+- **Design target:** Paper artboard `Q3-0` ("Ghostties — Title bar - terminal name inside termi...")
+- **Prior fix:** `509fc927f` — forced base Terminal nib, removed title text
+- **Solution doc:** `docs/solutions/architecture/nib-window-subclass-titlebar-hiding.md`
+- **State machine:** `docs/solutions/architecture/sidebar-3-state-machine-overlay-pattern.md`
+- **Arc/Dia research:** fullSizeContentView + titlebarAppearsTransparent + no accessories = invisible titlebar with natural traffic light position
+- **NSWindowStyles showcase:** [lukakerr/NSWindowStyles](https://github.com/lukakerr/NSWindowStyles)
+- **Traffic light repositioning:** [CocoaPods/CPModifiedDecorationsWindow](https://github.com/CocoaPods/CocoaPods-app/blob/master/app/CocoaPods/CPModifiedDecorationsWindow.swift)
+- **macOS resize revert bug:** Traffic lights revert to default position on `NSWindow.didResizeNotification` — must reapply

--- a/docs/solutions/architecture/nib-window-subclass-titlebar-hiding.md
+++ b/docs/solutions/architecture/nib-window-subclass-titlebar-hiding.md
@@ -1,0 +1,114 @@
+---
+title: "Force Base Terminal Nib to Hide Workspace Titlebar"
+category: architecture
+component: TerminalController, WorkspaceViewContainer
+symptoms:
+  - Native window title "~" visible in titlebar despite hiding attempts
+  - Visible titlebar band persists after setting titlebarAppearsTransparent
+  - KVO-based title hiding immediately overridden by window subclass
+tags:
+  - macos
+  - nswindow
+  - titlebar
+  - nib
+  - workspace-sidebar
+date_solved: 2026-02-26
+---
+
+# Force Base Terminal Nib to Hide Workspace Titlebar
+
+## Problem
+
+In workspace mode, the native macOS window title ("~") and a visible titlebar band persisted despite multiple attempts to hide them. The workspace sidebar provides its own session title label inside the floating terminal card, so the native titlebar elements are redundant.
+
+**Observable symptoms:**
+- Window title "~" displayed in the titlebar area
+- Opaque titlebar band visible between the sidebar and terminal content
+- Setting `titleVisibility = .hidden` and `titlebarAppearsTransparent = true` had no effect
+- KVO observer to hide the NSTextField was immediately overridden
+
+## Investigation
+
+### Approach 1: KVO + isHidden on NSTextField (Failed)
+
+Added a KVO observer on `window.title` to find and hide the native `NSTextField` in the titlebar view hierarchy. macOS internally manages `isHidden` on titlebar text fields and resets the value, making this approach fragile and ineffective.
+
+### Approach 2: alphaValue on NSTextField (Failed)
+
+Switched from `isHidden = true` to `alphaValue = 0` with async dispatch for timing. Still targeted the wrong element — the visible title was rendered by a custom `TerminalToolbar`, not the native NSTextField.
+
+### Approach 3: Remove toolbar (Partial)
+
+Set `window.toolbar = nil` in `configureWorkspaceTitlebar()`. This removed the "~" text (custom `CenteredDynamicLabel` in `TerminalToolbar`) but the titlebar **band** remained because `TitlebarTabsVenturaTerminalWindow` paints `titlebarContainer.layer?.backgroundColor` via its `titlebarColor` property.
+
+### Approach 4: Clear titlebar background (Failed)
+
+Cleared `titlebarContainer.layer?.backgroundColor` after each `syncAppearance()` call. The window subclass repainted it immediately — `syncAppearance()` resets `titlebarColor` from the surface config on every change.
+
+## Root Cause
+
+The user's Ghostty config (`~/.config/ghostty/config`) included:
+
+```
+macos-titlebar-style = tabs
+```
+
+This caused `TerminalController.windowNibName` to return `"TerminalTabsTitlebarVentura"`, loading the `TitlebarTabsVenturaTerminalWindow` subclass. This subclass:
+
+1. Creates a custom `TerminalToolbar` with `CenteredDynamicLabel` (line 589) that independently renders the window title
+2. Overrides `title` didSet (line 303) to update `toolbar.titleText`
+3. Overrides `titlebarColor` didSet (line 13) to paint `titlebarContainer.layer?.backgroundColor`
+4. Runs `syncAppearance()` (line 142) on every surface config change, resetting titlebar colors
+
+Standard NSWindow properties (`titleVisibility`, `titlebarAppearsTransparent`) are ineffective against these overrides because the subclass manages its own parallel title rendering and background painting systems.
+
+## Solution
+
+**Bypass the complex window subclass entirely** by forcing the base "Terminal" nib in workspace mode.
+
+### TerminalController.swift — Force base nib
+
+```swift
+override var windowNibName: NSNib.Name? {
+    // Workspace mode always uses the base Terminal nib. The sidebar
+    // replaces native tabs and provides its own titlebar appearance,
+    // so we bypass macosTitlebarStyle entirely to avoid fighting
+    // complex titlebar subclasses (TitlebarTabsVenturaTerminalWindow, etc.).
+    return "Terminal"
+}
+```
+
+### TerminalController.swift — Simple titlebar configuration
+
+```swift
+private func configureWorkspaceTitlebar() {
+    guard let window else { return }
+    window.titleVisibility = .hidden
+    window.titlebarAppearsTransparent = true
+}
+```
+
+Called once from `windowDidLoad()` after setting `WorkspaceViewContainer` as the content view.
+
+### WorkspaceViewContainer.swift — Remove workarounds
+
+Removed all previous title-hiding infrastructure:
+- `cachedTitlebarTextField` weak reference
+- `titleObservation` KVO observer
+- `hideTitlebarTextField(in:)` method
+- `observeWindowTitle(_:)` method
+- Title-related cleanup in `deinit` and `viewDidMoveToWindow()`
+
+The base `TerminalWindow` class respects standard NSWindow properties, so `titleVisibility = .hidden` and `titlebarAppearsTransparent = true` work correctly without workarounds.
+
+## Prevention
+
+1. **Match nib to mode**: When a feature replaces native window chrome (tabs, titlebar), force a nib that doesn't fight back. Complex window subclasses manage their own rendering pipelines.
+2. **Check user config**: `macos-titlebar-style` in `~/.config/ghostty/config` determines which window subclass loads. Always test with the user's actual config.
+3. **Prefer bypass over suppression**: Instead of suppressing side effects of a complex subclass (clearing backgrounds, hiding text fields, removing toolbars), avoid loading the subclass at all.
+
+## Related
+
+- [Sidebar 3-State Machine Pattern](sidebar-3-state-machine-overlay-pattern.md) — the overlay/pinned/closed state machine that this titlebar fix supports
+- `TitlebarTabsVenturaTerminalWindow.swift` — the bypassed subclass with custom toolbar and titlebar painting
+- `TerminalWindow.swift` — the base class that respects standard NSWindow properties

--- a/docs/solutions/architecture/sidebar-3-state-machine-overlay-pattern.md
+++ b/docs/solutions/architecture/sidebar-3-state-machine-overlay-pattern.md
@@ -1,0 +1,92 @@
+---
+date: 2026-02-26
+tags: [appkit, state-machine, nsview, overlay, auto-layout, nstrackingarea, animation]
+applies_to: [WorkspaceViewContainer.swift, WorkspaceLayout.swift, WorkspaceStore.swift]
+---
+
+# 3-State Sidebar: Pinned, Closed, and Hover Overlay
+
+## Problem
+
+The sidebar used a boolean `isSidebarVisible` toggle. This couldn't express a third state: sidebar floating *on top* of the terminal without pushing it right. The boolean also made it impossible to hide traffic lights only when closed, or auto-dismiss on window resign.
+
+## Root Cause
+
+A boolean conflates two independent axes: "is the sidebar showing?" and "does it affect terminal layout?" Overlay mode needs sidebar visible but terminal full-width — impossible with one bool.
+
+## Solution
+
+### 1. Tri-state enum replaces boolean
+
+```swift
+enum SidebarMode: Int, Codable {
+    case pinned   // sidebar open, terminal pushed right
+    case closed   // sidebar hidden, terminal full-width
+    case overlay  // sidebar floats on top of terminal
+}
+```
+
+### 2. Dual mutually-exclusive leading constraints
+
+The terminal's leading edge needs to follow the sidebar in pinned mode but snap to the superview in closed/overlay. Two constraints, never both active:
+
+```swift
+private var shadowHostLeadingToSidebar: NSLayoutConstraint!
+private var shadowHostLeadingToSuperview: NSLayoutConstraint!
+
+// In transitionTo():
+shadowHostLeadingToSidebar.isActive = false   // deactivate FIRST
+shadowHostLeadingToSuperview.isActive = false
+// then activate the right one
+shadowHostLeadingToSidebar.isActive = (newMode == .pinned)
+shadowHostLeadingToSuperview.isActive = (newMode != .pinned)
+```
+
+**Key gotcha:** Always deactivate both before activating one. Activating conflicting constraints simultaneously causes Auto Layout exceptions.
+
+### 3. Z-ordering for overlay via layer.zPosition
+
+In overlay mode, the sidebar must render above the terminal. Use `layer.zPosition` rather than `addSubview` reordering (which breaks constraint relationships):
+
+```swift
+case .overlay:
+    sidebarHostingView.layer?.zPosition = 100
+    sidebarOverlayBackground.layer?.zPosition = 99
+case .pinned, .closed:
+    sidebarHostingView.layer?.zPosition = 0
+    sidebarOverlayBackground.layer?.zPosition = 0
+```
+
+Requires `wantsLayer = true` set once in `setup()`.
+
+### 4. NSTrackingArea swap pattern
+
+NSTrackingArea rects are immutable. Swap the entire area on state change:
+
+- `.closed` → install trigger zone (10pt left edge strip). `mouseEntered` → `.overlay`
+- `.overlay` → install sidebar zone (220pt from left). `mouseExited` → `.closed`
+- `.pinned` → no tracking area needed
+
+```swift
+override func updateTrackingAreas() {
+    if let area = activeTrackingArea { removeTrackingArea(area) }
+    // Install new area based on current sidebarMode
+}
+```
+
+### 5. Centralized transitionTo()
+
+All state changes go through one method that handles constraints, z-ordering, animation, traffic lights, tracking areas, isHidden toggles, and persistence in a fixed order. This eliminates scattered state manipulation.
+
+### 6. Overlay is transient — persisted as .closed
+
+```swift
+let persistedMode: SidebarMode = sidebarMode == .overlay ? .closed : sidebarMode
+```
+
+## Prevention
+
+- When a boolean starts accumulating special cases, it's time for an enum.
+- Always deactivate conflicting constraints before activating new ones.
+- Use `layer.zPosition` for z-ordering, not view hierarchy reordering.
+- NSTrackingArea rects are immutable — swap the object, don't try to resize.

--- a/docs/solutions/architecture/titlebar-accessory-inflation-arc-style-fix.md
+++ b/docs/solutions/architecture/titlebar-accessory-inflation-arc-style-fix.md
@@ -1,0 +1,138 @@
+---
+title: "Remove Titlebar Accessory Inflation for Arc-Style Invisible Titlebar"
+category: architecture
+component:
+  - TerminalController
+  - WorkspaceSidebarView
+symptoms:
+  - Visible titlebar band despite titlebarAppearsTransparent = true
+  - Traffic lights and sidebar toolbar buttons on different horizontal lines
+  - ~30pt gap between window chrome and sidebar content
+tags:
+  - macos
+  - nswindow
+  - titlebar
+  - workspace-sidebar
+  - arc-browser-pattern
+  - NSTitlebarAccessoryViewController
+date_solved: 2026-02-26
+---
+
+# Remove Titlebar Accessory Inflation for Arc-Style Invisible Titlebar
+
+## Problem
+
+After forcing the base Terminal nib (commit `509fc927f`) to hide the native title text, a visible titlebar band persisted in workspace mode. The band was ~30pt tall, pushing the sidebar toolbar buttons below the traffic lights instead of aligning them on the same horizontal line.
+
+**Observable symptoms:**
+- Titlebar text and background were gone, but vertical space remained
+- Traffic lights sat higher than the sidebar's `+` and sidebar-toggle buttons
+- The sidebar background did not extend flush to the window's top chrome edge
+
+## Root Cause
+
+Two `NSTitlebarAccessoryViewControllers` added in `TerminalWindow.awakeFromNib()` inflated the titlebar height from ~28pt to ~50-60pt:
+
+```swift
+// TerminalWindow.swift — awakeFromNib()
+resetZoomAccessory.layoutAttribute = .right
+addTitlebarAccessoryViewController(resetZoomAccessory)   // +height
+
+updateAccessory.layoutAttribute = .right
+addTitlebarAccessoryViewController(updateAccessory)       // +height
+```
+
+Additionally:
+1. **Missing `titlebarSeparatorStyle = .none`** — the default separator drew a hairline between titlebar and content
+2. **Missing `.ignoresSafeArea`** — with `.fullSizeContentView`, the NSWindow safe area includes the titlebar height. The sidebar's `NSHostingView` passed this inset to SwiftUI, pushing the `VStack` down even though the frame extended to the top
+
+## Solution
+
+Three changes, all applied as a unit:
+
+### 1. Remove accessories and suppress separator
+
+**File:** `TerminalController.swift` — `configureWorkspaceTitlebar()`
+
+```swift
+private func configureWorkspaceTitlebar() {
+    guard let window else { return }
+
+    window.titleVisibility = .hidden
+    window.titlebarAppearsTransparent = true
+    window.titlebarSeparatorStyle = .none
+
+    // Remove titlebar accessories (resetZoom, update notification) that
+    // the base TerminalWindow adds in awakeFromNib. These inflate the
+    // titlebar height and create a visible band. The workspace sidebar
+    // replaces their functionality.
+    while !window.titlebarAccessoryViewControllers.isEmpty {
+        window.removeTitlebarAccessoryViewController(at: 0)
+    }
+}
+```
+
+Called from `windowDidLoad()` after setting `WorkspaceViewContainer` as the content view and after `awakeFromNib` has added the accessories.
+
+### 2. Ignore safe area in sidebar SwiftUI view
+
+**File:** `WorkspaceSidebarView.swift` — root body modifier chain
+
+```swift
+.background(.clear)
+.ignoresSafeArea(.container, edges: .top)
+```
+
+This tells SwiftUI to extend into the titlebar safe area inset, allowing the sidebar toolbar to start at y=0 of the hosting view frame.
+
+### The Arc/Dia Browser Recipe
+
+The complete pattern for an invisible titlebar with naturally-positioned traffic lights:
+
+```
+.titled + .fullSizeContentView
++ titlebarAppearsTransparent = true
++ titleVisibility = .hidden
++ titlebarSeparatorStyle = .none
++ NO NSTitlebarAccessoryViewControllers
++ NO NSToolbar
+= invisible titlebar, traffic lights at natural ~(7, 6) position
+```
+
+All components are required. Missing any one leaves visual artifacts.
+
+## Investigation Trail
+
+| # | Approach | Result | Why |
+|---|----------|--------|-----|
+| 1 | KVO + `isHidden` on NSTextField | Failed | macOS resets `isHidden` internally |
+| 2 | `alphaValue = 0` on NSTextField | Failed | Targeted wrong element |
+| 3 | `toolbar = nil` | Partial | Removed text but band remained |
+| 4 | Clear `titlebarContainer.layer?.backgroundColor` | Failed | `syncAppearance()` repaints it |
+| 5 | Force base Terminal nib (`509fc927f`) | Partial | Fixed title text, band remained |
+| 6 | Remove accessories + separator style | **Success** | Eliminates structural height inflation |
+
+**Key insight:** The titlebar band was a **structural layout problem**, not a visual style problem. The accessories reserved height that remained allocated even after hiding text. Removing the accessories prevents the height reservation entirely.
+
+## Prevention
+
+1. **The Arc/Dia pattern is atomic** — all four properties (visibility, transparency, separator, accessories) must be set together in one place. Missing one leaves artifacts.
+2. **Defer titlebar config to post-awakeFromNib** — let the base class add accessories, then remove them in the controller. Safer than preventing addition.
+3. **Always add `.ignoresSafeArea(.container, edges: .top)` to SwiftUI views that must reach the window edge** when using `.fullSizeContentView`.
+4. **Guard against reapplication** — use `while !isEmpty` loop rather than fixed count. Check that `syncAppearance()` and fullscreen transitions don't re-add accessories.
+
+## Testing Checklist
+
+- [ ] No visible band in pinned, closed, and overlay sidebar states
+- [ ] Traffic lights aligned horizontally with sidebar toolbar buttons
+- [ ] `window.titlebarAccessoryViewControllers.count == 0` after configuration
+- [ ] Fullscreen enter/exit doesn't restore the band
+- [ ] Dark/light mode toggle preserves invisible titlebar
+- [ ] App quit and relaunch restores state correctly
+
+## Related
+
+- [Force Base Terminal Nib](nib-window-subclass-titlebar-hiding.md) — prerequisite fix that bypasses the complex window subclass
+- [Sidebar 3-State Machine](sidebar-3-state-machine-overlay-pattern.md) — the pinned/closed/overlay state machine this titlebar fix supports
+- `TerminalWindow.swift` — base class where accessories are added in `awakeFromNib()`
+- `HiddenTitlebarTerminalWindow.swift` — reference for `.titled` + `.fullSizeContentView` pattern (but hides traffic lights, which we don't want)

--- a/docs/solutions/logic-errors/codable-enum-raw-value-wipes-state.md
+++ b/docs/solutions/logic-errors/codable-enum-raw-value-wipes-state.md
@@ -1,0 +1,57 @@
+---
+date: 2026-02-26
+tags: [swift, codable, persistence, data-loss, defensive-coding]
+applies_to: [WorkspacePersistence.swift]
+---
+
+# Invalid Codable Enum Raw Value Wipes All Persisted State
+
+## Problem
+
+If `workspace.json` contains `"sidebarMode": 99` (an invalid raw value for the `SidebarMode` enum), Swift's synthesized `Codable` throws a `DecodingError`. The `load()` function catches `DecodingError` by backing up the file and returning an empty `State()` — wiping all projects, sessions, and templates. One bad enum value destroys everything.
+
+## Root Cause
+
+Swift's synthesized `init(from:)` for `RawRepresentable` enums calls `fatalError`-style decoding when the raw value doesn't match any case. This bubbles up as a `DecodingError.dataCorrupted`, which is indistinguishable from truly corrupted JSON. The catch-all handler treats it the same as a completely garbled file.
+
+## Solution
+
+Decode as the raw type (`Int`) first, then safe-construct the enum:
+
+```swift
+// Instead of:
+// self.sidebarMode = try container.decode(SidebarMode.self, forKey: .sidebarMode)
+
+// Do this:
+if let rawMode = try container.decodeIfPresent(Int.self, forKey: .sidebarMode),
+   let mode = SidebarMode(rawValue: rawMode) {
+    self.sidebarMode = mode
+} else if let visible = try container.decodeIfPresent(Bool.self, forKey: .sidebarVisible) {
+    // Legacy migration
+    self.sidebarMode = visible ? .pinned : .closed
+} else {
+    self.sidebarMode = .pinned  // safe default
+}
+```
+
+This gracefully falls through to a default for unknown values instead of throwing.
+
+### Test coverage added
+
+```swift
+@Test func decodingInvalidSidebarModeRawValueDefaultsToPinned() throws {
+    let json = """
+    { "projects": [], "sessions": [], "templates": [], "sidebarMode": 99 }
+    """
+    let decoded = try JSONDecoder().decode(State.self, from: Data(json.utf8))
+    #expect(decoded.sidebarMode == .pinned)
+    #expect(decoded.projects.isEmpty)  // NOT wiped
+}
+```
+
+## Prevention
+
+- **Never use synthesized Codable for enums in persistence files.** Always decode as the raw type and safe-construct with `init(rawValue:)`.
+- **Write a custom `init(from:)`** for any `Codable` struct that holds user data. Use `decodeIfPresent` with defaults for every field.
+- **Test with invalid raw values** as part of the persistence test suite.
+- **Disproportionate-response rule:** If one field being invalid causes *all* data to be lost, the error handling is wrong. Degrade gracefully per-field.

--- a/docs/solutions/ui-bugs/safe-area-inset-blocks-terminal-card-top-constraint.md
+++ b/docs/solutions/ui-bugs/safe-area-inset-blocks-terminal-card-top-constraint.md
@@ -1,0 +1,89 @@
+---
+title: "Safe Area Inset Blocks Terminal Card Top Constraint"
+category: ui-bugs
+component:
+  - WorkspaceViewContainer
+  - NSView
+symptoms:
+  - Top constraint constant changes have no visible effect
+  - Terminal card does not reach window top edge despite correct constraint values
+  - ~28pt gap between card top and expected position
+tags:
+  - auto-layout
+  - safe-area
+  - macos
+  - nswindow
+  - fullSizeContentView
+  - titlebar
+  - workspace-sidebar
+date_solved: 2026-02-27
+---
+
+# Safe Area Inset Blocks Terminal Card Top Constraint
+
+## Problem
+
+The floating terminal card in the workspace sidebar would not reach the top of the window. Changing the top constraint constant (e.g., from 8pt to 2pt) had no visible effect — the card stayed in the same position regardless of the value.
+
+**Observable symptoms:**
+- Terminal card started ~28pt below the expected position
+- Adjusting `terminalTopInset` from 8 to 2 produced zero visual change
+- The gap matched the titlebar height exactly
+
+## Root Cause
+
+With `.fullSizeContentView`, macOS applies safe area insets derived from the titlebar height (~28pt) to `NSView.topAnchor`. Even though `titlebarAppearsTransparent = true` makes the titlebar invisible, the **safe area still reserves space** for it.
+
+The constraint `terminalShadowHost.topAnchor.constraint(equalTo: topAnchor, constant: 8)` was effectively `topAnchor + 28 (safe area) + 8 (constant) = 36pt` from the window edge. Changing the constant to 2 made it `28 + 2 = 30pt` — a 6pt change that was barely perceptible against the dominant 28pt offset.
+
+**Key insight:** Visual invisibility of the titlebar does not equal constraint system invisibility. The Auto Layout anchor system continues to respect safe area boundaries even when the titlebar is transparent.
+
+## Solution
+
+**File:** `WorkspaceViewContainer.swift`
+
+```swift
+/// Zero out safe area insets so Auto Layout constraints measure from
+/// the actual window edge, not the titlebar-offset safe area.
+/// Without this, `topAnchor` is shifted down by ~28pt (titlebar height)
+/// and our `terminalTopInset` constant has no visible effect.
+override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+```
+
+This single override tells the view to ignore the titlebar safe area, letting the constraint constant directly control the distance from the window edge.
+
+### Additional refinements in the same commit
+
+- **Shadow opacity**: 0.15 → 0.2 (tested at 0.3, settled on 0.2 per design comparison with Paper)
+- **Corner rounding**: Added `.continuous` cornerCurve and explicit `maskedCorners` for all four corners
+- **Design verification**: Paper computed styles confirmed 8pt equal padding on all four sides
+
+## Investigation Trail
+
+| # | Approach | Result | Why |
+|---|----------|--------|-----|
+| 1 | Changed `terminalTopInset` from 8 to 2 | No visible change | Safe area (~28pt) dominated the 6pt difference |
+| 2 | Explored agent investigated `topAnchor` behavior | Found safe area insets on the view | `NSView.topAnchor` includes safe area offset |
+| 3 | Added `override var safeAreaInsets` returning zero | **Success** | Constraints now measure from actual window edge |
+| 4 | Verified with Paper design tool | Confirmed 8pt on all sides | Reverted `terminalTopInset` back to shared 8pt constant |
+
+## Prevention
+
+1. **When using `.fullSizeContentView`**: Always check whether safe area insets are shifting your views. Override `safeAreaInsets` on container views that need to reach the window edge.
+2. **Debug layout gaps**: If a constraint constant change has no visible effect, check the view's `safeAreaInsets` property — they may be adding a hidden offset.
+3. **The Arc/Dia pattern is cumulative**: This fix joins the existing set of required properties (see related doc). The complete recipe now includes `safeAreaInsets` override on the container view.
+
+## Testing Checklist
+
+- [ ] Terminal card top edge aligns to the 8pt inset from the window edge (not 36pt)
+- [ ] Changing `terminalInset` constant produces a proportional visual change
+- [ ] All three sidebar states (pinned/closed/overlay) render correctly
+- [ ] Fullscreen enter/exit doesn't restore the offset
+- [ ] Window minimize and restore preserves correct positioning
+
+## Related
+
+- [Titlebar Accessory Inflation Fix](../architecture/titlebar-accessory-inflation-arc-style-fix.md) — removes accessories that inflate titlebar height
+- [Nib Window Subclass Titlebar Hiding](../architecture/nib-window-subclass-titlebar-hiding.md) — forces base Terminal nib for transparent titlebar
+- [Sidebar 3-State Machine](../architecture/sidebar-3-state-machine-overlay-pattern.md) — the state machine this card layout supports
+- `.ignoresSafeArea(.container, edges: .top)` on the SwiftUI sidebar (in `WorkspaceSidebarView.swift`) handles the SwiftUI side; this fix handles the AppKit container side

--- a/docs/solutions/ui-bugs/sidebar-visual-polish-design-parity.md
+++ b/docs/solutions/ui-bugs/sidebar-visual-polish-design-parity.md
@@ -1,0 +1,108 @@
+---
+title: "Sidebar Visual Polish — Ghost Characters, Pixel Chevrons, Design Parity"
+category: ui-bugs
+component: workspace-sidebar
+date: 2026-02-27
+tags: [design-parity, pixel-art, ghost-characters, accessibility, swiftui]
+severity: medium
+status: resolved
+---
+
+# Sidebar Visual Polish — Ghost Characters, Pixel Chevrons, Design Parity
+
+## Problem
+
+The workspace sidebar had solid functionality (3-state machine, sessions, projects, persistence) but the visual treatment didn't match the Paper design mockups (artboards `1O-0` dark, `XX-0` light). Key mismatches:
+
+1. **Status dots** (8px circles) instead of ghost characters (16px pixel art) in session rows
+2. **SF Symbol chevron** instead of pixel-art chevron matching ghost aesthetic
+3. **No expanded project container** background
+4. **No plus icon** in expanded project headers
+5. **No empty state** when zero projects exist
+6. **No hover states** on toolbar buttons, session rows, or new session button
+7. **Missing a11y features**: no "Move Up/Down" in session context menu, animations not gated on reduced motion
+
+Design quality score before: 73/100
+
+## Root Cause
+
+Visual implementation lagged behind Paper design iterations. The sidebar was built function-first with placeholder styling (SF Symbols, plain circles) that was never updated to match the final pixel-art aesthetic.
+
+## Solution
+
+### Phase 1: PixelChevronView (new file)
+
+Created `PixelChevronView.swift` — a pixel-art chevron matching the ghost character aesthetic:
+- 7×5 grid rendered via `Path` + `.fill(color)`, same pattern as `GhostCharacterView`
+- 8×8 pixels inside a 16×16 frame
+- Rotates -90° (points right) when collapsed, 0° (points down) when expanded
+- Animation gated on `accessibilityDisplayShouldReduceMotion`
+- Color parameter: green when project has running sessions, gray otherwise
+
+### Phase 2: ProjectDisclosureRow updates
+
+- Replaced SF Symbol chevron with `PixelChevronView`
+- Added plus icon (24×24 hit target) in header when expanded, triggers new session flow
+- Added hover feedback on project header (`@State isHeaderHovered`)
+- Wrapped expanded content in themed container background (8px radius)
+- Added "Move Up" / "Move Down" to session context menu
+- Gated expand/collapse animation on reduced motion
+
+### Phase 3: SessionRow rewrite
+
+- Removed status dot Circle from left side
+- Added `GhostCharacterView` on RIGHT side (12×12 in 16×16 frame)
+- Ghost inherits from `project.ghostCharacter`; fallback: first letter of session name
+- Row height: 28pt, HStack spacing: 4pt
+- Active row: themed background + subtle shadow
+- Hover feedback on all rows
+- Status colors: green (running), gray (exited), red (killed)
+
+### Phase 4: WorkspaceSidebarView updates
+
+- Toolbar refactored to `ToolbarIconButton` private struct with hover states
+- Empty state: centered ghost character + "Add a project to get started" + `EmptyStateAddButton` with hover
+
+### Phase 5: WorkspaceLayout constants
+
+Extracted shared color constants to avoid magic values:
+- `expandedContainerDark` / `expandedContainerLight`
+- `activeRowDark` / `activeRowLight`
+
+## Design Quality Fixes Applied
+
+After initial implementation (score 82/100), a design review caught 6 issues:
+1. Expand/collapse animation not gated on reduced motion → added check
+2. Plus icon hit target too small (16pt) → increased to 24×24 with `contentShape`
+3. Hardcoded inactive text colors → replaced with `Color(.secondaryLabelColor)`
+4. Hardcoded container backgrounds → extracted to `WorkspaceLayout` constants
+5. 6pt spacing off grid → snapped to 4pt
+6. Empty state button no hover → added `EmptyStateAddButton` with hover
+
+Final score: 88/100
+
+## Key Patterns
+
+- **Pixel art rendering**: `GeometryReader` + `Path` with grid array, same pattern for ghosts and chevrons
+- **Reduced motion gating**: `NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? nil : .easeInOut(duration: 0.2)`
+- **Adaptive colors**: Use `Color(.secondaryLabelColor)` (NSColor-backed) for automatic dark/light adaptation; use `WorkspaceLayout` constants for custom themed values
+- **Hover states**: `@State private var isHovered = false` + `.onHover { isHovered = $0 }` + conditional background/foreground
+
+## Files Changed
+
+- **New:** `PixelChevronView.swift`
+- **Modified:** `ProjectDisclosureRow.swift`, `SessionDetailView.swift`, `WorkspaceSidebarView.swift`, `WorkspaceLayout.swift`, `WorkspaceViewContainer.swift`
+
+## Prevention
+
+- Run `/design:review` after visual changes to catch parity gaps early
+- Keep Paper designs and implementation in sync — update one, update the other
+- Extract shared colors to `WorkspaceLayout` constants rather than hardcoding hex values
+
+## Related Solutions
+
+- [Safe Area Inset Blocks Terminal Card Top Constraint](safe-area-inset-blocks-terminal-card-top-constraint.md) — companion fix in same session
+- [3-State Sidebar: Pinned, Closed, and Hover Overlay](../architecture/sidebar-3-state-machine-overlay-pattern.md) — sidebar state machine this builds on
+- [Titlebar Accessory Inflation Fix](../architecture/titlebar-accessory-inflation-arc-style-fix.md) — Arc-style titlebar that frames the sidebar
+- [Phase 1: Forking Ghostty and Adding a Workspace Sidebar](../integration-issues/ghostty-fork-workspace-sidebar-phase1.md) — original sidebar implementation
+- [Phase 2: Icon Rail, Project Management, and Persistence](../integration-issues/ghostty-fork-workspace-sidebar-phase2.md) — project/session model this polishes

--- a/macos/Sources/Features/Ghostties/PixelChevronView.swift
+++ b/macos/Sources/Features/Ghostties/PixelChevronView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Pixel-art chevron matching the ghost character aesthetic.
+///
+/// Renders an 8×8 chevron (7×5 grid) inside a 16×16 frame using `Path`,
+/// following the same pattern as `GhostCharacterView`. Points right when
+/// collapsed, down when expanded. Animation respects reduced motion.
+struct PixelChevronView: View {
+    var color: Color = Color(.tertiaryLabelColor)
+    var isExpanded: Bool = false
+
+    /// 7×5 pixel grid defining the chevron shape (points downward).
+    /// Rotated -90° (270°) to point right when collapsed.
+    private static let grid: [(x: Int, y: Int, w: Int, h: Int)] = [
+        (0, 0, 1, 1), (6, 0, 1, 1),
+        (0, 1, 2, 1), (5, 1, 2, 1),
+        (1, 2, 2, 1), (4, 2, 2, 1),
+        (2, 3, 3, 1),
+        (3, 4, 1, 1),
+    ]
+
+    var body: some View {
+        GeometryReader { geo in
+            chevronPath(in: CGRect(origin: .zero, size: geo.size))
+                .fill(color)
+        }
+        .frame(width: 8, height: 8)
+        .frame(width: 16, height: 16)
+        .rotationEffect(.degrees(isExpanded ? 0 : -90))
+        .animation(
+            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                ? nil
+                : .easeInOut(duration: 0.2),
+            value: isExpanded
+        )
+        .accessibilityHidden(true)
+    }
+
+    private func chevronPath(in rect: CGRect) -> Path {
+        let cellW = rect.width / 7
+        let cellH = rect.height / 5
+
+        var path = Path()
+        for pixel in Self.grid {
+            let x = rect.minX + CGFloat(pixel.x) * cellW
+            let y = rect.minY + CGFloat(pixel.y) * cellH
+            path.addRect(CGRect(x: x, y: y, width: CGFloat(pixel.w) * cellW, height: CGFloat(pixel.h) * cellH))
+        }
+        return path
+    }
+}

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -11,11 +11,14 @@ struct ProjectDisclosureRow: View {
 
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var settingsProject: Project?
     @State private var showingTemplatePicker = false
     @State private var editingSessionId: UUID?
     @State private var editingName: String = ""
+    @State private var isHeaderHovered = false
+    @State private var isNewSessionHovered = false
     @FocusState private var renameFieldFocused: Bool
 
     var body: some View {
@@ -25,10 +28,11 @@ struct ProjectDisclosureRow: View {
 
             // Expanded children: sessions + "New Session" button
             if isExpanded {
-                ForEach(sessions) { session in
+                ForEach(Array(sessions.enumerated()), id: \.element.id) { index, session in
                     SessionRow(
                         session: session,
                         status: store.globalStatuses[session.id] ?? coordinator.statuses[session.id] ?? .exited,
+                        ghostCharacter: project.ghostCharacter,
                         isActive: coordinator.activeSessionId == session.id,
                         isEditing: editingSessionId == session.id,
                         editingName: editingSessionId == session.id ? $editingName : .constant(""),
@@ -49,6 +53,19 @@ struct ProjectDisclosureRow: View {
                             beginRename(session: session)
                         }
                         Divider()
+                        if index > 0 {
+                            Button("Move Up") {
+                                store.moveSession(id: session.id, toIndex: index - 1, inProject: project.id)
+                            }
+                        }
+                        if index < sessions.count - 1 {
+                            Button("Move Down") {
+                                store.moveSession(id: session.id, toIndex: index + 1, inProject: project.id)
+                            }
+                        }
+                        if index > 0 || index < sessions.count - 1 {
+                            Divider()
+                        }
                         if coordinator.isRunning(id: session.id) {
                             Button("Stop") {
                                 coordinator.closeSession(id: session.id)
@@ -84,42 +101,57 @@ struct ProjectDisclosureRow: View {
                     .padding(.leading, 20)
             }
         }
+        .background(expandedContainerBackground)
     }
 
     // MARK: - Project Header
 
     private var projectHeader: some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
+            let animation: Animation? = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+                ? nil
+                : .easeInOut(duration: 0.2)
+            withAnimation(animation) {
                 isExpanded.toggle()
             }
             selectedProjectId = project.id
         } label: {
-            HStack(spacing: 8) {
-                // Chevron (rotates on expand)
-                Image(systemName: "chevron.right")
-                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.tertiary)
-                    .animation(.easeInOut(duration: 0.2), value: isExpanded)
-
-                // Aggregate status dot
-                projectIcon
+            HStack(spacing: 4) {
+                PixelChevronView(
+                    color: projectHasRunning ? Color(nsColor: .systemGreen) : Color(.tertiaryLabelColor),
+                    isExpanded: isExpanded
+                )
 
                 Text(project.name)
                     .font(.system(size: 13, weight: .medium))
+                    .tracking(-0.13)
                     .lineLimit(1)
 
                 Spacer()
+
+                if isExpanded {
+                    Button(action: handleNewSession) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .medium))
+                            .frame(width: 24, height: 24)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("New session")
+                }
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .frame(minHeight: 32)
-            .background(selectedProjectId == project.id ? Color.accentColor.opacity(0.1) : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .padding(.leading, 8)
+            .padding(.trailing, 12)
+            .frame(height: 32)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHeaderHovered ? Color.primary.opacity(0.06) : Color.clear)
+            )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .onHover { isHeaderHovered = $0 }
         .contextMenu {
             Button("Settings\u{2026}") {
                 settingsProject = project
@@ -150,24 +182,25 @@ struct ProjectDisclosureRow: View {
         .accessibilityHint("Double-tap to \(isExpanded ? "collapse" : "expand")")
     }
 
-    // MARK: - Icon
+    // MARK: - Container Background
 
     @ViewBuilder
-    private var projectIcon: some View {
-        Circle()
-            .fill(projectStatusColor)
-            .frame(width: 8, height: 8)
+    private var expandedContainerBackground: some View {
+        if isExpanded {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(colorScheme == .dark ? WorkspaceLayout.expandedContainerDark : WorkspaceLayout.expandedContainerLight)
+        }
     }
 
-    private var projectStatusColor: Color {
-        let projectSessions = store.sessions(for: project.id)
-        let hasRunning = projectSessions.contains { session in
+    // MARK: - Status
+
+    private var projectHasRunning: Bool {
+        store.sessions(for: project.id).contains { session in
             let status = store.globalStatuses[session.id]
                 ?? coordinator.statuses[session.id]
                 ?? .exited
             return status == .running
         }
-        return hasRunning ? .green : Color(.tertiaryLabelColor)
     }
 
     // MARK: - Sessions
@@ -190,9 +223,10 @@ struct ProjectDisclosureRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.tertiary)
+        .foregroundStyle(isNewSessionHovered ? .secondary : .tertiary)
         .padding(.horizontal, 8)
-        .padding(.vertical, 6)
+        .padding(.vertical, 4)
+        .onHover { isNewSessionHovered = $0 }
         .popover(isPresented: $showingTemplatePicker) {
             TemplatePickerView(project: project)
         }

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -36,7 +36,11 @@ final class SessionCoordinator: ObservableObject {
     @Published private(set) var statuses: [UUID: SessionStatus] = [:]
 
     /// Cache resolved command paths to avoid repeated shell spawns.
-    nonisolated(unsafe) private static var resolvedPaths: [String: String] = [:]
+    /// Guarded by `resolvedPathsLock` since `resolveCommand` runs on detached tasks.
+    /// `nonisolated(unsafe)` opts out of @MainActor isolation so the nonisolated
+    /// `resolveCommand` method can access these; the lock provides actual safety.
+    nonisolated(unsafe) private static let resolvedPathsLock = NSLock()
+    nonisolated(unsafe) private static var _resolvedPaths: [String: String] = [:]
 
     /// Tracks the last focused session per project per window, so clicking a
     /// project in the icon rail can restore the correct terminal session.
@@ -327,7 +331,10 @@ final class SessionCoordinator: ObservableObject {
         guard !command.hasPrefix("/") else { return command }
 
         // Check cache first.
-        if let cached = resolvedPaths[command] { return cached }
+        resolvedPathsLock.lock()
+        let cached = _resolvedPaths[command]
+        resolvedPathsLock.unlock()
+        if let cached { return cached }
 
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser.path
@@ -345,7 +352,9 @@ final class SessionCoordinator: ObservableObject {
         for dir in commonPaths {
             let candidate = (dir as NSString).appendingPathComponent(command)
             if fm.isExecutableFile(atPath: candidate) {
-                resolvedPaths[command] = candidate
+                resolvedPathsLock.lock()
+                _resolvedPaths[command] = candidate
+                resolvedPathsLock.unlock()
                 return candidate
             }
         }
@@ -377,7 +386,9 @@ final class SessionCoordinator: ObservableObject {
         for dir in pathString.split(separator: ":").map(String.init) {
             let candidate = (dir as NSString).appendingPathComponent(command)
             if fm.isExecutableFile(atPath: candidate) {
-                resolvedPaths[command] = candidate
+                resolvedPathsLock.lock()
+                _resolvedPaths[command] = candidate
+                resolvedPathsLock.unlock()
                 return candidate
             }
         }

--- a/macos/Sources/Features/Ghostties/SessionDetailView.swift
+++ b/macos/Sources/Features/Ghostties/SessionDetailView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
-/// A single session row: status dot + name + active highlight.
+/// A single session row: name + ghost character status indicator.
 ///
 /// Used by ProjectDisclosureRow to render sessions under each project.
+/// Ghost character appears on the right, colored by session status.
 struct SessionRow: View {
     let session: AgentSession
     let status: SessionStatus
+    var ghostCharacter: GhostCharacter? = nil
     var isActive: Bool = false
     var isEditing: Bool = false
     @Binding var editingName: String
@@ -13,10 +15,11 @@ struct SessionRow: View {
     var onCommitRename: () -> Void
     var onCancelRename: () -> Void
 
-    var body: some View {
-        HStack(spacing: 8) {
-            statusIndicator
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isHovered = false
 
+    var body: some View {
+        HStack(spacing: 4) {
             if isEditing {
                 TextField("Session name", text: $editingName)
                     .font(.system(size: 12))
@@ -25,40 +28,75 @@ struct SessionRow: View {
                     .onSubmit { onCommitRename() }
                     .onExitCommand { onCancelRename() }
                     .onChange(of: isRenameFocused.wrappedValue) { focused in
-                        // Commit on focus loss (clicking away).
                         if !focused, isEditing { onCommitRename() }
                     }
             } else {
                 Text(session.name)
                     .font(.system(size: 12))
-                    .foregroundStyle(isActive ? .primary : .secondary)
+                    .foregroundColor(isActive ? .primary : inactiveTextColor)
                     .lineLimit(1)
             }
 
             Spacer()
+
+            ghostIndicator
         }
         .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .frame(minHeight: 32)
-        .background(isActive ? Color.accentColor.opacity(0.15) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .frame(height: 28)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(rowBackground)
+        )
+        .shadow(
+            color: isActive ? Color.black.opacity(0.1) : .clear,
+            radius: 2, x: 0, y: 1
+        )
         .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(session.name), \(statusLabel)\(isActive ? ", active" : "")")
     }
 
-    private var statusIndicator: some View {
-        Circle()
-            .fill(statusColor)
-            .frame(width: 8, height: 8)
+    // MARK: - Ghost Indicator
+
+    @ViewBuilder
+    private var ghostIndicator: some View {
+        if let ghost = ghostCharacter {
+            GhostCharacterView(character: ghost, color: statusColor)
+                .frame(width: 12, height: 12)
+                .frame(width: 16, height: 16)
+        } else {
+            Text(String(session.name.prefix(1)).uppercased())
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundColor(statusColor)
+                .frame(width: 16, height: 16)
+        }
     }
+
+    // MARK: - Colors
 
     private var statusColor: Color {
         switch status {
-        case .running: return .green
+        case .running: return Color(nsColor: .systemGreen)
         case .exited: return Color(.tertiaryLabelColor)
-        case .killed: return .red
+        case .killed: return Color(nsColor: .systemRed)
         }
+    }
+
+    private var inactiveTextColor: Color {
+        Color(.secondaryLabelColor)
+    }
+
+    private var rowBackground: Color {
+        if isActive {
+            return colorScheme == .dark
+                ? WorkspaceLayout.activeRowDark
+                : WorkspaceLayout.activeRowLight
+        }
+        if isHovered {
+            return Color.primary.opacity(0.04)
+        }
+        return .clear
     }
 
     private var statusLabel: String {

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+/// Three-state sidebar visibility model.
+///
+/// - `pinned`: Sidebar open, terminal pushed right (floating card).
+/// - `closed`: Sidebar hidden, terminal fills window flush.
+/// - `overlay`: Sidebar floats on top of full-width terminal (hover-to-reveal).
+enum SidebarMode: Int, Codable {
+    case pinned
+    case closed
+    case overlay
+}
+
 /// Shared layout constants for the workspace sidebar.
 enum WorkspaceLayout {
     /// Width of the sidebar panel.
@@ -8,8 +19,14 @@ enum WorkspaceLayout {
     /// Height reserved at top for window traffic light controls.
     static let titlebarSpacerHeight: CGFloat = 38
 
-    /// Corner radius on the terminal's leading edge (top-left, bottom-left).
-    static let terminalCornerRadius: CGFloat = 10
+    /// Corner radius on the floating terminal panel (all four corners).
+    static let terminalCornerRadius: CGFloat = 12
+
+    /// Inset around the terminal panel when sidebar is visible (floating card effect).
+    static let terminalInset: CGFloat = 8
+
+    /// Width of the invisible hover trigger strip at the left edge (closed mode).
+    static let overlayTriggerWidth: CGFloat = 10
 }
 
 // MARK: - Workspace Notifications

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -23,6 +23,7 @@ enum WorkspaceLayout {
     static let terminalCornerRadius: CGFloat = 12
 
     /// Inset around the terminal panel when sidebar is visible (floating card effect).
+    /// The design uses 8pt on all four sides (top, bottom, left, right).
     static let terminalInset: CGFloat = 8
 
     /// Width of the invisible hover trigger strip at the left edge (closed mode).

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// Three-state sidebar visibility model.
 ///
@@ -28,6 +29,18 @@ enum WorkspaceLayout {
 
     /// Width of the invisible hover trigger strip at the left edge (closed mode).
     static let overlayTriggerWidth: CGFloat = 10
+
+    /// Background for expanded project group container (dark mode).
+    static let expandedContainerDark = Color(white: 0.16)
+
+    /// Background for expanded project group container (light mode).
+    static let expandedContainerLight = Color.white
+
+    /// Background for active session row (dark mode): 6% white.
+    static let activeRowDark = Color.white.opacity(0.06)
+
+    /// Background for active session row (light mode): 4% black.
+    static let activeRowLight = Color.black.opacity(0.04)
 }
 
 // MARK: - Workspace Notifications

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -20,6 +20,9 @@ enum WorkspaceLayout {
     /// Height reserved at top for window traffic light controls.
     static let titlebarSpacerHeight: CGFloat = 38
 
+    /// Height of the session-name title bar inside the terminal card.
+    static let terminalTitleBarHeight: CGFloat = 28
+
     /// Corner radius on the floating terminal panel (all four corners).
     static let terminalCornerRadius: CGFloat = 12
 

--- a/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
+++ b/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
@@ -32,8 +32,9 @@ struct WorkspacePersistence {
         var sessions: [AgentSession]
         var templates: [SessionTemplate]
 
-        /// Whether the sidebar was visible when the app last saved state.
-        var sidebarVisible: Bool
+        /// Sidebar mode when the app last saved state.
+        /// `.overlay` is transient — always persisted as `.closed`.
+        var sidebarMode: SidebarMode
 
         /// The last selected project ID, for restoring selection on launch.
         var lastSelectedProjectId: UUID?
@@ -42,14 +43,20 @@ struct WorkspacePersistence {
             projects: [Project] = [],
             sessions: [AgentSession] = [],
             templates: [SessionTemplate] = [],
-            sidebarVisible: Bool = true,
+            sidebarMode: SidebarMode = .pinned,
             lastSelectedProjectId: UUID? = nil
         ) {
             self.projects = projects
             self.sessions = sessions
             self.templates = templates
-            self.sidebarVisible = sidebarVisible
+            self.sidebarMode = sidebarMode
             self.lastSelectedProjectId = lastSelectedProjectId
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case projects, sessions, templates, sidebarMode, lastSelectedProjectId
+            // Legacy key for backward compatibility.
+            case sidebarVisible
         }
 
         init(from decoder: Decoder) throws {
@@ -57,8 +64,29 @@ struct WorkspacePersistence {
             self.projects = try container.decodeIfPresent([Project].self, forKey: .projects) ?? []
             self.sessions = try container.decodeIfPresent([AgentSession].self, forKey: .sessions) ?? []
             self.templates = try container.decodeIfPresent([SessionTemplate].self, forKey: .templates) ?? []
-            self.sidebarVisible = try container.decodeIfPresent(Bool.self, forKey: .sidebarVisible) ?? true
             self.lastSelectedProjectId = try container.decodeIfPresent(UUID.self, forKey: .lastSelectedProjectId)
+
+            // Try new sidebarMode first; fall back to legacy sidebarVisible bool.
+            // Decode as raw Int to avoid a DecodingError (and full state wipe) on
+            // unknown raw values — gracefully fall through to the default instead.
+            if let rawMode = try container.decodeIfPresent(Int.self, forKey: .sidebarMode),
+               let mode = SidebarMode(rawValue: rawMode) {
+                self.sidebarMode = mode
+            } else if let visible = try container.decodeIfPresent(Bool.self, forKey: .sidebarVisible) {
+                self.sidebarMode = visible ? .pinned : .closed
+            } else {
+                self.sidebarMode = .pinned
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(projects, forKey: .projects)
+            try container.encode(sessions, forKey: .sessions)
+            try container.encode(templates, forKey: .templates)
+            try container.encode(sidebarMode, forKey: .sidebarMode)
+            try container.encodeIfPresent(lastSelectedProjectId, forKey: .lastSelectedProjectId)
+            // Omit the legacy sidebarVisible key on new writes.
         }
     }
 

--- a/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
+++ b/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
@@ -84,7 +84,9 @@ struct WorkspacePersistence {
             try container.encode(projects, forKey: .projects)
             try container.encode(sessions, forKey: .sessions)
             try container.encode(templates, forKey: .templates)
-            try container.encode(sidebarMode, forKey: .sidebarMode)
+            // Overlay is transient — always persist as closed.
+            let persistedMode = sidebarMode == .overlay ? SidebarMode.closed : sidebarMode
+            try container.encode(persistedMode, forKey: .sidebarMode)
             try container.encodeIfPresent(lastSelectedProjectId, forKey: .lastSelectedProjectId)
             // Omit the legacy sidebarVisible key on new writes.
         }

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -37,7 +37,7 @@ struct WorkspaceSidebarView: View {
 
             Spacer(minLength: 0)
         }
-        .background(.regularMaterial)
+        .background(.clear)
         .onAppear {
             // Restore persisted project selection, or default to the first project.
             if selectedProjectId == nil {

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -34,6 +34,7 @@ struct WorkspaceSidebarView: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
             }
+            .accessibilityLabel("Projects")
 
             Spacer(minLength: 0)
         }
@@ -83,6 +84,7 @@ struct WorkspaceSidebarView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
+            .focusable()
             .accessibilityLabel("Add project")
 
             Button(action: toggleSidebar) {
@@ -91,6 +93,7 @@ struct WorkspaceSidebarView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
+            .focusable()
             .accessibilityLabel("Toggle sidebar")
         }
         .padding(.horizontal, 12)

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -20,21 +20,25 @@ struct WorkspaceSidebarView: View {
             // Titlebar toolbar: action buttons right of traffic lights
             titlebarToolbar
 
-            // Scrollable disclosure list
-            ScrollView {
-                LazyVStack(spacing: 2) {
-                    ForEach(store.sortedProjects) { project in
-                        ProjectDisclosureRow(
-                            project: project,
-                            isExpanded: expandedBinding(for: project.id),
-                            selectedProjectId: $selectedProjectId
-                        )
+            // Scrollable disclosure list or empty state
+            if store.sortedProjects.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        ForEach(store.sortedProjects) { project in
+                            ProjectDisclosureRow(
+                                project: project,
+                                isExpanded: expandedBinding(for: project.id),
+                                selectedProjectId: $selectedProjectId
+                            )
+                        }
                     }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
+                .accessibilityLabel("Projects")
             }
-            .accessibilityLabel("Projects")
 
             Spacer(minLength: 0)
         }
@@ -79,26 +83,29 @@ struct WorkspaceSidebarView: View {
     private var titlebarToolbar: some View {
         HStack {
             Spacer()
-            Button(action: presentFolderPicker) {
-                Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .focusable()
-            .accessibilityLabel("Add project")
-
-            Button(action: toggleSidebar) {
-                Image(systemName: "sidebar.left")
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .focusable()
-            .accessibilityLabel("Toggle sidebar")
+            ToolbarIconButton(systemName: "plus", label: "Add project", action: presentFolderPicker)
+            ToolbarIconButton(systemName: "sidebar.left", label: "Toggle sidebar", action: toggleSidebar)
         }
         .padding(.horizontal, 12)
         .frame(height: WorkspaceLayout.titlebarSpacerHeight)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            GhostCharacterView(character: .blinky, color: Color(.tertiaryLabelColor))
+                .frame(width: 48, height: 48)
+
+            Text("Add a project to get started")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            EmptyStateAddButton(action: presentFolderPicker)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No projects. Add a project to get started.")
     }
 
     // MARK: - Helpers
@@ -172,5 +179,56 @@ struct WorkspaceSidebarView: View {
         let targetId = sorted[newIndex].id
         selectedProjectId = targetId
         expandedProjectIds.insert(targetId)
+    }
+}
+
+// MARK: - Empty State Add Button
+
+/// "Add Project" button with hover feedback for the sidebar empty state.
+private struct EmptyStateAddButton: View {
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .medium))
+                Text("Add Project")
+                    .font(.system(size: 12, weight: .medium))
+            }
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isHovered ? .primary : .secondary)
+        .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - Toolbar Icon Button
+
+/// A small icon button with hover highlight for the sidebar toolbar.
+private struct ToolbarIconButton: View {
+    let systemName: String
+    let label: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 24, height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .focusable()
+        .onHover { isHovered = $0 }
+        .accessibilityLabel(label)
     }
 }

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -39,6 +39,7 @@ struct WorkspaceSidebarView: View {
             Spacer(minLength: 0)
         }
         .background(.clear)
+        .ignoresSafeArea(.container, edges: .top)
         .onAppear {
             // Restore persisted project selection, or default to the first project.
             if selectedProjectId == nil {

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -21,9 +21,10 @@ final class WorkspaceStore: ObservableObject {
     /// Coordinators write via `updateSessionStatus`; views read directly.
     @Published private(set) var globalStatuses: [UUID: SessionStatus] = [:]
 
-    /// Whether the sidebar should be visible. Persisted across launches.
-    var sidebarVisible: Bool = true {
-        didSet { if oldValue != sidebarVisible { persist() } }
+    /// Current sidebar mode. Persisted across launches.
+    /// `.overlay` is transient — always saved as `.closed`.
+    var sidebarMode: SidebarMode = .pinned {
+        didSet { if oldValue != sidebarMode { persist() } }
     }
 
     /// The last selected project ID, used to restore selection on launch.
@@ -35,7 +36,7 @@ final class WorkspaceStore: ObservableObject {
         let state = WorkspacePersistence.load()
         self.projects = state.projects
         self.sessions = state.sessions
-        self.sidebarVisible = state.sidebarVisible
+        self.sidebarMode = state.sidebarMode
         self.lastSelectedProjectId = state.lastSelectedProjectId
 
         // Merge persisted custom templates with built-in defaults.
@@ -271,15 +272,17 @@ final class WorkspaceStore: ObservableObject {
 
     private func persist() {
         persistTask?.cancel()
-        persistTask = Task { [projects, sessions, templates, sidebarVisible, lastSelectedProjectId] in
+        persistTask = Task { [projects, sessions, templates, sidebarMode, lastSelectedProjectId] in
             try? await Task.sleep(for: .milliseconds(100))
             guard !Task.isCancelled else { return }
             let customTemplates = templates.filter { !$0.isDefault }
+            // Overlay is transient — persist as closed so next launch starts closed.
+            let persistedMode: SidebarMode = sidebarMode == .overlay ? .closed : sidebarMode
             let state = WorkspacePersistence.State(
                 projects: projects,
                 sessions: sessions,
                 templates: customTemplates,
-                sidebarVisible: sidebarVisible,
+                sidebarMode: persistedMode,
                 lastSelectedProjectId: lastSelectedProjectId
             )
             await Task.detached(priority: .utility) {

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -23,8 +23,15 @@ final class WorkspaceStore: ObservableObject {
 
     /// Current sidebar mode. Persisted across launches.
     /// `.overlay` is transient — always saved as `.closed`.
-    var sidebarMode: SidebarMode = .pinned {
+    /// Only `WorkspaceViewContainer.transitionTo(_:)` should mutate this
+    /// (via `updateSidebarMode`) to keep the UI and store in sync.
+    private(set) var sidebarMode: SidebarMode = .pinned {
         didSet { if oldValue != sidebarMode { persist() } }
+    }
+
+    /// Called by `WorkspaceViewContainer` after state transitions.
+    func updateSidebarMode(_ mode: SidebarMode) {
+        sidebarMode = mode
     }
 
     /// The last selected project ID, used to restore selection on launch.

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -277,8 +277,9 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         }
 
         // 4. Animate constraints, widths, alphas.
+        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
         NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.2
+            context.duration = reduceMotion ? 0 : 0.2
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
 
             switch newMode {

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 /// An NSView that contains the workspace sidebar alongside the existing terminal view.
@@ -11,12 +12,45 @@ import SwiftUI
 /// This container also creates and owns the `SessionCoordinator`, which bridges
 /// the sidebar's SwiftUI world to the terminal controller's AppKit world.
 class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
+    private let backgroundEffectView: NSVisualEffectView = {
+        let view = NSVisualEffectView()
+        view.material = .sidebar
+        view.blendingMode = .behindWindow
+        view.state = .active
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
     private let sidebarHostingView: NSView
     private let terminalContainer: TerminalViewContainer<ViewModel>
     private let coordinator: SessionCoordinator
 
-    /// Stored constraint for animating sidebar show/hide.
+    /// Shadow host wraps the terminal container so the drop shadow renders
+    /// outside `masksToBounds` clipping. The shadow host carries the shadow;
+    /// the inner terminal container clips its corners.
+    private let terminalShadowHost: NSView = {
+        let view = NSView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    /// Session name centered at the top of the terminal card (titlebar region).
+    private let titleLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 13, weight: .regular)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Stored constraints for animating sidebar show/hide and terminal insets.
     private var sidebarWidthConstraint: NSLayoutConstraint!
+    private var shadowHostTopConstraint: NSLayoutConstraint!
+    private var shadowHostLeadingConstraint: NSLayoutConstraint!
+    private var shadowHostTrailingConstraint: NSLayoutConstraint!
+    private var shadowHostBottomConstraint: NSLayoutConstraint!
 
     init(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil) {
         self.terminalContainer = TerminalViewContainer(
@@ -60,13 +94,28 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         window.styleMask.insert(.fullSizeContentView)
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
+
+        // The session title label replaces the macOS window title. Hide the native
+        // titlebar text field directly — titleVisibility alone isn't reliable because
+        // TerminalWindow's titlebar management can re-show it.
+        DispatchQueue.main.async {
+            window.contentView?
+                .firstViewFromRoot(withClassName: "NSTitlebarContainerView")?
+                .firstDescendant(withClassName: "NSTitlebarView")?
+                .firstDescendant(withClassName: "NSTextField")?
+                .isHidden = true
+        }
     }
 
     override var intrinsicContentSize: NSSize {
         let termSize = terminalContainer.intrinsicContentSize
         guard termSize.width != NSView.noIntrinsicMetric else { return termSize }
         let sidebarWidth = sidebarWidthConstraint?.constant ?? WorkspaceLayout.sidebarWidth
-        return NSSize(width: termSize.width + sidebarWidth, height: termSize.height)
+        let inset = isSidebarVisible ? WorkspaceLayout.terminalInset : 0
+        return NSSize(
+            width: termSize.width + sidebarWidth + inset * 2,
+            height: termSize.height + inset * 2
+        )
     }
 
     // MARK: - Sidebar Toggle
@@ -79,25 +128,37 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     /// Toggle sidebar visibility with animation.
     @objc func toggleSidebar() {
         let hiding = isSidebarVisible
+        let inset = WorkspaceLayout.terminalInset
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.2
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             sidebarWidthConstraint.animator().constant = hiding ? 0 : WorkspaceLayout.sidebarWidth
+            shadowHostTopConstraint.animator().constant = hiding ? 0 : inset
+            shadowHostLeadingConstraint.animator().constant = hiding ? 0 : inset
+            shadowHostTrailingConstraint.animator().constant = hiding ? 0 : -inset
+            shadowHostBottomConstraint.animator().constant = hiding ? 0 : -inset
+            titleLabel.animator().alphaValue = hiding ? 0 : 1
         }
-        // Rounded leading corners when sidebar visible, square when hidden.
         terminalContainer.layer?.cornerRadius = hiding ? 0 : WorkspaceLayout.terminalCornerRadius
+        terminalShadowHost.layer?.shadowOpacity = hiding ? 0 : 0.15
         WorkspaceStore.shared.sidebarVisible = !hiding
     }
 
     // MARK: - Layout
 
     private func setup() {
-        // Z-order: sidebar behind, terminal on top.
+        // Z-order: background material → sidebar → shadow host (with terminal inside).
+        addSubview(backgroundEffectView)
         addSubview(sidebarHostingView)
-        addSubview(terminalContainer)
+        addSubview(terminalShadowHost)
 
         sidebarHostingView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Terminal lives inside the shadow host. The host carries the shadow;
+        // the terminal clips its own corners via masksToBounds.
+        terminalShadowHost.addSubview(terminalContainer)
+        terminalShadowHost.addSubview(titleLabel)
         terminalContainer.translatesAutoresizingMaskIntoConstraints = false
 
         // Read persisted sidebar visibility.
@@ -106,24 +167,78 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
 
         sidebarWidthConstraint = sidebarHostingView.widthAnchor.constraint(equalToConstant: initialWidth)
 
+        let inset: CGFloat = sidebarVisible ? WorkspaceLayout.terminalInset : 0
+
+        // Inset constraints target the shadow host, not the terminal directly.
+        shadowHostTopConstraint = terminalShadowHost.topAnchor.constraint(
+            equalTo: topAnchor, constant: inset)
+        shadowHostLeadingConstraint = terminalShadowHost.leadingAnchor.constraint(
+            equalTo: sidebarHostingView.trailingAnchor, constant: inset)
+        shadowHostTrailingConstraint = terminalShadowHost.trailingAnchor.constraint(
+            equalTo: trailingAnchor, constant: -inset)
+        shadowHostBottomConstraint = terminalShadowHost.bottomAnchor.constraint(
+            equalTo: bottomAnchor, constant: -inset)
+
         NSLayoutConstraint.activate([
-            // Sidebar: flush to window edges (no insets).
+            backgroundEffectView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
             sidebarHostingView.topAnchor.constraint(equalTo: topAnchor),
             sidebarHostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             sidebarHostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
             sidebarWidthConstraint,
 
-            // Terminal: leading edge meets sidebar trailing, extends under titlebar.
-            terminalContainer.topAnchor.constraint(equalTo: topAnchor),
-            terminalContainer.leadingAnchor.constraint(equalTo: sidebarHostingView.trailingAnchor),
-            terminalContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
-            terminalContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            shadowHostTopConstraint,
+            shadowHostLeadingConstraint,
+            shadowHostBottomConstraint,
+            shadowHostTrailingConstraint,
+
+            // Terminal fills the shadow host.
+            terminalContainer.topAnchor.constraint(equalTo: terminalShadowHost.topAnchor),
+            terminalContainer.leadingAnchor.constraint(equalTo: terminalShadowHost.leadingAnchor),
+            terminalContainer.trailingAnchor.constraint(equalTo: terminalShadowHost.trailingAnchor),
+            terminalContainer.bottomAnchor.constraint(equalTo: terminalShadowHost.bottomAnchor),
+
+            // Title label centered in the titlebar region of the card.
+            titleLabel.centerXAnchor.constraint(equalTo: terminalShadowHost.centerXAnchor),
+            titleLabel.topAnchor.constraint(
+                equalTo: terminalShadowHost.topAnchor,
+                constant: (WorkspaceLayout.titlebarSpacerHeight - 16) / 2),
         ])
 
-        // Terminal rounded leading corners (top-left, bottom-left).
+        // Terminal floating card: all four corners rounded when sidebar visible.
         terminalContainer.wantsLayer = true
         terminalContainer.layer?.cornerRadius = sidebarVisible ? WorkspaceLayout.terminalCornerRadius : 0
-        terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
         terminalContainer.layer?.masksToBounds = true
+
+        // Configure shadow on the host layer. Must happen after addSubview so the
+        // layer exists (wantsLayer in a property closure may not create it in time).
+        terminalShadowHost.wantsLayer = true
+        terminalShadowHost.layer?.shadowColor = NSColor.black.cgColor
+        terminalShadowHost.layer?.shadowOpacity = sidebarVisible ? 0.15 : 0
+        terminalShadowHost.layer?.shadowRadius = 8
+        terminalShadowHost.layer?.shadowOffset = CGSize(width: 0, height: -2)
+
+        // Hide title when sidebar starts collapsed.
+        if !sidebarVisible {
+            titleLabel.alphaValue = 0
+        }
+
+        // Bind title label to the active session name.
+        coordinator.$activeSessionId
+            .combineLatest(WorkspaceStore.shared.$sessions)
+            .map { activeId, sessions -> String in
+                guard let id = activeId,
+                      let session = sessions.first(where: { $0.id == id })
+                else { return "" }
+                return session.name
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] name in
+                self?.titleLabel.stringValue = name
+            }
+            .store(in: &cancellables)
     }
 }

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -11,6 +11,13 @@ import SwiftUI
 ///
 /// This container also creates and owns the `SessionCoordinator`, which bridges
 /// the sidebar's SwiftUI world to the terminal controller's AppKit world.
+///
+/// ## Sidebar State Machine
+///
+/// The sidebar operates in three modes (see `SidebarMode`):
+/// - **pinned**: Sidebar pushes terminal right (floating card with shadow/insets).
+/// - **closed**: Sidebar hidden, terminal fills window flush, traffic lights hidden.
+/// - **overlay**: Sidebar floats on top of full-width terminal (hover-to-reveal).
 class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     private let backgroundEffectView: NSVisualEffectView = {
         let view = NSVisualEffectView()
@@ -33,6 +40,21 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         return view
     }()
 
+    /// Sidebar material backing for overlay mode. In pinned mode the shared
+    /// `backgroundEffectView` already covers the sidebar area, so this is hidden.
+    /// In overlay mode it provides the .sidebar material behind the hosting view
+    /// with a right-edge shadow to separate from terminal content.
+    private let sidebarOverlayBackground: NSVisualEffectView = {
+        let view = NSVisualEffectView()
+        view.material = .sidebar
+        view.blendingMode = .behindWindow
+        view.state = .active
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.alphaValue = 0
+        view.isHidden = true
+        return view
+    }()
+
     /// Session name centered at the top of the terminal card (titlebar region).
     private let titleLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
@@ -45,12 +67,27 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// Current sidebar state — always kept in sync with `WorkspaceStore.shared.sidebarMode`.
+    private var sidebarMode: SidebarMode = .pinned
+
     /// Stored constraints for animating sidebar show/hide and terminal insets.
     private var sidebarWidthConstraint: NSLayoutConstraint!
     private var shadowHostTopConstraint: NSLayoutConstraint!
-    private var shadowHostLeadingConstraint: NSLayoutConstraint!
     private var shadowHostTrailingConstraint: NSLayoutConstraint!
     private var shadowHostBottomConstraint: NSLayoutConstraint!
+
+    /// Dual leading constraints — mutually exclusive.
+    /// `.pinned`: terminal leading follows sidebar trailing (pushed right).
+    /// `.closed`/`.overlay`: terminal leading follows superview leading (full-width).
+    private var shadowHostLeadingToSidebar: NSLayoutConstraint!
+    private var shadowHostLeadingToSuperview: NSLayoutConstraint!
+
+    /// Tracking area for hover detection. Only one is active at a time.
+    private var activeTrackingArea: NSTrackingArea?
+
+    /// Cached reference to the native titlebar text field to avoid
+    /// recursive view hierarchy traversal on every window title change.
+    private weak var cachedTitlebarTextField: NSTextField?
 
     init(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil) {
         self.terminalContainer = TerminalViewContainer(
@@ -79,8 +116,20 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        titleObservation?.invalidate()
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+
+        // Clean up previous window's observers (handles view moving between windows).
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
+        titleObservation?.invalidate()
+        titleObservation = nil
+        cachedTitlebarTextField = nil
+
         guard let window = window else { return }
         // Give the coordinator a reference to this view so it can discover
         // the window controller through the responder chain.
@@ -95,65 +144,289 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
 
-        // The session title label replaces the macOS window title. Hide the native
-        // titlebar text field directly — titleVisibility alone isn't reliable because
-        // TerminalWindow's titlebar management can re-show it.
-        DispatchQueue.main.async {
-            window.contentView?
-                .firstViewFromRoot(withClassName: "NSTitlebarContainerView")?
-                .firstDescendant(withClassName: "NSTitlebarView")?
-                .firstDescendant(withClassName: "NSTextField")?
-                .isHidden = true
-        }
+        // Hide the native titlebar title text. The session name label inside the
+        // terminal card replaces it. We must re-hide on every title change because
+        // macOS re-shows the text field when window.title is updated.
+        hideTitlebarTextField(in: window)
+        observeWindowTitle(window)
+
+        // Apply initial traffic light visibility.
+        setTrafficLightsHidden(sidebarMode == .closed)
+
+        // Auto-dismiss overlay when window loses focus.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidResignKey),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
     }
 
     override var intrinsicContentSize: NSSize {
         let termSize = terminalContainer.intrinsicContentSize
         guard termSize.width != NSView.noIntrinsicMetric else { return termSize }
-        let sidebarWidth = sidebarWidthConstraint?.constant ?? WorkspaceLayout.sidebarWidth
-        let inset = isSidebarVisible ? WorkspaceLayout.terminalInset : 0
-        return NSSize(
-            width: termSize.width + sidebarWidth + inset * 2,
-            height: termSize.height + inset * 2
+        switch sidebarMode {
+        case .pinned:
+            let inset = WorkspaceLayout.terminalInset
+            return NSSize(
+                width: termSize.width + WorkspaceLayout.sidebarWidth + inset * 2,
+                height: termSize.height + inset * 2
+            )
+        case .closed, .overlay:
+            return termSize
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        // Explicit shadow paths eliminate per-frame offscreen rendering.
+        // Without these, Core Animation rasterizes the entire layer to compute
+        // the shadow shape every frame — expensive for a terminal that redraws at 60fps.
+        terminalShadowHost.layer?.shadowPath = CGPath(
+            roundedRect: terminalShadowHost.bounds,
+            cornerWidth: WorkspaceLayout.terminalCornerRadius,
+            cornerHeight: WorkspaceLayout.terminalCornerRadius,
+            transform: nil
+        )
+        sidebarOverlayBackground.layer?.shadowPath = CGPath(
+            rect: sidebarOverlayBackground.bounds,
+            transform: nil
         )
     }
 
-    // MARK: - Sidebar Toggle
+    // MARK: - Titlebar
 
-    /// Whether the sidebar is currently visible.
-    var isSidebarVisible: Bool {
-        sidebarWidthConstraint.constant > 0
+    /// Observe window title changes so we can re-hide the titlebar text field.
+    /// macOS automatically re-shows it whenever `window.title` is updated.
+    private var titleObservation: NSKeyValueObservation?
+
+    private func hideTitlebarTextField(in window: NSWindow) {
+        if let cached = cachedTitlebarTextField {
+            cached.isHidden = true
+            return
+        }
+        // Find the text field through the theme frame (same path as TerminalWindow.titlebarTextField).
+        if let themeFrame = window.contentView?.superview,
+           let titleBarView = themeFrame.firstDescendant(withClassName: "NSTitlebarContainerView")?
+            .firstDescendant(withClassName: "NSTitlebarView"),
+           let textField = titleBarView.firstDescendant(withClassName: "NSTextField") as? NSTextField {
+            cachedTitlebarTextField = textField
+            textField.isHidden = true
+        }
     }
 
-    /// Toggle sidebar visibility with animation.
+    private func observeWindowTitle(_ window: NSWindow) {
+        titleObservation = window.observe(\.title, options: [.new]) { [weak self] window, _ in
+            self?.hideTitlebarTextField(in: window)
+        }
+    }
+
+    // MARK: - Traffic Lights
+
+    private func setTrafficLightsHidden(_ hidden: Bool) {
+        guard let window = window else { return }
+        for buttonType: NSWindow.ButtonType in [.closeButton, .miniaturizeButton, .zoomButton] {
+            window.standardWindowButton(buttonType)?.isHidden = hidden
+        }
+    }
+
+    // MARK: - Sidebar State Machine
+
+    /// Toggle sidebar via keyboard shortcut (Cmd+Shift+E).
     @objc func toggleSidebar() {
-        let hiding = isSidebarVisible
+        switch sidebarMode {
+        case .pinned:  transitionTo(.closed)
+        case .closed:  transitionTo(.pinned)
+        case .overlay: transitionTo(.pinned)  // promote overlay to pinned
+        }
+    }
+
+    /// Centralized state transition. All sidebar mode changes go through here.
+    private func transitionTo(_ newMode: SidebarMode) {
+        guard newMode != sidebarMode else { return }
+        sidebarMode = newMode
+
         let inset = WorkspaceLayout.terminalInset
 
+        // 1. Swap leading constraints before animation.
+        switch newMode {
+        case .pinned:
+            shadowHostLeadingToSuperview.isActive = false
+            shadowHostLeadingToSidebar.isActive = true
+        case .closed, .overlay:
+            shadowHostLeadingToSidebar.isActive = false
+            shadowHostLeadingToSuperview.isActive = true
+        }
+
+        // 2. Z-ordering for overlay mode.
+        let overlayZ: CGFloat = newMode == .overlay ? 100 : 0
+        sidebarHostingView.layer?.zPosition = overlayZ
+        sidebarOverlayBackground.layer?.zPosition = newMode == .overlay ? 99 : 0
+
+        // 3. Toggle isHidden so inactive NSVisualEffectViews leave the compositing tree.
+        switch newMode {
+        case .pinned:
+            backgroundEffectView.isHidden = false
+            sidebarOverlayBackground.isHidden = true
+        case .closed:
+            backgroundEffectView.isHidden = true
+            sidebarOverlayBackground.isHidden = true
+        case .overlay:
+            backgroundEffectView.isHidden = false
+            sidebarOverlayBackground.isHidden = false
+        }
+
+        // 4. Animate constraints, widths, alphas.
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.2
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-            sidebarWidthConstraint.animator().constant = hiding ? 0 : WorkspaceLayout.sidebarWidth
-            shadowHostTopConstraint.animator().constant = hiding ? 0 : inset
-            shadowHostLeadingConstraint.animator().constant = hiding ? 0 : inset
-            shadowHostTrailingConstraint.animator().constant = hiding ? 0 : -inset
-            shadowHostBottomConstraint.animator().constant = hiding ? 0 : -inset
-            titleLabel.animator().alphaValue = hiding ? 0 : 1
+
+            switch newMode {
+            case .pinned:
+                sidebarWidthConstraint.animator().constant = WorkspaceLayout.sidebarWidth
+                shadowHostTopConstraint.animator().constant = inset
+                shadowHostLeadingToSidebar.animator().constant = inset
+                shadowHostTrailingConstraint.animator().constant = -inset
+                shadowHostBottomConstraint.animator().constant = -inset
+                titleLabel.animator().alphaValue = 1
+                sidebarOverlayBackground.animator().alphaValue = 0
+
+            case .closed:
+                sidebarWidthConstraint.animator().constant = 0
+                shadowHostTopConstraint.animator().constant = 0
+                shadowHostLeadingToSuperview.animator().constant = 0
+                shadowHostTrailingConstraint.animator().constant = 0
+                shadowHostBottomConstraint.animator().constant = 0
+                titleLabel.animator().alphaValue = 0
+                sidebarOverlayBackground.animator().alphaValue = 0
+
+            case .overlay:
+                sidebarWidthConstraint.animator().constant = WorkspaceLayout.sidebarWidth
+                // Terminal stays full-width (leading to superview, no insets).
+                shadowHostTopConstraint.animator().constant = 0
+                shadowHostLeadingToSuperview.animator().constant = 0
+                shadowHostTrailingConstraint.animator().constant = 0
+                shadowHostBottomConstraint.animator().constant = 0
+                titleLabel.animator().alphaValue = 0
+                sidebarOverlayBackground.animator().alphaValue = 1
+            }
         }
-        terminalContainer.layer?.cornerRadius = hiding ? 0 : WorkspaceLayout.terminalCornerRadius
-        terminalShadowHost.layer?.shadowOpacity = hiding ? 0 : 0.15
-        WorkspaceStore.shared.sidebarVisible = !hiding
+
+        // 5. Non-animatable properties.
+        switch newMode {
+        case .pinned:
+            terminalContainer.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
+            terminalShadowHost.layer?.shadowOpacity = 0.15
+            sidebarOverlayBackground.layer?.shadowOpacity = 0
+        case .closed:
+            terminalContainer.layer?.cornerRadius = 0
+            terminalShadowHost.layer?.shadowOpacity = 0
+            sidebarOverlayBackground.layer?.shadowOpacity = 0
+        case .overlay:
+            terminalContainer.layer?.cornerRadius = 0
+            terminalShadowHost.layer?.shadowOpacity = 0
+            sidebarOverlayBackground.layer?.shadowOpacity = 0.2
+        }
+
+        // 6. Traffic lights.
+        setTrafficLightsHidden(newMode == .closed)
+
+        // 7. Refresh tracking areas.
+        updateTrackingAreas()
+
+        // 8. Persist (overlay is transient — store persists it as .closed).
+        WorkspaceStore.shared.sidebarMode = newMode
+
+        invalidateIntrinsicContentSize()
+    }
+
+    // MARK: - Hover Tracking
+
+    override func updateTrackingAreas() {
+        // Remove existing tracking area.
+        if let area = activeTrackingArea {
+            removeTrackingArea(area)
+            activeTrackingArea = nil
+        }
+
+        super.updateTrackingAreas()
+
+        switch sidebarMode {
+        case .closed:
+            // Install trigger zone: thin strip at left edge.
+            let triggerRect = CGRect(
+                x: 0, y: 0,
+                width: WorkspaceLayout.overlayTriggerWidth,
+                height: bounds.height
+            )
+            let area = NSTrackingArea(
+                rect: triggerRect,
+                options: [.mouseEnteredAndExited, .activeInKeyWindow],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            activeTrackingArea = area
+
+        case .overlay:
+            // Install sidebar zone: covers sidebar width.
+            let sidebarRect = CGRect(
+                x: 0, y: 0,
+                width: WorkspaceLayout.sidebarWidth,
+                height: bounds.height
+            )
+            let area = NSTrackingArea(
+                rect: sidebarRect,
+                options: [.mouseEnteredAndExited, .activeInKeyWindow],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            activeTrackingArea = area
+
+        case .pinned:
+            // No tracking areas needed.
+            break
+        }
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        if sidebarMode == .closed {
+            transitionTo(.overlay)
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        if sidebarMode == .overlay {
+            transitionTo(.closed)
+        }
+    }
+
+    // MARK: - Window Focus
+
+    @objc private func windowDidResignKey() {
+        if sidebarMode == .overlay {
+            transitionTo(.closed)
+        }
     }
 
     // MARK: - Layout
 
     private func setup() {
-        // Z-order: background material → sidebar → shadow host (with terminal inside).
+        // Z-order: background material → overlay background → sidebar → shadow host.
         addSubview(backgroundEffectView)
+        addSubview(sidebarOverlayBackground)
         addSubview(sidebarHostingView)
         addSubview(terminalShadowHost)
 
         sidebarHostingView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Enable layers for z-ordering in overlay mode.
+        sidebarHostingView.wantsLayer = true
+        sidebarOverlayBackground.wantsLayer = true
+        sidebarOverlayBackground.layer?.shadowColor = NSColor.black.cgColor
+        sidebarOverlayBackground.layer?.shadowRadius = 6
+        sidebarOverlayBackground.layer?.shadowOffset = CGSize(width: 2, height: 0)
 
         // Terminal lives inside the shadow host. The host carries the shadow;
         // the terminal clips its own corners via masksToBounds.
@@ -161,23 +434,31 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         terminalShadowHost.addSubview(titleLabel)
         terminalContainer.translatesAutoresizingMaskIntoConstraints = false
 
-        // Read persisted sidebar visibility.
-        let sidebarVisible = WorkspaceStore.shared.sidebarVisible
-        let initialWidth: CGFloat = sidebarVisible ? WorkspaceLayout.sidebarWidth : 0
+        // Read persisted sidebar mode.
+        let initialMode = WorkspaceStore.shared.sidebarMode
+        self.sidebarMode = initialMode
+        let isPinned = initialMode == .pinned
+        let initialWidth: CGFloat = isPinned ? WorkspaceLayout.sidebarWidth : 0
 
         sidebarWidthConstraint = sidebarHostingView.widthAnchor.constraint(equalToConstant: initialWidth)
 
-        let inset: CGFloat = sidebarVisible ? WorkspaceLayout.terminalInset : 0
+        let inset: CGFloat = isPinned ? WorkspaceLayout.terminalInset : 0
 
         // Inset constraints target the shadow host, not the terminal directly.
         shadowHostTopConstraint = terminalShadowHost.topAnchor.constraint(
             equalTo: topAnchor, constant: inset)
-        shadowHostLeadingConstraint = terminalShadowHost.leadingAnchor.constraint(
-            equalTo: sidebarHostingView.trailingAnchor, constant: inset)
         shadowHostTrailingConstraint = terminalShadowHost.trailingAnchor.constraint(
-            equalTo: trailingAnchor, constant: -inset)
+            equalTo: trailingAnchor, constant: isPinned ? -inset : 0)
         shadowHostBottomConstraint = terminalShadowHost.bottomAnchor.constraint(
-            equalTo: bottomAnchor, constant: -inset)
+            equalTo: bottomAnchor, constant: isPinned ? -inset : 0)
+
+        // Dual leading constraints (mutually exclusive).
+        shadowHostLeadingToSidebar = terminalShadowHost.leadingAnchor.constraint(
+            equalTo: sidebarHostingView.trailingAnchor, constant: inset)
+        shadowHostLeadingToSuperview = terminalShadowHost.leadingAnchor.constraint(
+            equalTo: leadingAnchor, constant: 0)
+        shadowHostLeadingToSidebar.isActive = isPinned
+        shadowHostLeadingToSuperview.isActive = !isPinned
 
         NSLayoutConstraint.activate([
             backgroundEffectView.topAnchor.constraint(equalTo: topAnchor),
@@ -185,13 +466,18 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
             backgroundEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
             backgroundEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
+            // Overlay background tracks sidebar width via trailing edge.
+            sidebarOverlayBackground.topAnchor.constraint(equalTo: topAnchor),
+            sidebarOverlayBackground.leadingAnchor.constraint(equalTo: leadingAnchor),
+            sidebarOverlayBackground.bottomAnchor.constraint(equalTo: bottomAnchor),
+            sidebarOverlayBackground.trailingAnchor.constraint(equalTo: sidebarHostingView.trailingAnchor),
+
             sidebarHostingView.topAnchor.constraint(equalTo: topAnchor),
             sidebarHostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             sidebarHostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
             sidebarWidthConstraint,
 
             shadowHostTopConstraint,
-            shadowHostLeadingConstraint,
             shadowHostBottomConstraint,
             shadowHostTrailingConstraint,
 
@@ -208,21 +494,22 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
                 constant: (WorkspaceLayout.titlebarSpacerHeight - 16) / 2),
         ])
 
-        // Terminal floating card: all four corners rounded when sidebar visible.
+        // Terminal floating card: all four corners rounded when pinned.
         terminalContainer.wantsLayer = true
-        terminalContainer.layer?.cornerRadius = sidebarVisible ? WorkspaceLayout.terminalCornerRadius : 0
+        terminalContainer.layer?.cornerRadius = isPinned ? WorkspaceLayout.terminalCornerRadius : 0
         terminalContainer.layer?.masksToBounds = true
 
         // Configure shadow on the host layer. Must happen after addSubview so the
         // layer exists (wantsLayer in a property closure may not create it in time).
         terminalShadowHost.wantsLayer = true
         terminalShadowHost.layer?.shadowColor = NSColor.black.cgColor
-        terminalShadowHost.layer?.shadowOpacity = sidebarVisible ? 0.15 : 0
+        terminalShadowHost.layer?.shadowOpacity = isPinned ? 0.15 : 0
         terminalShadowHost.layer?.shadowRadius = 8
         terminalShadowHost.layer?.shadowOffset = CGSize(width: 0, height: -2)
 
-        // Hide title when sidebar starts collapsed.
-        if !sidebarVisible {
+        // Hide background material and title when sidebar starts collapsed.
+        if !isPinned {
+            backgroundEffectView.isHidden = true
             titleLabel.alphaValue = 0
         }
 
@@ -235,6 +522,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
                 else { return "" }
                 return session.name
             }
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] name in
                 self?.titleLabel.stringValue = name

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -76,6 +76,10 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     private var shadowHostTrailingConstraint: NSLayoutConstraint!
     private var shadowHostBottomConstraint: NSLayoutConstraint!
 
+    /// Top offset of the terminal inside the shadow host, reserving space
+    /// for the title bar in pinned mode.
+    private var terminalTopConstraint: NSLayoutConstraint!
+
     /// Dual leading constraints — mutually exclusive.
     /// `.pinned`: terminal leading follows sidebar trailing (pushed right).
     /// `.closed`/`.overlay`: terminal leading follows superview leading (full-width).
@@ -98,7 +102,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         let sidebarView = WorkspaceSidebarView()
             .environmentObject(WorkspaceStore.shared)
             .environmentObject(coordinator)
-        let hostingView = NSHostingView(rootView: sidebarView)
+        let hostingView = TransparentHostingView(rootView: sidebarView)
         // Auto Layout controls the sidebar width; disable intrinsic size reporting
         // to avoid unnecessary layout computation from the hosting view.
         hostingView.sizingOptions = []
@@ -235,9 +239,11 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         sidebarOverlayBackground.layer?.zPosition = newMode == .overlay ? 99 : 0
 
         // 3. Toggle isHidden so inactive NSVisualEffectViews leave the compositing tree.
+        //    The background material is only visible in overlay mode (floating hover state).
+        //    In pinned mode the sidebar is transparent — the window background shows through.
         switch newMode {
         case .pinned:
-            backgroundEffectView.isHidden = false
+            backgroundEffectView.isHidden = true
             sidebarOverlayBackground.isHidden = true
         case .closed:
             backgroundEffectView.isHidden = true
@@ -260,6 +266,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
                 shadowHostLeadingToSidebar.animator().constant = inset
                 shadowHostTrailingConstraint.animator().constant = -inset
                 shadowHostBottomConstraint.animator().constant = -inset
+                terminalTopConstraint.animator().constant = WorkspaceLayout.titlebarSpacerHeight
                 titleLabel.animator().alphaValue = 1
                 sidebarOverlayBackground.animator().alphaValue = 0
 
@@ -269,6 +276,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
                 shadowHostLeadingToSuperview.animator().constant = 0
                 shadowHostTrailingConstraint.animator().constant = 0
                 shadowHostBottomConstraint.animator().constant = 0
+                terminalTopConstraint.animator().constant = 0
                 titleLabel.animator().alphaValue = 0
                 sidebarOverlayBackground.animator().alphaValue = 0
 
@@ -279,6 +287,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
                 shadowHostLeadingToSuperview.animator().constant = 0
                 shadowHostTrailingConstraint.animator().constant = 0
                 shadowHostBottomConstraint.animator().constant = 0
+                terminalTopConstraint.animator().constant = 0
                 titleLabel.animator().alphaValue = 0
                 sidebarOverlayBackground.animator().alphaValue = 1
             }
@@ -288,15 +297,24 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         switch newMode {
         case .pinned:
             terminalContainer.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
+            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
             terminalShadowHost.layer?.shadowOpacity = 0.2
+            terminalShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
+            terminalShadowHost.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .closed:
             terminalContainer.layer?.cornerRadius = 0
+            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             terminalShadowHost.layer?.shadowOpacity = 0
+            terminalShadowHost.layer?.cornerRadius = 0
+            terminalShadowHost.layer?.backgroundColor = nil
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .overlay:
             terminalContainer.layer?.cornerRadius = 0
+            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             terminalShadowHost.layer?.shadowOpacity = 0
+            terminalShadowHost.layer?.cornerRadius = 0
+            terminalShadowHost.layer?.backgroundColor = nil
             sidebarOverlayBackground.layer?.shadowOpacity = 0.2
         }
 
@@ -431,6 +449,11 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         shadowHostLeadingToSidebar.isActive = isPinned
         shadowHostLeadingToSuperview.isActive = !isPinned
 
+        // Terminal top offset inside the shadow host — reserves title bar space when pinned.
+        let titlebarInset: CGFloat = isPinned ? WorkspaceLayout.titlebarSpacerHeight : 0
+        terminalTopConstraint = terminalContainer.topAnchor.constraint(
+            equalTo: terminalShadowHost.topAnchor, constant: titlebarInset)
+
         NSLayoutConstraint.activate([
             backgroundEffectView.topAnchor.constraint(equalTo: topAnchor),
             backgroundEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -452,8 +475,8 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
             shadowHostBottomConstraint,
             shadowHostTrailingConstraint,
 
-            // Terminal fills the shadow host.
-            terminalContainer.topAnchor.constraint(equalTo: terminalShadowHost.topAnchor),
+            // Terminal fills the shadow host (top offset reserves title bar space).
+            terminalTopConstraint,
             terminalContainer.leadingAnchor.constraint(equalTo: terminalShadowHost.leadingAnchor),
             terminalContainer.trailingAnchor.constraint(equalTo: terminalShadowHost.trailingAnchor),
             terminalContainer.bottomAnchor.constraint(equalTo: terminalShadowHost.bottomAnchor),
@@ -469,10 +492,9 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         terminalContainer.wantsLayer = true
         terminalContainer.layer?.cornerRadius = isPinned ? WorkspaceLayout.terminalCornerRadius : 0
         terminalContainer.layer?.cornerCurve = .continuous
-        terminalContainer.layer?.maskedCorners = [
-            .layerMinXMinYCorner, .layerMaxXMinYCorner,  // top-left, top-right
-            .layerMinXMaxYCorner, .layerMaxXMaxYCorner,  // bottom-left, bottom-right
-        ]
+        terminalContainer.layer?.maskedCorners = isPinned
+            ? [.layerMinXMinYCorner, .layerMaxXMinYCorner]  // bottom only (MinY = bottom in CA coords)
+            : [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         terminalContainer.layer?.masksToBounds = true
 
         // Configure shadow on the host layer. Must happen after addSubview so the
@@ -483,9 +505,16 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         terminalShadowHost.layer?.shadowRadius = 8
         terminalShadowHost.layer?.shadowOffset = CGSize(width: 0, height: -2)
 
-        // Hide background material and title when sidebar starts collapsed.
+        // Card background behind the title bar region. No masksToBounds — shadow
+        // must render outside the layer bounds.
+        terminalShadowHost.layer?.cornerRadius = isPinned ? WorkspaceLayout.terminalCornerRadius : 0
+        terminalShadowHost.layer?.cornerCurve = .continuous
+        terminalShadowHost.layer?.backgroundColor = isPinned ? NSColor.textBackgroundColor.cgColor : nil
+
+        // Background material is only visible in overlay (floating hover) mode.
+        // In pinned mode the sidebar is transparent; in closed mode it's hidden entirely.
+        backgroundEffectView.isHidden = true
         if !isPinned {
-            backgroundEffectView.isHidden = true
             titleLabel.alphaValue = 0
         }
 
@@ -505,4 +534,14 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
             }
             .store(in: &cancellables)
     }
+}
+
+// MARK: - Transparent Hosting View
+
+/// NSHostingView subclass that doesn't draw the default window background.
+/// Used for the sidebar so it's transparent in pinned mode — the window
+/// background shows through. The overlay NSVisualEffectView provides
+/// material only in hover mode.
+private class TransparentHostingView<Content: View>: NSHostingView<Content> {
+    override var isOpaque: Bool { false }
 }

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -147,6 +147,12 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         )
     }
 
+    /// Zero out safe area insets so Auto Layout constraints measure from
+    /// the actual window edge, not the titlebar-offset safe area.
+    /// Without this, `topAnchor` is shifted down by ~28pt (titlebar height)
+    /// and our `terminalTopInset` constant has no visible effect.
+    override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+
     override var intrinsicContentSize: NSSize {
         let termSize = terminalContainer.intrinsicContentSize
         guard termSize.width != NSView.noIntrinsicMetric else { return termSize }
@@ -275,7 +281,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         switch newMode {
         case .pinned:
             terminalContainer.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
-            terminalShadowHost.layer?.shadowOpacity = 0.15
+            terminalShadowHost.layer?.shadowOpacity = 0.2
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .closed:
             terminalContainer.layer?.cornerRadius = 0
@@ -402,7 +408,6 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         sidebarWidthConstraint = sidebarHostingView.widthAnchor.constraint(equalToConstant: initialWidth)
 
         let inset: CGFloat = isPinned ? WorkspaceLayout.terminalInset : 0
-
         // Inset constraints target the shadow host, not the terminal directly.
         shadowHostTopConstraint = terminalShadowHost.topAnchor.constraint(
             equalTo: topAnchor, constant: inset)
@@ -456,13 +461,18 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         // Terminal floating card: all four corners rounded when pinned.
         terminalContainer.wantsLayer = true
         terminalContainer.layer?.cornerRadius = isPinned ? WorkspaceLayout.terminalCornerRadius : 0
+        terminalContainer.layer?.cornerCurve = .continuous
+        terminalContainer.layer?.maskedCorners = [
+            .layerMinXMinYCorner, .layerMaxXMinYCorner,  // top-left, top-right
+            .layerMinXMaxYCorner, .layerMaxXMaxYCorner,  // bottom-left, bottom-right
+        ]
         terminalContainer.layer?.masksToBounds = true
 
         // Configure shadow on the host layer. Must happen after addSubview so the
         // layer exists (wantsLayer in a property closure may not create it in time).
         terminalShadowHost.wantsLayer = true
         terminalShadowHost.layer?.shadowColor = NSColor.black.cgColor
-        terminalShadowHost.layer?.shadowOpacity = isPinned ? 0.15 : 0
+        terminalShadowHost.layer?.shadowOpacity = isPinned ? 0.2 : 0
         terminalShadowHost.layer?.shadowRadius = 8
         terminalShadowHost.layer?.shadowOffset = CGSize(width: 0, height: -2)
 

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -205,9 +205,16 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         }
     }
 
+    /// Minimum interval between transitions to prevent rapid oscillation
+    /// (e.g. mouse hovering at the overlay/closed boundary).
+    private var lastTransitionTime: CFTimeInterval = 0
+
     /// Centralized state transition. All sidebar mode changes go through here.
     private func transitionTo(_ newMode: SidebarMode) {
         guard newMode != sidebarMode else { return }
+        let now = CACurrentMediaTime()
+        guard now - lastTransitionTime > 0.25 else { return }
+        lastTransitionTime = now
         sidebarMode = newMode
 
         let inset = WorkspaceLayout.terminalInset
@@ -300,7 +307,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         updateTrackingAreas()
 
         // 8. Persist (overlay is transient — store persists it as .closed).
-        WorkspaceStore.shared.sidebarMode = newMode
+        WorkspaceStore.shared.updateSidebarMode(newMode)
 
         invalidateIntrinsicContentSize()
     }
@@ -427,7 +434,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         NSLayoutConstraint.activate([
             backgroundEffectView.topAnchor.constraint(equalTo: topAnchor),
             backgroundEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            backgroundEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundEffectView.trailingAnchor.constraint(equalTo: sidebarHostingView.trailingAnchor),
             backgroundEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             // Overlay background tracks sidebar width via trailing edge.

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -58,7 +58,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     /// Session name centered at the top of the terminal card (titlebar region).
     private let titleLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
-        label.font = .systemFont(ofSize: 13, weight: .regular)
+        label.font = .systemFont(ofSize: 11, weight: .regular)
         label.textColor = .secondaryLabelColor
         label.alignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -455,7 +455,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
             titleLabel.centerXAnchor.constraint(equalTo: terminalShadowHost.centerXAnchor),
             titleLabel.topAnchor.constraint(
                 equalTo: terminalShadowHost.topAnchor,
-                constant: (WorkspaceLayout.titlebarSpacerHeight - 16) / 2),
+                constant: 6),
         ])
 
         // Terminal floating card: all four corners rounded when pinned.

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -85,9 +85,6 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     /// Tracking area for hover detection. Only one is active at a time.
     private var activeTrackingArea: NSTrackingArea?
 
-    /// Cached reference to the native titlebar text field to avoid
-    /// recursive view hierarchy traversal on every window title change.
-    private weak var cachedTitlebarTextField: NSTextField?
 
     init(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil) {
         self.terminalContainer = TerminalViewContainer(
@@ -118,7 +115,6 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        titleObservation?.invalidate()
     }
 
     override func viewDidMoveToWindow() {
@@ -126,9 +122,6 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
 
         // Clean up previous window's observers (handles view moving between windows).
         NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
-        titleObservation?.invalidate()
-        titleObservation = nil
-        cachedTitlebarTextField = nil
 
         guard let window = window else { return }
         // Give the coordinator a reference to this view so it can discover
@@ -141,14 +134,6 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
 
         // Extend content under titlebar — traffic lights appear inside the sidebar panel.
         window.styleMask.insert(.fullSizeContentView)
-        window.titlebarAppearsTransparent = true
-        window.titleVisibility = .hidden
-
-        // Hide the native titlebar title text. The session name label inside the
-        // terminal card replaces it. We must re-hide on every title change because
-        // macOS re-shows the text field when window.title is updated.
-        hideTitlebarTextField(in: window)
-        observeWindowTitle(window)
 
         // Apply initial traffic light visibility.
         setTrafficLightsHidden(sidebarMode == .closed)
@@ -192,33 +177,6 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
             rect: sidebarOverlayBackground.bounds,
             transform: nil
         )
-    }
-
-    // MARK: - Titlebar
-
-    /// Observe window title changes so we can re-hide the titlebar text field.
-    /// macOS automatically re-shows it whenever `window.title` is updated.
-    private var titleObservation: NSKeyValueObservation?
-
-    private func hideTitlebarTextField(in window: NSWindow) {
-        if let cached = cachedTitlebarTextField {
-            cached.isHidden = true
-            return
-        }
-        // Find the text field through the theme frame (same path as TerminalWindow.titlebarTextField).
-        if let themeFrame = window.contentView?.superview,
-           let titleBarView = themeFrame.firstDescendant(withClassName: "NSTitlebarContainerView")?
-            .firstDescendant(withClassName: "NSTitlebarView"),
-           let textField = titleBarView.firstDescendant(withClassName: "NSTextField") as? NSTextField {
-            cachedTitlebarTextField = textField
-            textField.isHidden = true
-        }
-    }
-
-    private func observeWindowTitle(_ window: NSWindow) {
-        titleObservation = window.observe(\.title, options: [.new]) { [weak self] window, _ in
-            self?.hideTitlebarTextField(in: window)
-        }
     }
 
     // MARK: - Traffic Lights

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -30,6 +30,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     private let sidebarHostingView: NSView
     private let terminalContainer: TerminalViewContainer<ViewModel>
     private let coordinator: SessionCoordinator
+    private let ghostty: Ghostty.App
 
     /// Shadow host wraps the terminal container so the drop shadow renders
     /// outside `masksToBounds` clipping. The shadow host carries the shadow;
@@ -89,8 +90,14 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
     /// Tracking area for hover detection. Only one is active at a time.
     private var activeTrackingArea: NSTrackingArea?
 
+    /// Terminal background color from Ghostty config, used for the card title bar.
+    private var terminalBackgroundCGColor: CGColor {
+        NSColor(ghostty.config.backgroundColor).cgColor
+    }
+
 
     init(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil) {
+        self.ghostty = ghostty
         self.terminalContainer = TerminalViewContainer(
             ghostty: ghostty,
             viewModel: viewModel,
@@ -266,7 +273,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
                 shadowHostLeadingToSidebar.animator().constant = inset
                 shadowHostTrailingConstraint.animator().constant = -inset
                 shadowHostBottomConstraint.animator().constant = -inset
-                terminalTopConstraint.animator().constant = WorkspaceLayout.titlebarSpacerHeight
+                terminalTopConstraint.animator().constant = WorkspaceLayout.terminalTitleBarHeight
                 titleLabel.animator().alphaValue = 1
                 sidebarOverlayBackground.animator().alphaValue = 0
 
@@ -300,7 +307,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
             terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
             terminalShadowHost.layer?.shadowOpacity = 0.2
             terminalShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
-            terminalShadowHost.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
+            terminalShadowHost.layer?.backgroundColor = terminalBackgroundCGColor
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .closed:
             terminalContainer.layer?.cornerRadius = 0
@@ -450,7 +457,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         shadowHostLeadingToSuperview.isActive = !isPinned
 
         // Terminal top offset inside the shadow host — reserves title bar space when pinned.
-        let titlebarInset: CGFloat = isPinned ? WorkspaceLayout.titlebarSpacerHeight : 0
+        let titlebarInset: CGFloat = isPinned ? WorkspaceLayout.terminalTitleBarHeight : 0
         terminalTopConstraint = terminalContainer.topAnchor.constraint(
             equalTo: terminalShadowHost.topAnchor, constant: titlebarInset)
 
@@ -509,7 +516,7 @@ class WorkspaceViewContainer<ViewModel: TerminalViewModel>: NSView {
         // must render outside the layer bounds.
         terminalShadowHost.layer?.cornerRadius = isPinned ? WorkspaceLayout.terminalCornerRadius : 0
         terminalShadowHost.layer?.cornerCurve = .continuous
-        terminalShadowHost.layer?.backgroundColor = isPinned ? NSColor.textBackgroundColor.cgColor : nil
+        terminalShadowHost.layer?.backgroundColor = isPinned ? terminalBackgroundCGColor : nil
 
         // Background material is only visible in overlay (floating hover) mode.
         // In pinned mode the sidebar is transparent; in closed mode it's hidden entirely.

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -7,35 +7,11 @@ import GhosttyKit
 /// A classic, tabbed terminal experience.
 class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Controller {
     override var windowNibName: NSNib.Name? {
-        let defaultValue = "Terminal"
-
-        guard let appDelegate = NSApp.delegate as? AppDelegate else { return defaultValue }
-        let config = appDelegate.ghostty.config
-
-        // If we have no window decorations, there's no reason to do anything but
-        // the default titlebar (because there will be no titlebar).
-        if !config.windowDecorations {
-            return defaultValue
-        }
-
-        let nib = switch config.macosTitlebarStyle {
-        case "native": "Terminal"
-        case "hidden": "TerminalHiddenTitlebar"
-        case "transparent": "TerminalTransparentTitlebar"
-        case "tabs":
-#if compiler(>=6.2)
-            if #available(macOS 26.0, *) {
-                "TerminalTabsTitlebarTahoe"
-            } else {
-                "TerminalTabsTitlebarVentura"
-            }
-#else
-            "TerminalTabsTitlebarVentura"
-#endif
-        default: defaultValue
-        }
-
-        return nib
+        // Workspace mode always uses the base Terminal nib. The sidebar
+        // replaces native tabs and provides its own titlebar appearance,
+        // so we bypass macosTitlebarStyle entirely to avoid fighting
+        // complex titlebar subclasses (TitlebarTabsVenturaTerminalWindow, etc.).
+        return "Terminal"
     }
 
     /// This is set to true when we care about frame changes. This is a small optimization since
@@ -1046,6 +1022,10 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             delegate: self,
         )
 
+        // Hide the native titlebar text — the workspace sidebar's title label
+        // inside the terminal card replaces it.
+        configureWorkspaceTitlebar()
+
         // If we have a default size, we want to apply it.
         if let defaultSize {
             switch defaultSize {
@@ -1196,6 +1176,18 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
     }
 
     // MARK: Workspace Sidebar
+
+    /// Configure the window for workspace mode: transparent titlebar with
+    /// all title text hidden. The workspace sidebar and its terminal-card
+    /// title label replace the native/toolbar title display.
+    ///
+    /// Must be called after setting WorkspaceViewContainer as the contentView.
+    private func configureWorkspaceTitlebar() {
+        guard let window else { return }
+
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+    }
 
     @IBAction func toggleWorkspaceSidebar(_ sender: Any?) {
         guard let container = window?.contentView as? WorkspaceViewContainer<TerminalController> else { return }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1177,16 +1177,26 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
 
     // MARK: Workspace Sidebar
 
-    /// Configure the window for workspace mode: transparent titlebar with
-    /// all title text hidden. The workspace sidebar and its terminal-card
-    /// title label replace the native/toolbar title display.
+    /// Configure the window for workspace mode: invisible titlebar with
+    /// traffic lights at their natural position. The workspace sidebar
+    /// extends behind the titlebar and provides its own toolbar buttons.
     ///
-    /// Must be called after setting WorkspaceViewContainer as the contentView.
+    /// Must be called after setting WorkspaceViewContainer as the contentView
+    /// and after `awakeFromNib` has added the default titlebar accessories.
     private func configureWorkspaceTitlebar() {
         guard let window else { return }
 
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
+
+        // Remove titlebar accessories (resetZoom, update notification) that
+        // the base TerminalWindow adds in awakeFromNib. These inflate the
+        // titlebar height and create a visible band. The workspace sidebar
+        // replaces their functionality.
+        while !window.titlebarAccessoryViewControllers.isEmpty {
+            window.removeTitlebarAccessoryViewController(at: 0)
+        }
     }
 
     @IBAction func toggleWorkspaceSidebar(_ sender: Any?) {

--- a/macos/Tests/Workspace/WorkspacePersistenceTests.swift
+++ b/macos/Tests/Workspace/WorkspacePersistenceTests.swift
@@ -23,9 +23,9 @@ struct WorkspacePersistenceTests {
 
     // MARK: - State Init
 
-    @Test func defaultStateHasSidebarVisible() {
+    @Test func defaultStateHasSidebarPinned() {
         let state = WorkspacePersistence.State()
-        #expect(state.sidebarVisible == true)
+        #expect(state.sidebarMode == .pinned)
     }
 
     @Test func defaultStateHasNilLastSelectedProjectId() {
@@ -36,10 +36,10 @@ struct WorkspacePersistenceTests {
     @Test func initWithAllParamsSetsSidebarAndSelection() {
         let uuid = UUID()
         let state = WorkspacePersistence.State(
-            sidebarVisible: false,
+            sidebarMode: .closed,
             lastSelectedProjectId: uuid
         )
-        #expect(state.sidebarVisible == false)
+        #expect(state.sidebarMode == .closed)
         #expect(state.lastSelectedProjectId == uuid)
     }
 
@@ -54,7 +54,7 @@ struct WorkspacePersistenceTests {
             projects: [project],
             sessions: [session],
             templates: [template],
-            sidebarVisible: false,
+            sidebarMode: .closed,
             lastSelectedProjectId: projectId
         )
 
@@ -69,12 +69,12 @@ struct WorkspacePersistenceTests {
         #expect(decoded.sessions[0].projectId == projectId)
         #expect(decoded.templates.count == 1)
         #expect(decoded.templates[0].name == "Custom")
-        #expect(decoded.sidebarVisible == false)
+        #expect(decoded.sidebarMode == .closed)
         #expect(decoded.lastSelectedProjectId == projectId)
     }
 
     @Test func decodingOldJsonWithoutNewFieldsUsesDefaults() throws {
-        // Simulates workspace.json from before sidebarVisible and lastSelectedProjectId existed.
+        // Simulates workspace.json from before sidebarMode and lastSelectedProjectId existed.
         let json = """
         {
             "projects": [],
@@ -85,11 +85,56 @@ struct WorkspacePersistenceTests {
         let data = Data(json.utf8)
         let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
 
-        #expect(decoded.sidebarVisible == true)
+        #expect(decoded.sidebarMode == .pinned)
         #expect(decoded.lastSelectedProjectId == nil)
         #expect(decoded.projects.isEmpty)
         #expect(decoded.sessions.isEmpty)
         #expect(decoded.templates.isEmpty)
+    }
+
+    @Test func decodingLegacySidebarVisibleTrueMigratesToPinned() throws {
+        let json = """
+        {
+            "projects": [],
+            "sessions": [],
+            "templates": [],
+            "sidebarVisible": true
+        }
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
+        #expect(decoded.sidebarMode == .pinned)
+    }
+
+    @Test func decodingLegacySidebarVisibleFalseMigratesToClosed() throws {
+        let json = """
+        {
+            "projects": [],
+            "sessions": [],
+            "templates": [],
+            "sidebarVisible": false
+        }
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
+        #expect(decoded.sidebarMode == .closed)
+    }
+
+    @Test func decodingInvalidSidebarModeRawValueDefaultsToPinned() throws {
+        // An out-of-range raw value should gracefully default to .pinned,
+        // not throw a DecodingError that wipes all state.
+        let json = """
+        {
+            "projects": [],
+            "sessions": [],
+            "templates": [],
+            "sidebarMode": 99
+        }
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
+        #expect(decoded.sidebarMode == .pinned)
+        #expect(decoded.projects.isEmpty)
     }
 
     // MARK: - Validation

--- a/macos/Tests/Workspace/WorkspacePersistenceTests.swift
+++ b/macos/Tests/Workspace/WorkspacePersistenceTests.swift
@@ -137,6 +137,13 @@ struct WorkspacePersistenceTests {
         #expect(decoded.projects.isEmpty)
     }
 
+    @Test func encodingOverlayModePersistsAsClosed() throws {
+        let state = WorkspacePersistence.State(sidebarMode: .overlay)
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
+        #expect(decoded.sidebarMode == .closed)
+    }
+
     // MARK: - Validation
 
     @Test func validateClearsStaleLastSelectedProjectId() {

--- a/todos/007-complete-p1-missing-shadow-path.md
+++ b/todos/007-complete-p1-missing-shadow-path.md
@@ -1,0 +1,72 @@
+---
+status: complete
+priority: p1
+issue_id: "007"
+tags: [code-review, performance, gpu, rendering]
+dependencies: []
+---
+
+# Missing shadowPath Causes Continuous Offscreen Rendering
+
+## Problem Statement
+
+Both `terminalShadowHost` and `sidebarOverlayBackground` have `shadowOpacity > 0` without a `shadowPath` set. Without an explicit shadow path, Core Animation must rasterize the layer's content every frame to compute the shadow shape. For a terminal emulator where content updates on every keystroke/output line, this means a full-window offscreen render pass per frame on Retina displays.
+
+On a 5K display at 2x, this is ~59 MB re-rendered every frame. This can cause frame drops during rapid terminal output.
+
+## Findings
+
+- **Performance Oracle**: Flagged as P0 critical — "single highest-impact fix in this review"
+- **Pattern Recognition**: Not flagged (focused on code patterns, not GPU behavior)
+
+## Proposed Solutions
+
+### Option A: Set shadowPath in layout() override (Recommended)
+
+```swift
+override func layout() {
+    super.layout()
+    terminalShadowHost.layer?.shadowPath = CGPath(
+        roundedRect: terminalShadowHost.bounds,
+        cornerWidth: WorkspaceLayout.terminalCornerRadius,
+        cornerHeight: WorkspaceLayout.terminalCornerRadius,
+        transform: nil
+    )
+    sidebarOverlayBackground.layer?.shadowPath = CGPath(
+        rect: sidebarOverlayBackground.bounds,
+        transform: nil
+    )
+}
+```
+
+**Pros:** Eliminates offscreen rendering entirely, updates on every resize
+**Cons:** None — this is the standard approach
+**Effort:** Small
+**Risk:** Low
+
+## Technical Details
+
+**Affected files:**
+- `macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift`
+
+**Shadow layers without paths:**
+- Line 470-474: `terminalShadowHost` shadow (radius 8, offset 0,-2)
+- Line 282-284: `sidebarOverlayBackground` shadow (radius 6, offset 2,0)
+
+## Acceptance Criteria
+
+- [ ] `shadowPath` set on `terminalShadowHost` layer
+- [ ] `shadowPath` set on `sidebarOverlayBackground` layer
+- [ ] Both paths update on layout changes (window resize)
+- [ ] No visible change to shadow appearance
+- [ ] Smooth 60fps terminal scrolling in pinned mode on Retina displays
+
+## Work Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-02-26 | Identified by Performance Oracle agent | P0 finding |
+
+## Resources
+
+- Apple docs: [Improving Shadow Rendering](https://developer.apple.com/documentation/quartzcore/calayer/1410771-shadowpath)

--- a/todos/008-complete-p1-missing-deinit-observer-cleanup.md
+++ b/todos/008-complete-p1-missing-deinit-observer-cleanup.md
@@ -1,0 +1,69 @@
+---
+status: complete
+priority: p1
+issue_id: "008"
+tags: [code-review, security, memory, lifecycle]
+dependencies: []
+---
+
+# Missing deinit in WorkspaceViewContainer — Observer Leak
+
+## Problem Statement
+
+`WorkspaceViewContainer` registers a `NotificationCenter` observer in `viewDidMoveToWindow()` (selector-based) but has no `deinit` and never calls `removeObserver`. If `viewDidMoveToWindow()` is called multiple times (view moved between windows), observers accumulate. The KVO observation on `window.title` is also not explicitly invalidated when the view leaves its window.
+
+On modern macOS (10.11+), selector-based observers use zeroing weak references so this won't crash, but it is still a resource leak and correctness issue.
+
+## Findings
+
+- **Security Sentinel**: Flagged as MEDIUM — "most actionable fix"
+- **Architecture Strategist**: Flagged as MEDIUM — noted SessionCoordinator already has correct deinit pattern
+
+## Proposed Solutions
+
+### Option A: Add deinit + guard viewDidMoveToWindow (Recommended)
+
+```swift
+deinit {
+    NotificationCenter.default.removeObserver(self)
+    titleObservation?.invalidate()
+}
+
+override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    // Clean up previous window's observers.
+    NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
+    titleObservation?.invalidate()
+    titleObservation = nil
+    guard let window = window else { return }
+    // ... re-register with new window ...
+}
+```
+
+**Pros:** Follows existing pattern from `SessionCoordinator.deinit`, handles window-move edge case
+**Cons:** None
+**Effort:** Small
+**Risk:** Low
+
+## Technical Details
+
+**Affected files:**
+- `macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift`
+  - Line 142-148: NotificationCenter observer registration
+  - Line 170: `titleObservation` KVO property
+  - Line 182-186: `observeWindowTitle` KVO setup
+
+**Reference pattern:**
+- `SessionCoordinator.swift` line 412: `deinit { NotificationCenter.default.removeObserver(self) }`
+
+## Acceptance Criteria
+
+- [ ] `deinit` added with `removeObserver` and `titleObservation?.invalidate()`
+- [ ] `viewDidMoveToWindow` cleans up previous window's observer before re-registering
+- [ ] No duplicate observers accumulate if view moves between windows
+
+## Work Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-02-26 | Identified by Security Sentinel + Architecture Strategist | Consensus finding |

--- a/todos/009-complete-p1-stale-persistence-tests.md
+++ b/todos/009-complete-p1-stale-persistence-tests.md
@@ -1,0 +1,52 @@
+---
+status: complete
+priority: p1
+issue_id: "009"
+tags: [code-review, testing, compilation]
+dependencies: []
+---
+
+# WorkspacePersistenceTests References Removed sidebarVisible API
+
+## Problem Statement
+
+`WorkspacePersistenceTests.swift` still references `state.sidebarVisible` and the old `State(sidebarVisible:)` initializer. The `WorkspacePersistence.State` struct no longer has a `sidebarVisible` property — it now uses `sidebarMode: SidebarMode`. These tests will fail to compile.
+
+## Findings
+
+- **Architecture Strategist**: Flagged as HIGH priority — "most critical issue on this branch"
+
+## Proposed Solutions
+
+### Option A: Update all references (Recommended)
+
+Update all occurrences of `sidebarVisible` to `sidebarMode` and add a test for the legacy `sidebarVisible` JSON migration path.
+
+Lines to update:
+- `state.sidebarVisible == true` → `state.sidebarMode == .pinned`
+- `sidebarVisible: false` → `sidebarMode: .closed`
+- `state.sidebarVisible == false` → `state.sidebarMode == .closed`
+- `decoded.sidebarVisible == false` → `decoded.sidebarMode == .closed`
+- `decoded.sidebarVisible == true` → `decoded.sidebarMode == .pinned`
+
+New test to add: decode JSON containing `"sidebarVisible": false` (no `sidebarMode` key) and verify it produces `.closed`.
+
+**Effort:** Small
+**Risk:** Low
+
+## Technical Details
+
+**Affected files:**
+- `macos/Tests/Workspace/WorkspacePersistenceTests.swift`
+
+## Acceptance Criteria
+
+- [ ] All test references updated from `sidebarVisible` to `sidebarMode`
+- [ ] Tests compile and pass
+- [ ] New test for legacy `sidebarVisible` → `sidebarMode` migration
+
+## Work Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-02-26 | Identified by Architecture Strategist | Compilation blocker |

--- a/todos/010-complete-p2-hide-views-when-inactive.md
+++ b/todos/010-complete-p2-hide-views-when-inactive.md
@@ -1,0 +1,61 @@
+---
+status: complete
+priority: p2
+issue_id: "010"
+tags: [code-review, performance, gpu, compositing]
+dependencies: []
+---
+
+# NSVisualEffectViews Compositing When Not Visible
+
+## Problem Statement
+
+Two `NSVisualEffectView` instances continue compositing when they are not needed:
+
+1. `backgroundEffectView` (full-window) composites in all modes, including `.closed` where it is fully occluded by the terminal. This creates a Gaussian blur filter in WindowServer processing every pixel of the window backing.
+
+2. `sidebarOverlayBackground` uses `alphaValue = 0` in non-overlay modes, but `isHidden` is never set. `alphaValue = 0` does NOT remove a layer from the compositing tree — Core Animation still traverses it.
+
+## Findings
+
+- **Performance Oracle**: Flagged `backgroundEffectView` as P1, `sidebarOverlayBackground` as P1
+
+## Proposed Solutions
+
+### Option A: Toggle isHidden in transitionTo() (Recommended)
+
+```swift
+// In transitionTo(), add to each case:
+case .closed:
+    backgroundEffectView.isHidden = true
+    sidebarOverlayBackground.isHidden = true
+case .pinned:
+    backgroundEffectView.isHidden = false
+    sidebarOverlayBackground.isHidden = true
+case .overlay:
+    backgroundEffectView.isHidden = false
+    sidebarOverlayBackground.isHidden = false
+```
+
+**Pros:** Eliminates compositing overhead entirely when views not needed
+**Cons:** None — `isHidden` is the correct mechanism
+**Effort:** Small
+**Risk:** Low
+
+## Technical Details
+
+**Affected files:**
+- `macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift`
+
+## Acceptance Criteria
+
+- [ ] `backgroundEffectView.isHidden = true` in `.closed` mode
+- [ ] `sidebarOverlayBackground.isHidden = true` in `.pinned` and `.closed` modes
+- [ ] Visual appearance unchanged in all three modes
+- [ ] Reduced GPU compositing in Activity Monitor during closed mode
+
+## Work Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-02-26 | Identified by Performance Oracle | P1 performance finding |

--- a/todos/011-complete-p2-harden-sidebarmode-deserialization.md
+++ b/todos/011-complete-p2-harden-sidebarmode-deserialization.md
@@ -1,0 +1,54 @@
+---
+status: complete
+priority: p2
+issue_id: "011"
+tags: [code-review, security, persistence, data-loss]
+dependencies: []
+---
+
+# Out-of-Range SidebarMode Raw Value Wipes All Workspace State
+
+## Problem Statement
+
+If `workspace.json` contains `"sidebarMode": 99` (invalid raw value), Swift's synthesized `Codable` throws a `DecodingError`. This is caught by `load()`'s `catch is DecodingError` handler which backs up the file and starts fresh — wiping all projects, sessions, and templates. Losing all user data because one enum value is invalid is disproportionate.
+
+## Findings
+
+- **Security Sentinel**: Flagged as LOW severity but with disproportionate data loss impact
+
+## Proposed Solutions
+
+### Option A: Decode as raw Int then safe-construct (Recommended)
+
+```swift
+if let rawMode = try container.decodeIfPresent(Int.self, forKey: .sidebarMode),
+   let mode = SidebarMode(rawValue: rawMode) {
+    self.sidebarMode = mode
+} else if let visible = try container.decodeIfPresent(Bool.self, forKey: .sidebarVisible) {
+    self.sidebarMode = visible ? .pinned : .closed
+} else {
+    self.sidebarMode = .pinned
+}
+```
+
+**Pros:** Unknown values gracefully fall through to default; no state wipe
+**Cons:** Slightly more verbose
+**Effort:** Small
+**Risk:** Low
+
+## Technical Details
+
+**Affected files:**
+- `macos/Sources/Features/Ghostties/WorkspacePersistence.swift` (lines 70-76)
+
+## Acceptance Criteria
+
+- [ ] JSON with `"sidebarMode": 99` loads without wiping state (defaults to `.pinned`)
+- [ ] Valid `sidebarMode` values still decode correctly
+- [ ] Legacy `sidebarVisible` fallback still works
+
+## Work Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-02-26 | Identified by Security Sentinel | Data safety finding |

--- a/todos/012-complete-p3-simplify-mouse-handlers.md
+++ b/todos/012-complete-p3-simplify-mouse-handlers.md
@@ -1,0 +1,63 @@
+---
+status: complete
+priority: p3
+issue_id: "012"
+tags: [code-review, simplicity, code-quality]
+dependencies: []
+---
+
+# Simplify Mouse Handlers and Remove Stringly-Typed Zone userInfo
+
+## Problem Statement
+
+`mouseEntered`/`mouseExited` use `userInfo["zone"]` string matching to identify which tracking area fired. Since only one tracking area is active at a time, the zone is already known from `sidebarMode`. The zone check is redundant and the string literals are fragile. Additionally, `.removeDuplicates()` is missing from the Combine pipeline, and overlay shadow config values are re-set every transition.
+
+## Findings
+
+- **Code Simplicity**: ~21 LOC reduction identified
+- **Pattern Recognition**: Recommended `event.trackingArea === activeTrackingArea` or just checking `sidebarMode`
+- **Performance Oracle**: Recommended `.removeDuplicates()` on Combine pipeline and caching titlebar text field
+
+## Proposed Solutions
+
+### Batch of minor simplifications:
+
+1. **Mouse handlers** — drop userInfo, just check `sidebarMode`:
+   ```swift
+   override func mouseEntered(with event: NSEvent) {
+       if sidebarMode == .closed { transitionTo(.overlay) }
+   }
+   override func mouseExited(with event: NSEvent) {
+       if sidebarMode == .overlay { transitionTo(.closed) }
+   }
+   ```
+   Drop `userInfo` from NSTrackingArea constructors. (~8 lines saved)
+
+2. **Move overlay shadow radius/offset to setup()** (~2 lines saved)
+
+3. **Simplify initial constraint activation** to 2 lines (~5 lines saved)
+
+4. **Replace overlayBackgroundWidthConstraint** with trailing-to-sidebar constraint (~6 lines, 1 property saved)
+
+5. **Add `.removeDuplicates()`** to Combine pipeline (1 line)
+
+6. **Cache titlebar text field** reference (avoid recursive traversal on title changes)
+
+**Total: ~21 LOC reduction, 1 fewer stored property**
+
+## Technical Details
+
+**Affected files:**
+- `macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift`
+
+## Acceptance Criteria
+
+- [ ] Mouse handlers use `sidebarMode` check only, no string matching
+- [ ] Overlay shadow radius/offset set once in setup()
+- [ ] No behavioral changes to any sidebar state
+
+## Work Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-02-26 | Identified by Code Simplicity + Pattern Recognition + Performance Oracle | Cleanup items |

--- a/todos/013-complete-p2-protect-sidebarmode-write-access.md
+++ b/todos/013-complete-p2-protect-sidebarmode-write-access.md
@@ -1,0 +1,65 @@
+---
+status: complete
+priority: p2
+issue_id: "013"
+tags: [code-review, architecture, state-management]
+dependencies: []
+---
+
+# Protect sidebarMode Write Access on WorkspaceStore
+
+## Problem Statement
+
+`WorkspaceStore.sidebarMode` is a public `var` with a `didSet` that triggers persistence. Any code could write `WorkspaceStore.shared.sidebarMode = .closed` and persist the change without updating the UI in `WorkspaceViewContainer`. The intended data flow is unidirectional: only `transitionTo()` in the view container should write to the store.
+
+This is safe today (only `transitionTo()` writes) but fragile — a future contributor could easily bypass the view container and create a UI/persistence desync.
+
+## Findings
+
+- **Architecture Strategist**: Identified dual-write risk between `WorkspaceViewContainer.sidebarMode` (local) and `WorkspaceStore.shared.sidebarMode` (global). No reactive sync from store → container.
+- **Pattern Recognition**: Noted `sidebarMode` is intentionally not `@Published` but this asymmetry is undocumented.
+
+## Proposed Solutions
+
+### Option A: `private(set)` + explicit method (Recommended)
+
+In `WorkspaceStore.swift`:
+
+```swift
+private(set) var sidebarMode: SidebarMode = .pinned {
+    didSet { if oldValue != sidebarMode { persist() } }
+}
+
+/// Called by WorkspaceViewContainer after state transitions.
+func updateSidebarMode(_ mode: SidebarMode) {
+    sidebarMode = mode
+}
+```
+
+Update `WorkspaceViewContainer.transitionTo()` to call `WorkspaceStore.shared.updateSidebarMode(newMode)`.
+
+- **Effort**: Small
+- **Risk**: None
+- **Pros**: Locks in unidirectional flow, compiler enforces it
+- **Cons**: One extra method
+
+### Option B: Add doc comment only
+
+Add a comment on `sidebarMode` explaining the ownership contract. No compiler enforcement.
+
+- **Effort**: Trivial
+- **Risk**: None
+- **Pros**: Zero code change
+- **Cons**: Comment-only protection, easily violated
+
+## Acceptance Criteria
+
+- [ ] External code cannot directly set `WorkspaceStore.shared.sidebarMode`
+- [ ] `transitionTo()` still persists mode changes
+- [ ] Build succeeds
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-27 | Created from code review | Architecture strategist + pattern recognition flagged |

--- a/todos/014-complete-p2-scope-background-effect-view.md
+++ b/todos/014-complete-p2-scope-background-effect-view.md
@@ -1,0 +1,49 @@
+---
+status: complete
+priority: p2
+issue_id: "014"
+tags: [code-review, performance, compositing]
+dependencies: []
+---
+
+# Scope backgroundEffectView to Sidebar Width
+
+## Problem Statement
+
+`backgroundEffectView` is constrained to all four edges of the superview (full window). In pinned mode, `NSVisualEffectView` with `.behindWindow` blending composites the entire window through WindowServer, even though only the sidebar strip is visible — the terminal container is opaque and drawn on top. This is a wasted full-window vibrancy pass.
+
+## Findings
+
+- **Architecture Strategist**: Identified the full-window constraint as unnecessary compositing overhead.
+- **Performance Oracle**: Confirmed `isHidden = true` in closed mode correctly removes from compositing tree, but pinned mode still composites the full width.
+
+## Proposed Solutions
+
+### Constrain trailing edge to sidebar (Recommended)
+
+In `WorkspaceViewContainer.setup()`, change:
+
+```swift
+// Before:
+backgroundEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+// After:
+backgroundEffectView.trailingAnchor.constraint(equalTo: sidebarHostingView.trailingAnchor),
+```
+
+- **Effort**: Trivial (one line)
+- **Risk**: Low — verify visually that sidebar material still looks correct at the edge
+- **Pros**: Eliminates unnecessary vibrancy compositing behind the terminal
+- **Cons**: None expected
+
+## Acceptance Criteria
+
+- [ ] `backgroundEffectView` only covers the sidebar region
+- [ ] Sidebar material appearance unchanged visually
+- [ ] No compositing artifacts at the sidebar/terminal boundary
+- [ ] Build succeeds
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-27 | Created from code review | Architecture + performance flagged |

--- a/todos/015-complete-p2-thread-safe-resolved-paths-cache.md
+++ b/todos/015-complete-p2-thread-safe-resolved-paths-cache.md
@@ -1,0 +1,66 @@
+---
+status: complete
+priority: p2
+issue_id: "015"
+tags: [code-review, security, concurrency]
+dependencies: []
+---
+
+# Thread-Safe resolvedPaths Cache in SessionCoordinator
+
+## Problem Statement
+
+`SessionCoordinator` has a `nonisolated(unsafe) private static var resolvedPaths: [String: String]` dictionary that is read/written from `resolveCommand()`, which runs in `Task.detached`. Two windows creating sessions simultaneously could race on this dictionary, causing undefined behavior (potential crash).
+
+**Note**: This predates the current branch but is exercised by the new session creation flows.
+
+## Findings
+
+- **Security Sentinel**: Rated MEDIUM — technically a data race on concurrent Dictionary mutation. Practical risk is low (users rarely create two sessions at the exact same instant) but it's undefined behavior.
+
+## Proposed Solutions
+
+### Option A: NSLock wrapper (Recommended)
+
+```swift
+private static let resolvedPathsLock = NSLock()
+private static var _resolvedPaths: [String: String] = [:]
+
+nonisolated private static func cachedPath(for command: String) -> String? {
+    resolvedPathsLock.lock()
+    defer { resolvedPathsLock.unlock() }
+    return _resolvedPaths[command]
+}
+
+nonisolated private static func cachePath(_ resolved: String, for command: String) {
+    resolvedPathsLock.lock()
+    defer { resolvedPathsLock.unlock() }
+    _resolvedPaths[command] = resolved
+}
+```
+
+- **Effort**: Small
+- **Risk**: None
+- **Pros**: Eliminates undefined behavior, minimal overhead
+- **Cons**: Slightly more code
+
+### Option B: Actor isolation
+
+Move the cache into a dedicated actor. Cleaner but requires `await` at call sites.
+
+- **Effort**: Medium
+- **Risk**: Low
+- **Pros**: Swift-native concurrency safety
+- **Cons**: Requires async refactor of `resolveCommand`
+
+## Acceptance Criteria
+
+- [ ] No `nonisolated(unsafe)` on the paths dictionary
+- [ ] Concurrent access is synchronized
+- [ ] Build succeeds
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-27 | Created from code review | Security sentinel flagged pre-existing issue |

--- a/todos/016-complete-p3-overlay-transition-debounce.md
+++ b/todos/016-complete-p3-overlay-transition-debounce.md
@@ -1,0 +1,50 @@
+---
+status: complete
+priority: p3
+issue_id: "016"
+tags: [code-review, architecture, ux]
+dependencies: []
+---
+
+# Add Transition Debounce to Prevent Overlay Oscillation
+
+## Problem Statement
+
+When the mouse exits the overlay tracking area, `mouseExited` fires `transitionTo(.closed)`, which starts a 0.2s animation and calls `updateTrackingAreas()`. The new closed-mode tracking area is a 10pt strip. If the user's mouse is still within those 10pt during the animation, `mouseEntered` can fire immediately, causing rapid closed→overlay→closed oscillation.
+
+## Findings
+
+- **Architecture Strategist**: Identified the race between animation completion and tracking area activation.
+
+## Proposed Solutions
+
+### Timestamp guard in transitionTo()
+
+```swift
+private var lastTransitionTime: CFTimeInterval = 0
+
+private func transitionTo(_ newMode: SidebarMode) {
+    guard newMode != sidebarMode else { return }
+    let now = CACurrentMediaTime()
+    guard now - lastTransitionTime > 0.25 else { return }
+    lastTransitionTime = now
+    // ... rest of method
+}
+```
+
+- **Effort**: Trivial
+- **Risk**: None — 0.25s debounce is imperceptible for intentional gestures
+- **Pros**: Prevents visual flickering
+- **Cons**: Adds a small delay to legitimate rapid toggles (unlikely use case)
+
+## Acceptance Criteria
+
+- [ ] Rapid mouse movement near sidebar edge does not cause oscillation
+- [ ] Normal hover-to-reveal still works smoothly
+- [ ] Build succeeds
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-27 | Created from code review | Architecture strategist flagged |

--- a/todos/017-complete-p3-overlay-encode-guard.md
+++ b/todos/017-complete-p3-overlay-encode-guard.md
@@ -1,0 +1,41 @@
+---
+status: complete
+priority: p3
+issue_id: "017"
+tags: [code-review, security, persistence]
+dependencies: []
+---
+
+# Double-Layer Overlay Guard in State.encode(to:)
+
+## Problem Statement
+
+The overlay→closed mapping for persistence exists in `WorkspaceStore.persist()` but not in `State.encode(to:)`. If someone constructs a `State` directly with `.overlay` and encodes it (bypassing WorkspaceStore), the transient `.overlay` mode would reach disk. On next launch, the app would start in overlay mode with no way to dismiss.
+
+## Findings
+
+- **Security Sentinel**: Recommended defense-in-depth — enforce the invariant at the encoding layer too.
+
+## Proposed Solutions
+
+In `WorkspacePersistence.State.encode(to:)`:
+
+```swift
+let persistedMode = sidebarMode == .overlay ? SidebarMode.closed : sidebarMode
+try container.encode(persistedMode, forKey: .sidebarMode)
+```
+
+- **Effort**: Trivial (one line)
+- **Risk**: None
+
+## Acceptance Criteria
+
+- [ ] `State` with `.overlay` encodes as `.closed`
+- [ ] Add unit test verifying the encoding guard
+- [ ] Build succeeds
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-27 | Created from code review | Security sentinel flagged |

--- a/todos/018-complete-p3-test-overlay-persistence-roundtrip.md
+++ b/todos/018-complete-p3-test-overlay-persistence-roundtrip.md
@@ -1,0 +1,44 @@
+---
+status: complete
+priority: p3
+issue_id: "018"
+tags: [code-review, testing, persistence]
+dependencies: ["017"]
+---
+
+# Add Test for Overlay-to-Closed Persistence Round-Trip
+
+## Problem Statement
+
+There is no test verifying that the overlay→closed persistence conversion works correctly. The logic exists in `WorkspaceStore.persist()` but lacks test coverage.
+
+## Findings
+
+- **Pattern Recognition**: Identified gap in persistence test coverage — all other migration paths are tested but overlay persistence is not.
+
+## Proposed Solutions
+
+Add to `WorkspacePersistenceTests.swift`:
+
+```swift
+@Test func encodingOverlayModePersistsAsClosed() throws {
+    let state = WorkspacePersistence.State(sidebarMode: .overlay)
+    let data = try JSONEncoder().encode(state)
+    let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
+    #expect(decoded.sidebarMode == .closed)
+}
+```
+
+- **Effort**: Trivial
+- **Risk**: None
+
+## Acceptance Criteria
+
+- [ ] Test encodes a State with `.overlay` and verifies it decodes as `.closed`
+- [ ] Tests pass in Xcode (Cmd+U)
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-27 | Created from code review | Pattern recognition flagged test gap |


### PR DESCRIPTION
## Summary

- **3-state sidebar machine** (pinned / closed / overlay) with mouse-hover tracking for auto-show/hide
- **Floating terminal card** with continuous corner rounding and drop shadow
- **Session title bar** (28pt) matching terminal background color
- Ghost characters, pixel chevrons, and design parity polish
- Safe area fix, titlebar nib fix, accessibility improvements
- Code review fixes and session documentation

## Commits (15)

Preserves full branch history via merge commit.

## Test plan

- [x] Build passes (`zig build run -Doptimize=ReleaseFast`)
- [x] Sidebar transitions between pinned ↔ closed ↔ overlay states
- [x] Floating card renders with shadow and rounded corners
- [x] Title bar shows session label at correct height
- [x] No regressions in standard terminal usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)