### PR TITLE
fix(ci): unblock xcodebuild test via lazy-init + XCTest gate in main.swift

### DIFF
--- a/.github/workflows/test-ghostties.yml
+++ b/.github/workflows/test-ghostties.yml
@@ -130,25 +130,31 @@ jobs:
       # Xcode CLI will try to build universal and fail on linker misses.
       # (Xcode GUI masks this by defaulting ONLY_ACTIVE_ARCH=YES for Debug.)
       #
-      # Build-only on CI. The full `xcodebuild test` invocation hangs the
-      # XCTest host (`Ghostties Dev.app`) ~6 min before xcodebuild gives up
-      # with "test runner hung before establishing connection". Root cause is
-      # heavy `ghostty_init` / `Ghostty.App(configPath:)` work that runs in
-      # main.swift + AppDelegate property init — _before_ XCTest can load —
-      # in a headless GH Actions runner without a window-server session. The
-      # AppDelegate XCTest guard (skips startup work post-launch) is in place
-      # for the eventual fix; the proper fix is to either lazy-init those or
-      # make the test target not require the app as host. Until then, build-
-      # only here catches build breaks; Sean runs the tests locally with Cmd+U.
-      - name: Build Ghostties (build-only)
+      # The host app (`Ghostties Dev.app`) used to hang ~6 min in headless CI
+      # before XCTest could establish a connection because `ghostty_init` ran
+      # in main.swift and `Ghostty.App(configPath:)` ran in AppDelegate
+      # property init — both before any launch hook could short-circuit. The
+      # fix is in three layers: main.swift skips `ghostty_init` under
+      # XCTest, AppDelegate's `ghostty` / `updateController` are now `lazy`
+      # so they aren't constructed during property init, and the launch hooks
+      # short-circuit when `XCTestConfigurationFilePath` is set. Together
+      # those keep the test host from touching libghostty / Sparkle in a
+      # headless CI runner.
+      #
+      # Test scope is intentionally narrow: only the lightweight test classes
+      # that exercise pure-Swift fixture types. The broader suites need a
+      # window server / additional setup we don't have in headless CI yet.
+      - name: Test Ghostties
         working-directory: macos
         run: |
           set -o pipefail
-          xcodebuild build \
+          xcodebuild test \
             -scheme Ghostties \
             -configuration Debug \
             -destination 'platform=macOS' \
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             -skipPackagePluginValidation \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            -only-testing:GhosttyTests/TaskModelTests \
+            -only-testing:GhosttyTests/TaskFileWatcherTests

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -96,7 +96,23 @@ class AppDelegate: NSObject,
     private var derivedConfig: DerivedConfig = DerivedConfig()
 
     /// The ghostty global state. Only one per process.
-    let ghostty: Ghostty.App
+    ///
+    /// Lazy so it isn't constructed during AppDelegate property init (which
+    /// fires before any `applicationWillFinishLaunching` hook can run). Under
+    /// XCTest the launch hooks short-circuit before anyone reads `ghostty`,
+    /// so the heavy `Ghostty.App(configPath:)` work — which in turn touches
+    /// libghostty global state — never runs in headless CI test hosts. The
+    /// `applicationDidFinishLaunching` hook wires the delegate after first
+    /// access on real launches.
+    lazy var ghostty: Ghostty.App = {
+#if DEBUG
+        let app = Ghostty.App(configPath: ProcessInfo.processInfo.environment["GHOSTTY_CONFIG_PATH"])
+#else
+        let app = Ghostty.App()
+#endif
+        app.delegate = self
+        return app
+    }()
 
     /// The global undo manager for app-level state such as window restoration.
     lazy var undoManager = ExpiringUndoManager()
@@ -132,7 +148,14 @@ class AppDelegate: NSObject,
     }
 
     /// Manages updates
-    let updateController = UpdateController()
+    ///
+    /// Lazy so Sparkle's `SPUUpdater` isn't constructed during property init.
+    /// Under XCTest the launch hooks short-circuit before anyone reads
+    /// `updateController`; without the lazy guard, Sparkle's init touches
+    /// `Bundle.main` / appcast machinery that blocks the main thread long
+    /// enough to make headless XCTest hosts hang waiting for the test
+    /// connection.
+    lazy var updateController = UpdateController()
     var updateViewModel: UpdateViewModel {
         updateController.viewModel
     }
@@ -156,17 +179,6 @@ class AppDelegate: NSObject,
 
     /// The custom app icon image that is currently in use.
     @Published private(set) var appIcon: NSImage?
-
-    override init() {
-#if DEBUG
-        ghostty = Ghostty.App(configPath: ProcessInfo.processInfo.environment["GHOSTTY_CONFIG_PATH"])
-#else
-        ghostty = Ghostty.App()
-#endif
-        super.init()
-
-        ghostty.delegate = self
-    }
 
     // MARK: - NSApplicationDelegate
 

--- a/macos/Sources/App/macOS/main.swift
+++ b/macos/Sources/App/macOS/main.swift
@@ -2,32 +2,50 @@ import AppKit
 import Cocoa
 import GhosttyKit
 
-// Initialize Ghostty global state. We do this once right away because the
-// CLI APIs require it and it lets us ensure it is done immediately for the
-// rest of the app.
-if ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) != GHOSTTY_SUCCESS {
-    Ghostty.logger.critical("ghostty_init failed")
+// Detect XCTest hosting. When the process is launched as the host for an
+// XCTest bundle, the `XCTestConfigurationFilePath` env var is set by the
+// test runner before main runs. We must skip `ghostty_init` and
+// `ghostty_cli_try_action` in that case — both do heavy / blocking work
+// (loading the global config, parsing CLI flags, hitting libghostty
+// internals) that delays NSApplicationMain long enough for xcodebuild
+// to time out with "test runner hung before establishing connection" on
+// headless GitHub Actions runners (~6 minutes before failure).
+//
+// AppDelegate has a matching guard (`isRunningUnderXCTest`) plus lazy
+// initialization for `ghostty` / `updateController`, so the delegate's
+// launch hooks short-circuit and the heavy properties are never touched
+// under XCTest. NSApplicationMain still runs so XCTest can establish its
+// connection and load the test bundle.
+let isRunningUnderXCTest = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 
-    // We also write to stderr if this is executed from the CLI or zig run
-    switch Ghostty.launchSource {
-    case .cli, .zig_run:
-        let stderrHandle = FileHandle.standardError
-        stderrHandle.write(
-            "Ghostties failed to initialize! If you're executing Ghostties from the command line\n" +
-            "then this is usually because an invalid action or multiple actions were specified.\n" +
-            "Actions start with the `+` character.\n\n" +
-            "View all available actions by running `ghostty +help`.\n")
-        exit(1)
+if !isRunningUnderXCTest {
+    // Initialize Ghostty global state. We do this once right away because the
+    // CLI APIs require it and it lets us ensure it is done immediately for the
+    // rest of the app.
+    if ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) != GHOSTTY_SUCCESS {
+        Ghostty.logger.critical("ghostty_init failed")
 
-    case .app:
-        // For the app we exit immediately. We should handle this case more
-        // gracefully in the future.
-        exit(1)
+        // We also write to stderr if this is executed from the CLI or zig run
+        switch Ghostty.launchSource {
+        case .cli, .zig_run:
+            let stderrHandle = FileHandle.standardError
+            stderrHandle.write(
+                "Ghostties failed to initialize! If you're executing Ghostties from the command line\n" +
+                "then this is usually because an invalid action or multiple actions were specified.\n" +
+                "Actions start with the `+` character.\n\n" +
+                "View all available actions by running `ghostty +help`.\n")
+            exit(1)
+
+        case .app:
+            // For the app we exit immediately. We should handle this case more
+            // gracefully in the future.
+            exit(1)
+        }
     }
-}
 
-// This will run the CLI action and exit if one was specified. A CLI
-// action is a command starting with a `+`, such as `ghostty +boo`.
-ghostty_cli_try_action()
+    // This will run the CLI action and exit if one was specified. A CLI
+    // action is a command starting with a `+`, such as `ghostty +boo`.
+    ghostty_cli_try_action()
+}
 
 _ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)


### PR DESCRIPTION
## Summary

- `main.swift` now checks `XCTestConfigurationFilePath` and skips `ghostty_init` / `ghostty_cli_try_action` under XCTest. `NSApplicationMain` still runs so XCTest can establish its connection.
- `AppDelegate.ghostty` and `AppDelegate.updateController` are now `lazy var` so `Ghostty.App(configPath:)` and Sparkle's `SPUUpdater` aren't constructed during property init. `override init()` removed; `ghostty.delegate = self` lives inside the lazy initializer.
- The existing `applicationWillFinishLaunching` / `applicationDidFinishLaunching` XCTest guards stay in place as defense-in-depth — under XCTest the launch hooks short-circuit before anyone reads the lazy properties, so the heavy startup work never runs.
- Flipped the macOS workflow from `xcodebuild build` back to `xcodebuild test`, scoped via `-only-testing:GhosttyTests/TaskModelTests` + `-only-testing:GhosttyTests/TaskFileWatcherTests`.

## Why

The macOS CI job has been build-only because `xcodebuild test` hung the host app (`Ghostties Dev.app`) ~6 minutes before XCTest could connect — see `project-ci-host-app-hang.md` in orchestrator memory. Root cause was heavy work running in `main.swift` and AppDelegate property init, both of which fired before any launch hook could short-circuit under XCTest.

## Test plan

- [x] Clean build succeeds locally: `xcodebuild build -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Debug -destination 'platform=macOS' ONLY_ACTIVE_ARCH=YES ARCHS=arm64`
- [x] Headless XCTest finishes in seconds, not minutes: `xcodebuild test ... -only-testing:GhosttyTests/TaskModelTests -only-testing:GhosttyTests/TaskFileWatcherTests` ran in **~32s** with all 13 tests passing
- [ ] CI green on this PR (the real proof — first-ever green `xcodebuild test` run on the macOS job)
- [ ] Smoke-test normal `Ghostties Dev.app` launch (open from Xcode or `open` the built bundle) — terminal opens, sidebar works, Sparkle wires up

## Notes / fragility

- The lazy initializer fires the first time anything reads `self.ghostty` — that happens in `applicationDidFinishLaunching` (after the XCTest gate), so under tests it never fires. If a future test target reads `NSApp.delegate.ghostty` it would force eager evaluation; the test suites we ship today only `@testable import Ghostty` types and don't touch `NSApp`.
- `main.swift` skips `ghostty_init` under XCTest, but `Ghostty.App.init` calls `Config(at:)` which would touch libghostty if it ran. Belt-and-suspenders: lazy property init prevents that path entirely under XCTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)