### PR TITLE
fix(ci): skip GhosttyUITests target in xcodebuild test

### DIFF
--- a/.github/workflows/test-ghostties.yml
+++ b/.github/workflows/test-ghostties.yml
@@ -124,6 +124,9 @@ jobs:
       # Scope to the task-layer tests added in feat/automated-testing-v0.
       # The rest of the GhosttyTests bundle covers legacy + upstream fixtures
       # we do not gate CI on here.
+      # Skip GhosttyUITests entirely — the XCUITest runner hangs ~6 min on CI
+      # runners (no screen-recording permission / test-user setup required for
+      # UI automation). UI tests remain IDE-runnable via Cmd+U locally.
       - name: Build + test Ghostties
         working-directory: macos
         run: |
@@ -136,5 +139,6 @@ jobs:
             ARCHS=arm64 \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \
+            -skip-testing:GhosttyUITests \
             -only-testing:GhosttyTests/TaskModelTests \
             -only-testing:GhosttyTests/TaskFileWatcherTests


### PR DESCRIPTION
## Summary

- Adds `-skip-testing:GhosttyUITests` to the `xcodebuild test` invocation in `.github/workflows/test-ghostties.yml`.
- The XCUITest runner hangs ~6 minutes on GitHub Actions `macos-latest` before timing out — CI runners lack the screen-recording permission / test-user session that UI automation requires.
- Unit tests (`TaskModelTests`, `TaskFileWatcherTests`) already run fine; only the UI bundle is being excluded.

## Why

This is the final layer blocking the fork's first-ever green CI run. Four prior layers have been peeled (Debug `TEST_HOST`, Zig xcframework build, CEF download, xargs long-path). CI run [24874190054](https://github.com/SeanSmithDesign/ghostties/actions/runs/24874190054) failed at `xcodebuild test` with the UI runner hang — this PR is the surgical fix.

Green CI is the gate before tagging `v0.1.0-beta.1`.

## Invariants preserved

- `ONLY_ACTIVE_ARCH=YES ARCHS=arm64` (GhosttyKit.xcframework is arm64-only)
- `-scheme Ghostties`
- `-destination 'platform=macOS'`
- Existing `-only-testing` scoping to TaskModel + TaskFileWatcher tests

## Local testing

UI tests remain fully runnable from Xcode via Cmd+U — this change is CI-only.

## Test plan

- [ ] CI run on this PR completes the `macos-app` job without the UI runner hang
- [ ] `GhosttyTests/TaskModelTests` + `GhosttyTests/TaskFileWatcherTests` still execute and pass
- [ ] `swift-package` job remains green

Do not merge until CI verifies green.