### PR TITLE
fix(macos): bundle Resources/ via synchronized folder group

### DIFF
--- a/macos/Ghostties.xcodeproj/project.pbxproj
+++ b/macos/Ghostties.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A586167C2B7703CC009BDB1D /* fish in Resources */ = {isa = PBXBuildFile; fileRef = A586167B2B7703CC009BDB1D /* fish */; };
 		A5985CE62C33060F00C57AD3 /* man in Resources */ = {isa = PBXBuildFile; fileRef = A5985CE52C33060F00C57AD3 /* man */; };
 		A5A1F8852A489D6800D1E8BC /* terminfo in Resources */ = {isa = PBXBuildFile; fileRef = A5A1F8842A489D6800D1E8BC /* terminfo */; };
+		B0E55A022F80000000000002 /* presets in Resources */ = {isa = PBXBuildFile; fileRef = B0E55A012F80000000000001 /* presets */; };
 		A5B30539299BEAAB0047F10C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5B30538299BEAAB0047F10C /* Assets.xcassets */; };
 		AA1BFC302B30F1B800E92F16 /* GhosttiesMCPClient in Frameworks */ = {isa = PBXBuildFile; productRef = AA1BFC312B30F1B800E92F16 /* GhosttiesMCPClient */; };
 		AA1BFC322B30F1B800E92F16 /* GhosttiesCore in Frameworks */ = {isa = PBXBuildFile; productRef = AA1BFC332B30F1B800E92F16 /* GhosttiesCore */; };
@@ -92,6 +93,7 @@
 		A586167B2B7703CC009BDB1D /* fish */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fish; path = "../zig-out/share/fish"; sourceTree = "<group>"; };
 		A5985CE52C33060F00C57AD3 /* man */ = {isa = PBXFileReference; lastKnownFileType = folder; name = man; path = "../zig-out/share/man"; sourceTree = "<group>"; };
 		A5A1F8842A489D6800D1E8BC /* terminfo */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminfo; path = "../zig-out/share/terminfo"; sourceTree = "<group>"; };
+		B0E55A012F80000000000001 /* presets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = presets; path = Resources/presets; sourceTree = "<group>"; };
 		A5B30531299BEAAA0047F10C /* Ghostties Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Ghostties Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5B30538299BEAAB0047F10C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A5B3053D299BEAAB0047F10C /* Ghostties.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ghostties.entitlements; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 			isa = PBXGroup;
 			children = (
 				B0A55ABD2F72F4C100018CBF /* Presets */,
+				B0E55A012F80000000000001 /* presets */,
 				FC9ABA9B2D0F538D0020D4C8 /* bash-completion */,
 				29C15B1C2CDC3B2000520DD4 /* bat */,
 				A586167B2B7703CC009BDB1D /* fish */,
@@ -622,6 +625,7 @@
 				552964E62B34A9B400030505 /* vim in Resources */,
 				FC5218FA2D10FFCE004C93E0 /* zsh in Resources */,
 				A5B30539299BEAAB0047F10C /* Assets.xcassets in Resources */,
+				B0E55A022F80000000000002 /* presets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Problem

The Phase 5 streamlined wave shipped the first agent-driven source integration — `macos/Resources/presets/linear-sync/` containing `system.md`, `mcp-servers.json`, `defaults.json`, and `README.md`. The files existed on disk, but `macos/Ghostties.xcodeproj/project.pbxproj` never referenced them, so none of them made it into the built `.app`. `Bundle.main` could not find them at runtime, and the whole two-sided MCP pivot was effectively dark.

This is the blocker noted as Fragile Area #18 and in the current `SESSION_NOTES.md` as "pending before v0.1.0-beta.1 tag".

## Approach

Evaluated two options:

- **Option A** — Convert the existing `Resources` `PBXGroup` into a `PBXFileSystemSynchronizedRootGroup` (same pattern `macos/Sources/Features/Ghostties/` uses).
- **Option B** — Add a single folder reference for `macos/Resources/presets/` to the app's Resources build phase.

Picked **Option B**.

The current `Resources` `PBXGroup` is a logical collection of heterogeneous paths — most of its children live *outside* `macos/Resources/` on disk (folder references into `../zig-out/share/*` for terminfo, vim, nvim, fish, zsh, bash-completion, man, locale, ghostty; `Assets.xcassets` at `macos/Assets.xcassets`; `macos/Presets/*.md`). Converting it to a synchronized root group would require untangling those paths and was higher blast radius than the problem warranted. A single folder reference for `macos/Resources/presets/` covers the current need and is future-proof: any new preset directory dropped into `macos/Resources/presets/` is bundled automatically without another pbxproj edit.

## Change

Three additions to `macos/Ghostties.xcodeproj/project.pbxproj`:

1. `PBXFileReference` for the `presets` folder (`path = Resources/presets`, `lastKnownFileType = folder`).
2. `PBXBuildFile` wrapping it.
3. Added the build file to the Ghostties app's `PBXResourcesBuildPhase` and the file reference as a child of the existing `Resources` `PBXGroup`.

Total: 4 inserted lines, 0 deletions.

## Verification

Ran from the worktree root:

```
xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Debug \
  -destination 'platform=macOS' ONLY_ACTIVE_ARCH=YES ARCHS=arm64 build
```

Result: `** BUILD SUCCEEDED **`.

Then inspected the built `.app`:

- All 4 linear-sync files present under `Contents/Resources/presets/linear-sync/`:
  - `defaults.json`, `mcp-servers.json`, `README.md`, `system.md`
- No regression — spot-checked:
  - `Contents/Resources/terminfo/78/xterm-ghostty` sentinel still bundled.
  - All 6 `macos/Presets/*.md` files (architect, code-reviewer, debugger, orchestrator, pair-programmer, test-writer) still bundled.

## Test plan

- [ ] Open the Dev app, confirm `Bundle.main.url(forResource: "system", withExtension: "md", subdirectory: "presets/linear-sync")` returns a valid URL (or equivalent lookup when the Swift consumer lands).
- [ ] End-to-end live Linear sync smoke test using `Contents/Resources/presets/linear-sync/system.md` as the Claude `--append-system-prompt-file`.

Fixes Fragile Area #18. Unblocks v0.1.0-beta.1 tag gating.