### PR TITLE
feat(sidebar): re-order zones to brief order (Inbox · Backlog · Running · Needs · Review · Graveyard)

### DIFF
--- a/macos/Sources/Features/Ghostties/TaskSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/TaskSidebarView.swift
@@ -20,26 +20,35 @@ struct TaskSidebarView: View {
         VStack(spacing: 0) {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    // Inbox is source-based (Phase 5: external MCP arrivals).
-                    // Hides itself entirely when empty — most days it will not
-                    // render at all, so we only emit the trailing divider when
-                    // it has rows. Order is provisional: a follow-up pass will
-                    // re-shuffle the other zones to match the brief's full
-                    // lane order (Inbox · Backlog · Running · Needs you ·
-                    // Review · Graveyard).
+                    // Zone order follows the brief's locked lane order:
+                    // Inbox · Backlog · Running · Needs you · Review · Graveyard.
+                    //
+                    // Only four of the six lanes have a dedicated top-level
+                    // zone view today — Backlog and Review currently live as
+                    // sub-lanes inside the Graveyard (ArchiveZoneView) and are
+                    // not rendered as standalone zones. The order below is the
+                    // brief's order with those two skipped:
+                    //
+                    //   Inbox (source-based) → Running (Active) →
+                    //   Needs you → Graveyard (which internally holds
+                    //   Backlog · Review · Done).
+                    //
+                    // Inbox hides itself entirely when empty — most days it
+                    // will not render at all, so we only emit the trailing
+                    // divider when it has rows.
                     if !taskStore.externalInbox.isEmpty {
                         InboxZoneView(taskStore: taskStore)
                         zoneDivider
                     }
 
-                    NeedsYouZoneView(taskStore: taskStore)
-
-                    zoneDivider
-
                     ActiveZoneView(
                         taskStore: taskStore,
                         sessionDraftStore: sessionDraftStore
                     )
+
+                    zoneDivider
+
+                    NeedsYouZoneView(taskStore: taskStore)
 
                     zoneDivider
 


### PR DESCRIPTION
## Summary

Re-orders the top-level zone stack in `TaskSidebarView` to match the locked lane order from the sidebar task-view brief. Ordering-only change — no zone internals or behavior were touched.

### Order change

| | Order |
|-|-|
| Before | Inbox · Needs you · Running · Graveyard |
| After  | Inbox · Running · Needs you · Graveyard |

Brief canonical order (for reference):

    Inbox · Backlog · Running · Needs you · Review · Graveyard

### Lanes skipped (no backing top-level view yet)

Per the orchestrator instructions — match brief ordering for zones that exist; do not invent new zones. The following brief lanes have no dedicated top-level zone view in the v0 Concept F build and are therefore not placed at the top level:

- **Backlog** — currently rendered as a sub-lane inside the Graveyard (`ArchiveZoneView` → `lane(.backlog, …)`).
- **Review** — currently rendered as a sub-lane inside the Graveyard (`ArchiveZoneView` → `lane(.review, …)`).

Both are still user-visible inside the Graveyard's collapsible lane headers. A later pass can promote them to full top-level zones if/when that's desired — this PR intentionally doesn't scope-creep into that.

### Status mapping confirmed

- Graveyard → contains tasks whose `TaskStatus` raw value is `done` (never the string `"graveyard"` — Fragile Area #15 is respected; that's a UI-layer name only).
- Running → `TaskStatus.running` (exposed as `taskStore.active`).
- Needs you → `TaskStatus.needsYou` (raw `needs-you`).
- Inbox (top-level zone) → source-based `taskStore.externalInbox`; hides entirely when empty.

### Files changed

- `macos/Sources/Features/Ghostties/TaskSidebarView.swift` — VStack composition only.

## Test plan

- [x] `xcodebuild … build` passes (`ONLY_ACTIVE_ARCH=YES ARCHS=arm64` per Fragile Area #4) — ** BUILD SUCCEEDED **
- [x] `xcodebuild … -skip-testing:GhosttyUITests test` passes — ** TEST SUCCEEDED ** (TaskFileWatcher, TaskStore, SplitTree, WorkspaceStoreFreeze, TerminalViewContainer, TransferablePasteboard suites all green)
- [ ] **Visual check pending** — Sean to eyeball the new order next time at the machine. This is an ordering-only change so no regressions to zone internals, spacing, empty states, or per-row behavior are expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)