### PR TITLE
chore: prep beta.11 — Sparkle on ghostties.org + SEA-184 TCC name

### DIFF
--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -336,6 +336,8 @@ jobs:
   # ---------------------------------------------------------------------------
   appcast:
     needs: [setup, build-macos]
+    permissions:
+      contents: write
     # Skip appcast generation on dry-run — we're not publishing.
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
     runs-on: macos-26
@@ -473,6 +475,33 @@ jobs:
           path: |
             appcast-stable.xml
             appcast-beta.xml
+
+      - name: Commit appcast to web/
+        run: |
+          # Save generated appcasts before switching to main branch
+          cp appcast-beta.xml /tmp/appcast-beta.xml
+          cp appcast-stable.xml /tmp/appcast-stable.xml
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main:main
+          git switch main
+
+          cp /tmp/appcast-beta.xml web/appcast-beta.xml
+          if [[ "$IS_BETA" != "true" ]]; then
+            cp /tmp/appcast-stable.xml web/appcast-stable.xml
+          fi
+
+          git add web/appcast-beta.xml web/appcast-stable.xml
+          if git diff --cached --quiet; then
+            echo "No appcast changes to commit."
+          else
+            git commit -m "chore(appcast): update from ${GITHUB_REF_NAME} [skip ci]"
+            git push origin main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
   # release: Create the GitHub Release with all artifacts attached

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ default.profraw
 .ghostties/sessions.json
 .ghostties/sessions.json.tmp
 .vercel
+
+# Local session artifacts
+.claude/scheduled_tasks.lock
+docs/Crash\ report/

--- a/macos/Ghostties.xcodeproj/project.pbxproj
+++ b/macos/Ghostties.xcodeproj/project.pbxproj
@@ -1332,6 +1332,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Ghostties-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Ghostties;
+				INFOPLIST_KEY_CFBundleName = Ghostties;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "A program running within Ghostty would like to use AppleScript.";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "A program running within Ghostty would like to use Bluetooth.";

--- a/macos/Sources/Features/Update/UpdateDelegate.swift
+++ b/macos/Sources/Features/Update/UpdateDelegate.swift
@@ -8,12 +8,12 @@ extension UpdateDriver: SPUUpdaterDelegate {
         }
 
         // Ghostties-specific appcast feeds (not upstream Ghostty).
-        // Hosted on GitHub Releases — each tagged release uploads both files.
+        // Hosted on ghostties.org (Vercel) — updated by release workflow after each tag.
         // Stable channel: only receives non-beta releases.
         // Tip/beta channel: receives all releases including betas.
         switch appDelegate.ghostty.config.autoUpdateChannel {
-        case .tip: return "https://github.com/SeanSmithDesign/ghostties/releases/latest/download/appcast-beta.xml"
-        case .stable: return "https://github.com/SeanSmithDesign/ghostties/releases/latest/download/appcast-stable.xml"
+        case .tip: return "https://ghostties.org/appcast-beta.xml"
+        case .stable: return "https://ghostties.org/appcast-stable.xml"
         }
     }
 

--- a/web/appcast-beta.xml
+++ b/web/appcast-beta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Ghostties Beta Releases</title>
+    <description>No beta release available yet. Updated automatically on each release.</description>
+  </channel>
+</rss>

--- a/web/appcast-stable.xml
+++ b/web/appcast-stable.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Ghostties Stable Releases</title>
+    <description>No stable release available yet. Updated automatically on each release.</description>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- Migrates Sparkle appcast to self-hosted `https://ghostties.org/appcast-{beta,stable}.xml` (fixes prerelease 404 bug present since beta.9)
- Seeds `web/appcast-{beta,stable}.xml` placeholder files so the URL resolves immediately
- Release workflow now commits updated appcast to `web/` after each tag (beta.11+ gets working auto-update)
- Adds `INFOPLIST_KEY_CFBundleName = Ghostties` to Release build config (SEA-184 — TCC dialogs show correct app name)
- `.gitignore`: excludes lock file + crash report folder

Note: beta.10 users will not auto-update (their binary points at the dead GitHub latest URL). One-time manual install of beta.11 required.