### PR TITLE
fix(scripts): build-cef-wrapper avoids .o.o double extension

### DIFF
--- a/scripts/build-cef-wrapper.sh
+++ b/scripts/build-cef-wrapper.sh
@@ -63,8 +63,11 @@ compile_one() {
     local obj_dir="${WRAPPER_OBJ_DIR}"
     local cef_dir="${CEF_DIR}"
     local rel="${src#${cef_dir}/libcef_dll/}"
-    local obj="${obj_dir}/${rel%.cc}.o"
-    obj="${obj%.mm}.o"
+    # Strip any extension (.cc or .mm) and append .o exactly once.
+    # The prior two-step strip+append produced .o.o on files that didn't
+    # match the first pattern, and the odd-length member names broke
+    # 8-byte alignment inside libcef_dll_wrapper.a on some `ar` versions.
+    local obj="${obj_dir}/${rel%.*}.o"
     mkdir -p "$(dirname "${obj}")"
     clang++ -std=c++20 -arch arm64 -O2 \
         -mmacosx-version-min=13.0 \


### PR DESCRIPTION
## Summary

- `scripts/build-cef-wrapper.sh` produced object files named \`foo.o.o\` for \`.cc\` sources (and \`.mm.o.o\` for \`.mm\` sources).
- Odd-length archive member names broke 8-byte alignment inside \`libcef_dll_wrapper.a\` on some \`ar\` versions.
- Surfaced as an Xcode build error: \`64-bit mach-o member 'shutdown_checker.o.o' not 8-byte aligned in '.../vendor/cef-build/libcef_dll_wrapper.a'\`.

## Fix

Strip any trailing extension (\`.cc\` or \`.mm\`) in one step with \`\${rel%.*}\`, then append \`.o\` once. Object file names are now canonical.

## Test plan

- [ ] Clean the stale archive: \`rm vendor/cef-build/libcef_dll_wrapper.a\` (and any \`.o.o\` files under \`vendor/cef-build/obj/\`) — already done locally
- [ ] Xcode build → confirm \`** BUILD SUCCEEDED **\` and \`shutdown_checker.o\` (single \`.o\`) appears in the new archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)