### PR TITLE
chore: sweep cosmetic warnings + silence vendored CEF noise

### DIFF
--- a/macos/GhosttyUITests/TaskSidebarSmokeUITests.swift
+++ b/macos/GhosttyUITests/TaskSidebarSmokeUITests.swift
@@ -24,7 +24,7 @@ import XCTest
 /// To run locally from Xcode: ⌘U on the Ghostties scheme, or right-click the
 /// test method in the gutter.
 final class TaskSidebarSmokeUITests: XCTestCase {
-    override class var defaultTestSuite: XCTestSuite {
+    override static var defaultTestSuite: XCTestSuite {
         // Same guard `GhosttyCustomConfigCase` uses: Xcode IDE launches set
         // IDE_DISABLED_OS_ACTIVITY_DT_MODE, CLI-driven xcodebuild invocations
         // do not. See https://lldb.llvm.org/cpp_reference/PlatformDarwin_8cpp_source.html

--- a/macos/Sources/Features/Ghostties/ArchiveZoneView.swift
+++ b/macos/Sources/Features/Ghostties/ArchiveZoneView.swift
@@ -29,10 +29,10 @@ struct ArchiveZoneView: View {
             if isFullyEmpty {
                 emptyState
             } else {
-                lane(.inbox,   label: "Inbox",   tasks: taskStore.inbox,   rollup: .terracotta)
+                lane(.inbox, label: "Inbox", tasks: taskStore.inbox, rollup: .terracotta)
                 lane(.backlog, label: "Backlog", tasks: taskStore.backlog, rollup: .none)
-                lane(.review,  label: "Review",  tasks: taskStore.review,  rollup: .none)
-                lane(.done,    label: "Done",    tasks: taskStore.done,    rollup: .none)
+                lane(.review, label: "Review", tasks: taskStore.review, rollup: .none)
+                lane(.done, label: "Done", tasks: taskStore.done, rollup: .none)
             }
         }
         .padding(.vertical, 4)
@@ -78,7 +78,7 @@ struct ArchiveZoneView: View {
     ) -> some View {
         let isExpanded = expanded.contains(status)
         return VStack(alignment: .leading, spacing: 0) {
-            Button(action: { toggle(status) }) {
+            Button(action: { toggle(status) }, label: {
                 HStack(spacing: 8) {
                     Text(isExpanded ? "▾" : "▸")
                         .font(.system(size: 10, design: .monospaced))
@@ -104,7 +104,7 @@ struct ArchiveZoneView: View {
                 .padding(.horizontal, TaskRowMetrics.horizontalPadding)
                 .frame(height: 32)
                 .contentShape(Rectangle())
-            }
+            })
             .buttonStyle(.plain)
 
             if isExpanded, !tasks.isEmpty {

--- a/macos/Sources/Features/Ghostties/MenuBar/MenuBarDropdownView.swift
+++ b/macos/Sources/Features/Ghostties/MenuBar/MenuBarDropdownView.swift
@@ -70,7 +70,7 @@ struct MenuBarDropdownView: View {
         let state = store.globalIndicatorStates[session.id] ?? .inactive
         let templateName = store.templates.first(where: { $0.id == session.templateId })?.name
 
-        Button(action: { focusSession(session.id) }) {
+        Button(action: { focusSession(session.id) }, label: {
             HStack(spacing: 8) {
                 // Status dot.
                 Circle()
@@ -95,7 +95,7 @@ struct MenuBarDropdownView: View {
             .padding(.vertical, 4)
             .padding(.horizontal, 6)
             .contentShape(Rectangle())
-        }
+        })
         .buttonStyle(.plain)
         .background(
             RoundedRectangle(cornerRadius: 4)

--- a/macos/Sources/Features/Ghostties/Models/AgentTemplate.swift
+++ b/macos/Sources/Features/Ghostties/Models/AgentTemplate.swift
@@ -59,14 +59,14 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     ///
     /// All fields are optional — a minimal agent template needs only a command.
     struct AgentConfig: Codable, Hashable {
-        var systemPromptFile: String? = nil
+        var systemPromptFile: String?
         /// Inline system prompt content (used by presets instead of a file reference).
-        var systemPrompt: String? = nil
-        var model: String? = nil
-        var permissionMode: String? = nil
-        var effort: String? = nil
-        var allowedTools: [String]? = nil
-        var additionalFlags: [String]? = nil
+        var systemPrompt: String?
+        var model: String?
+        var permissionMode: String?
+        var effort: String?
+        var allowedTools: [String]?
+        var additionalFlags: [String]?
     }
 
     // MARK: - Initializer

--- a/macos/Sources/Features/Ghostties/PixelChevronView.swift
+++ b/macos/Sources/Features/Ghostties/PixelChevronView.swift
@@ -9,14 +9,22 @@ struct PixelChevronView: View {
     var color: Color = Color(.tertiaryLabelColor)
     var isExpanded: Bool = false
 
+    /// A single pixel rectangle on the chevron grid.
+    private struct Pixel {
+        let x: Int
+        let y: Int
+        let w: Int
+        let h: Int
+    }
+
     /// 7×5 pixel grid defining the chevron shape (points downward).
     /// Rotated -90° (270°) to point right when collapsed.
-    private static let grid: [(x: Int, y: Int, w: Int, h: Int)] = [
-        (0, 0, 1, 1), (6, 0, 1, 1),
-        (0, 1, 2, 1), (5, 1, 2, 1),
-        (1, 2, 2, 1), (4, 2, 2, 1),
-        (2, 3, 3, 1),
-        (3, 4, 1, 1),
+    private static let grid: [Pixel] = [
+        Pixel(x: 0, y: 0, w: 1, h: 1), Pixel(x: 6, y: 0, w: 1, h: 1),
+        Pixel(x: 0, y: 1, w: 2, h: 1), Pixel(x: 5, y: 1, w: 2, h: 1),
+        Pixel(x: 1, y: 2, w: 2, h: 1), Pixel(x: 4, y: 2, w: 2, h: 1),
+        Pixel(x: 2, y: 3, w: 3, h: 1),
+        Pixel(x: 3, y: 4, w: 1, h: 1),
     ]
 
     var body: some View {

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -838,8 +838,7 @@ final class SessionCoordinator: ObservableObject {
                 // current with real terminal output. The store handles the
                 // active-vs-idle indicator-state check internally.
                 if let projectId = WorkspaceStore.shared.sessions
-                    .first(where: { $0.id == sessionId })?.projectId
-                {
+                    .first(where: { $0.id == sessionId })?.projectId {
                     WorkspaceStore.shared.recordActivity(
                         sessionId: sessionId,
                         projectId: projectId

--- a/macos/Sources/Features/Ghostties/SessionDetailView.swift
+++ b/macos/Sources/Features/Ghostties/SessionDetailView.swift
@@ -8,11 +8,11 @@ import SwiftUI
 struct SessionRow: View {
     let session: AgentSession
     let indicatorState: SessionIndicatorState
-    var ghostCharacter: GhostCharacter? = nil
+    var ghostCharacter: GhostCharacter?
     var isActive: Bool = false
     var isEditing: Bool = false
     /// Template name shown as a subtle badge when the session was launched with agent config.
-    var agentTemplateName: String? = nil
+    var agentTemplateName: String?
     @Binding var editingName: String
     var isRenameFocused: FocusState<Bool>.Binding
     var onCommitRename: () -> Void

--- a/macos/Sources/Features/Ghostties/TemplatePickerView.swift
+++ b/macos/Sources/Features/Ghostties/TemplatePickerView.swift
@@ -143,7 +143,7 @@ struct TemplatePickerView: View {
     ///   - isPreset: Whether this is a file-based preset (uses preview-or-launch tap behavior).
     @ViewBuilder
     private func templateRow(_ template: AgentTemplate, isPreset: Bool = false) -> some View {
-        Button(action: { isPreset ? handlePresetTap(template) : createSession(from: template) }) {
+        Button(action: { isPreset ? handlePresetTap(template) : createSession(from: template) }, label: {
             HStack(spacing: 8) {
                 Image(systemName: resolvedIcon(for: template))
                     .font(.system(size: 12))
@@ -172,7 +172,7 @@ struct TemplatePickerView: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
             .contentShape(Rectangle())
-        }
+        })
         .buttonStyle(.plain)
         .contextMenu {
             if isPreset {

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -261,7 +261,6 @@ class WorkspaceViewContainer: NSView {
         chromePaletteNSColor.cgColor
     }
 
-
     init<ViewModel: TerminalViewModel>(ghostty: Ghostty.App, viewModel: ViewModel, delegate: (any TerminalViewDelegate)? = nil) {
         self.ghostty = ghostty
         self.terminalContainer = TerminalViewContainer {
@@ -656,7 +655,7 @@ class WorkspaceViewContainer: NSView {
 
         // Embed the active tab's browser view.
         if let activeTabId = manager.activeTabId,
-           let browserView = manager.browserViews[activeTabId] as? NSView {
+           let browserView = manager.browserViews[activeTabId] {
             browserView.translatesAutoresizingMaskIntoConstraints = false
             browserPanelView.contentArea.addSubview(browserView)
             NSLayoutConstraint.activate([

--- a/scripts/build-cef-wrapper.sh
+++ b/scripts/build-cef-wrapper.sh
@@ -74,6 +74,7 @@ compile_one() {
         -I"${cef_dir}" \
         -DWRAPPING_CEF_SHARED \
         -fno-exceptions \
+        -Wno-undefined-var-template -Wno-comma \
         -c "${src}" -o "${obj}"
 }
 export -f compile_one
@@ -89,5 +90,6 @@ printf '%s\n' "${WRAPPER_SOURCES[@]}" | \
 # --- Archive into static library ---
 
 find "${WRAPPER_OBJ_DIR}" -name "*.o" -print0 | xargs -0 ar rcs "${WRAPPER_LIB}"
+ranlib -no_warning_for_no_symbols "${WRAPPER_LIB}"
 
 echo "  libcef_dll_wrapper.a built ($(du -h "${WRAPPER_LIB}" | cut -f1))"


### PR DESCRIPTION
## Summary

Narrow, single-commit cleanup of SwiftLint cosmetic warnings, one real no-op downcast, and CEF vendored warning noise.

- Fixes 10 SwiftLint warning categories across 9 Swift files (trailing-closure form, optional init, comma spacing, large_tuple, opening_brace, vertical_whitespace, static_over_final_class)
- Removes one vestigial `as? NSView` conditional downcast in `WorkspaceViewContainer.swift:659` — the subscript on `[UUID: NSView]` already returns `NSView?`
- Silences CEF vendored warnings by adding `-Wno-undefined-var-template -Wno-comma` to the clang++ invocation in `scripts/build-cef-wrapper.sh` and running `ranlib -no_warning_for_no_symbols` after `ar rcs`

Intentionally skipped: `SessionCoordinator.swift:56` `nonisolated(unsafe)` on `NSLock`. The listed SwiftLint warning is real, but removing the attribute cascades into 6 new Swift 6 MainActor-isolation warnings at every lock acquisition inside the `nonisolated resolveCommand()` method. Deferred with the broader Swift 6 concurrency audit.

Out of scope (explicitly): BrowserSessionBridge / BrowserPanelView / SurfaceView_AppKit Swift 6 actor-isolation warnings, vendored `vendor/cef/` source, pbxproj, Assets, xibs.

## Test plan

- [x] Debug build succeeds with `ONLY_ACTIVE_ARCH=YES ARCHS=arm64`
- [x] All 10 listed SwiftLint warnings no longer appear in build output
- [x] `TaskModelTests` and `TaskFileWatcherTests` pass (13 tests, ~5s total)
- [ ] CI runs