### PR TITLE
U1 / SEA-157 — Frontmatter priority field across three surfaces (+ MCP enum align)

### DIFF
--- a/cli/Sources/GhosttiesCore/Task.swift
+++ b/cli/Sources/GhosttiesCore/Task.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+/// Task priority levels. Raw values are the strings written in `priority:`
+/// frontmatter and match across all three surfaces (CLI, MCP, macOS sidebar).
+/// Default when the field is absent or unrecognised is `.none`.
+public enum TaskPriority: String, Codable, CaseIterable, Sendable {
+    case high
+    case medium
+    case low
+    case none
+
+    /// Parse a raw frontmatter string, falling back to `.none` for any unknown
+    /// or empty value. Never crashes on bad input.
+    public static func parse(_ s: String) -> TaskPriority {
+        return TaskPriority(rawValue: s.lowercased()) ?? .none
+    }
+}
+
 /// Status lanes — raw values match what the macOS app writes and reads in
 /// `status:` frontmatter. "graveyard" is the UI name for `done` but the
 /// on-disk value must stay `done` so the app parses it.
@@ -45,6 +61,9 @@ public struct Task {
     public var id: String
     public var title: String
     public var lane: TaskLane
+    /// Task priority. Defaults to `.none` when the `priority:` frontmatter key
+    /// is absent or contains an unrecognised value — never crashes.
+    public var priority: TaskPriority
     public var project: String?
     public var source: String?
     public var sourceID: String?
@@ -65,6 +84,7 @@ public struct Task {
         id: String,
         title: String,
         lane: TaskLane,
+        priority: TaskPriority = .none,
         project: String?,
         source: String?,
         sourceID: String?,
@@ -77,6 +97,7 @@ public struct Task {
         self.id = id
         self.title = title
         self.lane = lane
+        self.priority = priority
         self.project = project
         self.source = source
         self.sourceID = sourceID

--- a/cli/Sources/GhosttiesCore/TaskStore.swift
+++ b/cli/Sources/GhosttiesCore/TaskStore.swift
@@ -42,10 +42,18 @@ public struct TaskStore {
         let id = Frontmatter.value(for: "source-id", in: pairs)
             ?? url.deletingPathExtension().lastPathComponent
 
+        // Parse priority with strict-with-skip: unknown value → .none, never crash.
+        let priority: TaskPriority = {
+            guard let raw = Frontmatter.value(for: "priority", in: pairs),
+                  !raw.isEmpty else { return .none }
+            return TaskPriority(rawValue: raw) ?? .none
+        }()
+
         return Task(
             id: id,
             title: title,
             lane: lane,
+            priority: priority,
             project: Frontmatter.value(for: "project", in: pairs),
             source: Frontmatter.value(for: "source", in: pairs),
             sourceID: Frontmatter.value(for: "source-id", in: pairs),

--- a/cli/Sources/ghostties-mcp/Tools.swift
+++ b/cli/Sources/ghostties-mcp/Tools.swift
@@ -70,11 +70,9 @@ func taskSummary(_ t: Task) -> JSONValue {
         "project_path": t.projectPath.map(JSONValue.string) ?? .null,
         "template": t.template.map(JSONValue.string) ?? .null
     ]
-    if let priority = Frontmatter.value(for: "priority", in: t.frontmatter) {
-        out["priority"] = .string(priority)
-    } else {
-        out["priority"] = .null
-    }
+    // Emit priority as a string using the typed field. `.none` serialises as
+    // "none" (not null) so consumers can distinguish "unset" from "no value".
+    out["priority"] = .string(t.priority.rawValue)
     // Prefer `updated` frontmatter if set; else `completed`; else `created`.
     let updated = Frontmatter.value(for: "updated", in: t.frontmatter)
         ?? Frontmatter.value(for: "completed", in: t.frontmatter)
@@ -172,7 +170,7 @@ enum S {
 /// All 9 lanes accepted as status-ish strings. Spec says `graveyard` is an
 /// alias for `done`.
 let laneEnum = ["inbox", "backlog", "running", "needs-you", "review", "done", "graveyard"]
-let priorityEnum = ["low", "normal", "high"]
+let priorityEnum = ["high", "medium", "low", "none"]
 
 // MARK: - Tools
 

--- a/cli/Sources/ghostties-mcp/Tools/CreateTask.swift
+++ b/cli/Sources/ghostties-mcp/Tools/CreateTask.swift
@@ -42,7 +42,11 @@ func createTaskTool() -> Tool {
             let project = args["project"]?.string ?? defaultProject(from: dir)
             let projectPath = args["project_path"]?.string
             let template = args["template"]?.string
-            let priority = args["priority"]?.string
+            // Validate priority against the typed enum; unknown values default to .none.
+            let priorityValue: TaskPriority = {
+                guard let raw = args["priority"]?.string, !raw.isEmpty else { return .none }
+                return TaskPriority(rawValue: raw) ?? .none
+            }()
             let seedNotes = args["notes"]?.string
 
             let id = makeID(title: title)
@@ -57,8 +61,10 @@ func createTaskTool() -> Tool {
                 ("created", created),
                 ("status", laneValue.rawValue)
             ]
-            if let priority {
-                pairs.append(("priority", priority))
+            // Only write priority to disk when it is explicitly set (non-.none).
+            // Omitting the key for .none keeps legacy fixtures clean.
+            if priorityValue != .none {
+                pairs.append(("priority", priorityValue.rawValue))
             }
             if let projectPath, !projectPath.isEmpty {
                 pairs.append(("project-path", projectPath))

--- a/cli/Tests/GhosttiesCoreTests/CrossSurfaceCoherenceTests.swift
+++ b/cli/Tests/GhosttiesCoreTests/CrossSurfaceCoherenceTests.swift
@@ -130,7 +130,7 @@ final class CrossSurfaceCoherenceTests: XCTestCase {
             ("project", "ghostties"),
             ("created", "2026-04-22T22:35:00Z"),
             ("status", "running"),
-            ("priority", "normal"),
+            ("priority", "high"),
             ("updated", "2026-04-22T23:00:00Z"),
             ("completed", "2026-04-22T23:30:00Z")
         ]
@@ -239,6 +239,69 @@ final class CrossSurfaceCoherenceTests: XCTestCase {
         // Negative assertions — no camelCase / snake_case leakage.
         XCTAssertFalse(raw.contains("projectPath:"), "no camelCase 'projectPath' key allowed")
         XCTAssertFalse(raw.contains("project_path:"), "no snake_case 'project_path' key allowed")
+    }
+
+    // MARK: - Priority cross-surface contract
+
+    /// The four `TaskPriority` raw values that the CLI writes must match the
+    /// strings the MCP `priorityEnum` advertises and the macOS parser reads.
+    /// If this test fails, a surface has drifted from the contract.
+    func testPriorityEnumRawValuesMatchContractStrings() {
+        // Canonical set agreed across all three surfaces (CLI, MCP, macOS):
+        let contractValues: Set<String> = ["high", "medium", "low", "none"]
+
+        // CLI-side: TaskPriority enum raw values must exactly match.
+        let cliRawValues = Set(TaskPriority.allCases.map(\.rawValue))
+        XCTAssertEqual(cliRawValues, contractValues,
+                       "CLI TaskPriority raw values must be exactly \(contractValues). " +
+                       "Got: \(cliRawValues)")
+
+        // Spot-check each value parses correctly.
+        XCTAssertEqual(TaskPriority.parse("high"),   .high)
+        XCTAssertEqual(TaskPriority.parse("medium"), .medium)
+        XCTAssertEqual(TaskPriority.parse("low"),    .low)
+        XCTAssertEqual(TaskPriority.parse("none"),   .none)
+
+        // Unknown value must fall back to .none without crashing.
+        XCTAssertEqual(TaskPriority.parse("urgent"), .none,
+                       "unknown priority value must default to .none (strict-with-skip)")
+        XCTAssertEqual(TaskPriority.parse(""),       .none,
+                       "empty priority string must default to .none")
+
+        // Legacy value `normal` (old MCP enum) must fall back gracefully.
+        XCTAssertEqual(TaskPriority.parse("normal"), .none,
+                       "old 'normal' priority value must default to .none after F-002 migration")
+    }
+
+    /// Write a task with priority=high via TaskStore, read it back, confirm the
+    /// on-disk key is `priority: high` (not `priority: normal` or absent).
+    func testPriorityOnDiskUsesCorrectRawValue() throws {
+        let store = TaskStore(directory: tmpDir)
+        let pairs: [(String, String)] = [
+            ("title", "Priority contract"),
+            ("source", "linear"),
+            ("source-id", "SEA-priority"),
+            ("project", "ghostties"),
+            ("created", "2026-04-25T10:00:00Z"),
+            ("status", "running"),
+            ("priority", "high")
+        ]
+        _ = try store.create(id: "priority-contract", pairs: pairs, body: "\n")
+
+        let url = tmpDir.appendingPathComponent("priority-contract.md")
+        let raw = try String(contentsOf: url, encoding: .utf8)
+
+        XCTAssertTrue(raw.contains("priority: high"),
+                      "on-disk priority must be 'high'; got:\n\(raw)")
+        XCTAssertFalse(raw.contains("priority: normal"),
+                       "legacy 'normal' must never appear on disk after F-002 migration")
+
+        // Re-parse and confirm round-trip.
+        guard let task = store.loadFile(at: url) else {
+            XCTFail("failed to reload priority-contract task")
+            return
+        }
+        XCTAssertEqual(task.priority, .high)
     }
 
     /// All six lanes the sidebar reads have matching raw values in `TaskLane`.

--- a/cli/Tests/GhosttiesCoreTests/FrontmatterTests.swift
+++ b/cli/Tests/GhosttiesCoreTests/FrontmatterTests.swift
@@ -198,6 +198,110 @@ final class FrontmatterTests: XCTestCase {
         XCTAssertEqual(reloaded.template, "Orchestrator")
     }
 
+    // MARK: - priority round-trip
+
+    /// All four priority values round-trip through TaskStore write → load.
+    func testPriorityRoundTrip() throws {
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("gt-priority-rt-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let store = TaskStore(directory: tmpDir)
+        let values: [(String, TaskPriority)] = [
+            ("high",   .high),
+            ("medium", .medium),
+            ("low",    .low),
+            ("none",   .none)
+        ]
+        for (rawValue, expected) in values {
+            let id = "priority-\(rawValue)"
+            let pairs: [(String, String)] = [
+                ("title", "Priority \(rawValue)"),
+                ("source", "shell"),
+                ("source-id", id),
+                ("branch", "null"),
+                ("project", "ghostties"),
+                ("created", "2026-04-25T10:00:00Z"),
+                ("status", "backlog"),
+                ("priority", rawValue)
+            ]
+            let url = try store.create(id: id, pairs: pairs, body: "\n## Goal\n\n")
+            guard let reloaded = store.loadFile(at: url) else {
+                XCTFail("failed to reload task with priority=\(rawValue)")
+                continue
+            }
+            XCTAssertEqual(reloaded.priority, expected,
+                           "priority '\(rawValue)' did not round-trip correctly")
+        }
+    }
+
+    /// A file with no `priority:` key defaults to `.none` — legacy files keep loading.
+    func testMissingPriorityDefaultsToNone() throws {
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("gt-priority-missing-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let raw = """
+        ---
+        title: Legacy no-priority
+        source: shell
+        source-id: no-priority
+        branch: null
+        project: ghostties
+        created: 2026-04-25T10:00:00Z
+        status: backlog
+        ---
+
+        ## Goal
+
+        """
+        let url = tmpDir.appendingPathComponent("no-priority.md")
+        try raw.write(to: url, atomically: true, encoding: .utf8)
+
+        let store = TaskStore(directory: tmpDir)
+        guard let task = store.loadFile(at: url) else {
+            XCTFail("legacy task without priority key failed to load")
+            return
+        }
+        XCTAssertEqual(task.priority, .none, "missing priority key must default to .none")
+    }
+
+    /// An unknown priority value (e.g. `urgent`) must NOT crash — falls back to `.none`.
+    func testUnknownPriorityValueDefaultsToNone() throws {
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("gt-priority-unknown-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let raw = """
+        ---
+        title: Unknown priority
+        source: shell
+        source-id: unknown-priority
+        branch: null
+        project: ghostties
+        created: 2026-04-25T10:00:00Z
+        status: backlog
+        priority: urgent
+        ---
+
+        ## Goal
+
+        """
+        let url = tmpDir.appendingPathComponent("unknown-priority.md")
+        try raw.write(to: url, atomically: true, encoding: .utf8)
+
+        let store = TaskStore(directory: tmpDir)
+        guard let task = store.loadFile(at: url) else {
+            XCTFail("task with unknown priority value failed to load (should not crash)")
+            return
+        }
+        XCTAssertEqual(task.priority, .none,
+                       "unknown priority value 'urgent' must fall back to .none")
+    }
+
     /// A file with none of the new keys must still load cleanly — old fixtures
     /// pre-date the project-path/template additions and must continue to work.
     func testFileWithoutNewFieldsStillLoads() throws {

--- a/macos/Sources/Features/Ghostties/TaskModel.swift
+++ b/macos/Sources/Features/Ghostties/TaskModel.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// Task priority levels. Raw values match the `priority:` frontmatter key and
+/// are shared across CLI, MCP, and macOS surfaces. Default is `.none`.
+/// Unknown values decoded from disk fall back to `.none` — never crash.
+enum TaskPriority: String, Codable, CaseIterable {
+    case high
+    case medium
+    case low
+    case none
+}
+
 /// Status lanes for a task, matching the six-lane IA from the task-first sidebar brief.
 ///
 /// Raw values are the snake/kebab-case strings used in `.ghostties/tasks/*.md`
@@ -66,6 +76,9 @@ struct TaskItem: Identifiable, Codable, Equatable {
     let template: String?
     let created: Date
     let status: TaskStatus
+    /// Task priority parsed from the `priority:` frontmatter key.
+    /// Defaults to `.none` when the key is absent or contains an unknown value.
+    let priority: TaskPriority
     let filesStaged: Int?
     let goal: String?
     let notes: String?
@@ -88,6 +101,7 @@ struct TaskItem: Identifiable, Codable, Equatable {
         case template
         case created
         case status
+        case priority
         case filesStaged = "files-staged"
         case goal
         case notes
@@ -98,5 +112,85 @@ struct TaskItem: Identifiable, Codable, Equatable {
         case ci
         case completed
         case events
+    }
+
+    // Custom Decodable init so that:
+    //   1. Old fixture files without a `priority:` key default to `.none` (backward compat).
+    //   2. Unknown priority strings (e.g. `urgent`) also default to `.none` (strict-with-skip).
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        title = try c.decode(String.self, forKey: .title)
+        source = try c.decode(TaskSource.self, forKey: .source)
+        sourceID = try c.decodeIfPresent(String.self, forKey: .sourceID)
+        branch = try c.decodeIfPresent(String.self, forKey: .branch)
+        project = try c.decode(String.self, forKey: .project)
+        projectPath = try c.decodeIfPresent(String.self, forKey: .projectPath)
+        template = try c.decodeIfPresent(String.self, forKey: .template)
+        created = try c.decode(Date.self, forKey: .created)
+        status = try c.decode(TaskStatus.self, forKey: .status)
+        // priority: missing key → .none; unknown raw value → .none (strict-with-skip).
+        if let raw = try c.decodeIfPresent(String.self, forKey: .priority) {
+            priority = TaskPriority(rawValue: raw) ?? .none
+        } else {
+            priority = .none
+        }
+        filesStaged = try c.decodeIfPresent(Int.self, forKey: .filesStaged)
+        goal = try c.decodeIfPresent(String.self, forKey: .goal)
+        notes = try c.decodeIfPresent(String.self, forKey: .notes)
+        needs = try c.decodeIfPresent(String.self, forKey: .needs)
+        severity = try c.decodeIfPresent(String.self, forKey: .severity)
+        pr = try c.decodeIfPresent(Int.self, forKey: .pr)
+        prState = try c.decodeIfPresent(String.self, forKey: .prState)
+        ci = try c.decodeIfPresent(String.self, forKey: .ci)
+        completed = try c.decodeIfPresent(Date.self, forKey: .completed)
+        events = try c.decodeIfPresent([TaskEvent].self, forKey: .events)
+    }
+
+    // Explicit memberwise init used by TaskFixtureParser (not Codable-based).
+    init(
+        id: String,
+        title: String,
+        source: TaskSource,
+        sourceID: String?,
+        branch: String?,
+        project: String,
+        projectPath: String?,
+        template: String?,
+        created: Date,
+        status: TaskStatus,
+        priority: TaskPriority = .none,
+        filesStaged: Int?,
+        goal: String?,
+        notes: String?,
+        needs: String?,
+        severity: String?,
+        pr: Int?,
+        prState: String?,
+        ci: String?,
+        completed: Date?,
+        events: [TaskEvent]?
+    ) {
+        self.id = id
+        self.title = title
+        self.source = source
+        self.sourceID = sourceID
+        self.branch = branch
+        self.project = project
+        self.projectPath = projectPath
+        self.template = template
+        self.created = created
+        self.status = status
+        self.priority = priority
+        self.filesStaged = filesStaged
+        self.goal = goal
+        self.notes = notes
+        self.needs = needs
+        self.severity = severity
+        self.pr = pr
+        self.prState = prState
+        self.ci = ci
+        self.completed = completed
+        self.events = events
     }
 }

--- a/macos/Sources/Features/Ghostties/TaskStore.swift
+++ b/macos/Sources/Features/Ghostties/TaskStore.swift
@@ -234,6 +234,12 @@ enum TaskFixtureParser {
             return raw
         }()
 
+        // Parse priority with strict-with-skip: unknown value → .none, never crash.
+        let priority: TaskPriority = {
+            guard let raw = yaml["priority"], !raw.isEmpty else { return .none }
+            return TaskPriority(rawValue: raw) ?? .none
+        }()
+
         return TaskItem(
             id: id,
             title: title,
@@ -245,6 +251,7 @@ enum TaskFixtureParser {
             template: template,
             created: created,
             status: status,
+            priority: priority,
             filesStaged: yaml["files-staged"].flatMap(Int.init),
             goal: goal?.isEmpty == true ? nil : goal,
             notes: notes?.isEmpty == true ? nil : notes,


### PR DESCRIPTION
## Summary

- Adds `TaskPriority: String, Codable` enum (`high | medium | low | none`, default `none`) to the task schema across CLI, MCP, and macOS surfaces.
- Fixes F-002: replaces the old MCP `priorityEnum` `["low", "normal", "high"]` with the aligned `["high", "medium", "low", "none"]`.
- Strict-with-skip on all three surfaces: unknown/missing `priority:` values default to `.none`, never crash.
- macOS `TaskItem` gets a custom `Codable` init so legacy fixture files without a `priority:` key decode cleanly (backward-compat).

Linear: SEA-157 (U1 of row-click v0, parent SEA-156)

## Files changed

| File | Change |
|---|---|
| `cli/Sources/GhosttiesCore/Task.swift` | New `TaskPriority` enum + `priority` field on `Task` |
| `cli/Sources/GhosttiesCore/TaskStore.swift` | Parse `priority:` frontmatter key, strict-with-skip |
| `cli/Sources/ghostties-mcp/Tools.swift` | Updated `priorityEnum`; `taskSummary` uses typed `.priority` |
| `cli/Sources/ghostties-mcp/Tools/CreateTask.swift` | Validates priority via `TaskPriority` enum |
| `macos/Sources/Features/Ghostties/TaskModel.swift` | `TaskPriority` enum + `priority` field on `TaskItem`; custom `Codable` init |
| `macos/Sources/Features/Ghostties/TaskStore.swift` | Fixture parser reads `priority:` key, passes typed value |
| `cli/Tests/GhosttiesCoreTests/FrontmatterTests.swift` | 3 new tests: round-trip all 4 values, missing key → `.none`, unknown value → `.none` |
| `cli/Tests/GhosttiesCoreTests/CrossSurfaceCoherenceTests.swift` | 2 new tests: enum contract, on-disk raw value |

## Test results

```
GhosttiesCoreTests:  43 tests, 0 failures
MCPProtocolTests:    17 tests, 0 failures
swift build:         clean, no warnings
gt list:             no crash on existing .ghostties/tasks/*.md fixtures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)