### PR TITLE
feat(web): download page + licenses + diff animation + factual fixes

### DIFF
--- a/web/download.html
+++ b/web/download.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Support — ghostties</title>
+  <title>Download — ghostties</title>
   <link rel="icon" type="image/svg+xml" href="">
   <script>
     (function() {
@@ -20,7 +20,7 @@
       link.href = 'data:image/svg+xml;base64,' + btoa(svg);
     })();
   </script>
-  <meta name="description" content="Support for Ghostties — system requirements, known issues, and how to report bugs.">
+  <meta name="description" content="Download Ghostties — a multi-agent workspace terminal for macOS.">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -88,27 +88,6 @@
       margin-bottom: 12px;
     }
 
-    ul {
-      list-style: none;
-      margin-bottom: 12px;
-    }
-
-    ul li {
-      font-size: 15px;
-      line-height: 1.65;
-      color: rgba(255, 255, 255, 0.65);
-      padding-left: 16px;
-      position: relative;
-      margin-bottom: 4px;
-    }
-
-    ul li::before {
-      content: "–";
-      position: absolute;
-      left: 0;
-      color: rgba(255, 255, 255, 0.25);
-    }
-
     code {
       font-family: 'SFMono-Regular', 'SF Mono', 'Fira Code', monospace;
       font-size: 13px;
@@ -128,16 +107,65 @@
       color: rgba(255, 255, 255, 0.9);
     }
 
-    .known-issue {
-      font-size: 15px;
-      line-height: 1.65;
-      color: rgba(255, 255, 255, 0.65);
-      margin-bottom: 4px;
+    .download-block {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin: 32px 0;
     }
 
-    .known-issue .note {
+    .download-btn {
+      display: inline-block;
+      background: #ffffff;
+      color: #1a1a2e;
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 15px;
+      font-weight: 600;
+      text-decoration: none;
+      padding: 14px 28px;
+      border-radius: 8px;
+      letter-spacing: -0.01em;
+      transition: opacity 0.15s;
+      align-self: flex-start;
+    }
+
+    .download-btn:hover {
+      opacity: 0.85;
+      color: #1a1a2e;
+    }
+
+    .download-meta {
       font-size: 13px;
-      color: rgba(255, 255, 255, 0.35);
+      color: rgba(255, 255, 255, 0.4);
+      line-height: 1.6;
+    }
+
+    .all-releases {
+      display: inline-block;
+      margin-top: 24px;
+      font-size: 14px;
+      color: rgba(255, 255, 255, 0.4);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+      transition: color 0.2s;
+    }
+
+    .all-releases:hover {
+      color: rgba(255, 255, 255, 0.65);
+    }
+
+    .note {
+      margin-top: 36px;
+      padding: 16px 20px;
+      background: rgba(255, 255, 255, 0.04);
+      border-left: 2px solid rgba(255, 255, 255, 0.12);
+      border-radius: 4px;
+    }
+
+    .note p {
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.45);
+      margin-bottom: 0;
     }
 
     .updated {
@@ -180,6 +208,7 @@
       body { padding: 48px 16px 88px; }
       h1 { font-size: 22px; }
       footer { padding: 12px 16px; font-size: 12px; }
+      .download-btn { font-size: 14px; padding: 12px 22px; }
     }
   </style>
 </head>
@@ -187,28 +216,29 @@
   <div class="content">
     <a class="back" href="/">&larr; ghostties</a>
 
-    <h1>Support</h1>
-    <p class="lead">Ghostties is in beta. If something breaks or feels wrong, we'd like to know.</p>
+    <h1>Download</h1>
+    <p class="lead">Ghostties is a multi-agent workspace terminal for macOS. Currently in beta.</p>
 
-    <h2>Found a bug?</h2>
-    <p><a href="https://github.com/SeanSmithDesign/ghostties/issues" target="_blank" rel="noopener">Open an issue on GitHub.</a> Include your macOS version (Apple menu &rarr; About This Mac), Ghostties version (Ghostties menu &rarr; About Ghostties), and what you were doing when it broke.</p>
+    <h2>Current release</h2>
+    <div class="download-block">
+      <a class="download-btn" href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.12/Ghostties.dmg" download>
+        Download v0.1.0-beta.12 for macOS
+      </a>
+      <div class="download-meta">
+        v0.1.0-beta.12 &middot; April 27, 2026 &middot; 156 MB<br>
+        macOS 13 (Ventura) or later &middot; Apple Silicon
+      </div>
+    </div>
 
-    <h2>System requirements</h2>
-    <ul>
-      <li>macOS 13 (Ventura) or later</li>
-      <li>Apple Silicon Mac (M1, M2, M3, M4) — universal binary not available yet</li>
-    </ul>
+    <p>Beta release &mdash; auto-updates via Sparkle once installed.</p>
 
-    <h2>Updates</h2>
-    <p>Ghostties auto-updates via Sparkle. You'll get a prompt when a new release is ready. To disable updates, add <code>auto-update = off</code> to your config.</p>
+    <a class="all-releases" href="https://github.com/SeanSmithDesign/ghostties/releases" target="_blank" rel="noopener">View all releases on GitHub &rarr;</a>
 
-    <h2>Reset to factory state</h2>
-    <p>Quit the app, delete <code>~/Library/Application Support/com.seansmithdesign.ghostties/</code>, then relaunch. This wipes workspaces and preferences but leaves your project-local task notes (<code>.ghostties/tasks/</code>) alone.</p>
+    <div class="note">
+      <p><strong style="color:rgba(255,255,255,0.6)">Beta.10 and earlier users:</strong> Sparkle in those builds pointed at a now-fixed URL. Install this release manually &mdash; beta.12 and later auto-update from there.</p>
+    </div>
 
-    <h2>Contact</h2>
-    <p>For now, <a href="https://github.com/SeanSmithDesign/ghostties/issues" target="_blank" rel="noopener">GitHub Issues</a> is the best path. Email and Discord support coming once we're out of beta.</p>
-
-    <p class="updated">Last updated April 26, 2026</p>
+    <p class="updated">Last updated April 27, 2026</p>
   </div>
 
   <footer>

--- a/web/index.html
+++ b/web/index.html
@@ -20,16 +20,16 @@
       link.href = 'data:image/svg+xml;base64,' + btoa(svg);
     })();
   </script>
-  <meta name="description" content="Ghostties — a multi-agent workspace terminal. Coming soon.">
+  <meta name="description" content="Ghostties — a multi-agent workspace terminal. Now in beta.">
   <meta property="og:title" content="ghostties">
-  <meta property="og:description" content="A multi-agent workspace terminal. Coming soon.">
+  <meta property="og:description" content="A multi-agent workspace terminal. Now in beta.">
   <meta property="og:image" content="/assets/poster.png">
   <meta property="og:type" content="website">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
     html, body {
-      min-height: 100%;
+      height: 100%;
       background: #1a1a2e;
     }
 
@@ -38,7 +38,7 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: 24px 24px 64px;
+      padding: 24px;
     }
 
     /* --- Scene container --- */
@@ -77,10 +77,6 @@
     }
 
     /* --- Entrance: each ghost flies in from a unique direction --- */
-    .animate .ghost {
-      animation: float 2.5s ease-in-out infinite alternate;
-    }
-
     .animate .g0 { animation: entrance-g0 0.8s ease-out forwards, float-g0 2.4s ease-in-out 1.5s infinite alternate; }
     .animate .g1 { animation: entrance-g1 0.8s 1.8s ease-out forwards, float-g1 2.8s ease-in-out 3.0s infinite alternate; }
     .animate .g2 { animation: entrance-g2 0.8s 2.0s ease-out forwards, float-g2 3.1s ease-in-out 3.2s infinite alternate; }
@@ -126,60 +122,81 @@
       border-right: 2px solid transparent;
     }
 
-    /* Typing animation per line */
-    .animate .line-1 {
-      animation: type-line1 0.6s steps(16) 1.0s forwards, blink-caret 0.6s step-end 1.0s 1;
-      border-right-color: transparent;
+    /* Diff line colors */
+    .line-3 {
+      color: rgba(255, 100, 100, 0.7);
     }
 
+    .line-4 {
+      color: rgba(100, 220, 120, 0.9);
+    }
+
+    /* line-4 wraps the full content in an anchor */
+    .line-4 a {
+      color: inherit;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .line-4 a:hover {
+      text-decoration: underline;
+    }
+
+    /* Caret blink states */
     .animate .line-1.caret-visible {
       border-right-color: #E0E0E0;
-    }
-
-    .animate .line-2 {
-      animation: type-line2 0.9s steps(25) 4.2s forwards, blink-caret 0.6s step-end 4.2s 1;
-      border-right-color: transparent;
     }
 
     .animate .line-2.caret-visible {
       border-right-color: #E0E0E0;
     }
 
+    .animate .line-4.caret-visible {
+      border-right-color: rgba(100, 220, 120, 0.9);
+    }
+
+    .animate .line-4.caret-blink {
+      animation: blink-caret-green 0.53s step-end infinite !important;
+    }
+
+    /* Typing animations */
+    /* line-1: "cd ~/ghostties" = 14 chars */
+    .animate .line-1 {
+      animation: type-line1 0.56s steps(14) 1.0s forwards;
+    }
+
+    /* line-2: "https://github.com/SeanSmithDesign/ghostties" = 44 chars */
+    .animate .line-2 {
+      animation: type-line2 1.1s steps(44) 4.2s forwards;
+    }
+
+    /* line-3: "- ghostties % install soon" = 26 chars */
     .animate .line-3 {
-      animation: type-line3 1.5s steps(52) 5.5s forwards, blink-caret 0.53s step-end 5.5s infinite;
-      border-right-color: transparent;
+      animation: type-line3 0.65s steps(26) 5.5s forwards;
     }
 
-    .animate .line-3.caret-visible {
-      border-right-color: #E0E0E0;
+    /* line-4: "+ ghostties % v0.1.0-beta.12 · April 27, 2026 · [download now]" = 62 chars */
+    .animate .line-4 {
+      animation: type-line4 1.55s steps(62) 7.5s forwards;
     }
 
-    @keyframes type-line1 {
-      from { width: 0; }
-      to   { width: 16ch; }
+    @keyframes type-line1 { from { width: 0; } to { width: 14ch; } }
+    @keyframes type-line2 { from { width: 0; } to { width: 44ch; } }
+    @keyframes type-line3 { from { width: 0; } to { width: 26ch; } }
+    @keyframes type-line4 { from { width: 0; } to { width: 62ch; } }
+
+    @keyframes blink-caret-green {
+      0%, 100% { border-right-color: rgba(100, 220, 120, 0.9); }
+      50%       { border-right-color: transparent; }
     }
 
-    @keyframes type-line2 {
-      from { width: 0; }
-      to   { width: 25ch; }
-    }
-
-    @keyframes type-line3 {
-      from { width: 0; }
-      to   { width: 52ch; }
-    }
-
-    @keyframes blink-caret {
-      50% { border-color: transparent; }
-    }
-
-    .terminal a {
+    .terminal a.gh-link {
       color: #E0E0E0;
       text-decoration: none;
       cursor: pointer;
     }
 
-    .terminal a:hover {
+    .terminal a.gh-link:hover {
       text-decoration: underline;
     }
 
@@ -203,6 +220,18 @@
       opacity: 0;
     }
 
+    /* --- Letter plate (bottom-left fixed) --- */
+    .letter-plate {
+      position: fixed;
+      bottom: 16px;
+      left: 24px;
+      font-family: 'SFMono-Regular', 'SF Mono', monospace;
+      font-size: 11px;
+      color: rgba(255, 255, 255, 0.3);
+      line-height: 1.7;
+      pointer-events: none;
+    }
+
     /* --- Footer --- */
     footer {
       position: fixed;
@@ -220,6 +249,7 @@
 
     footer a {
       color: rgba(255, 255, 255, 0.25);
+      text-decoration: none;
       transition: color 0.2s;
     }
 
@@ -233,51 +263,6 @@
       display: block;
     }
 
-    /* --- Download CTA --- */
-    .cta {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 10px;
-      padding-top: 32px;
-      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-    }
-
-    .cta-download {
-      display: inline-block;
-      background: #ffffff;
-      color: #1a1a2e;
-      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-      font-size: 15px;
-      font-weight: 600;
-      text-decoration: none;
-      padding: 12px 24px;
-      border-radius: 8px;
-      letter-spacing: -0.01em;
-      transition: opacity 0.15s;
-    }
-
-    .cta-download:hover {
-      opacity: 0.85;
-    }
-
-    .cta-meta {
-      font-size: 12px;
-      color: rgba(255, 255, 255, 0.4);
-      text-align: center;
-      line-height: 1.6;
-    }
-
-    .cta-meta a {
-      color: rgba(255, 255, 255, 0.4);
-      text-decoration: underline;
-      transition: color 0.2s;
-    }
-
-    .cta-meta a:hover {
-      color: rgba(255, 255, 255, 0.65);
-    }
-
     /* --- Mobile --- */
     @media (max-width: 480px) {
       body { padding: 16px; }
@@ -285,10 +270,9 @@
       .ghost { width: 64px; height: 64px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      .terminal { font-size: 13px; }
+      .terminal { font-size: 11px; }
       footer { padding: 12px 16px; font-size: 12px; }
-      .cta { padding-top: 24px; }
-      .cta-download { font-size: 14px; padding: 11px 20px; }
+      .letter-plate { font-size: 10px; bottom: 12px; left: 16px; }
     }
   </style>
 </head>
@@ -350,25 +334,26 @@
     </div>
 
     <div class="terminal">
+      <!-- line-1: 14 chars: cd ~/ghostties -->
       <div class="line line-1">cd ~/ghostties</div>
-      <div class="line line-2">ghostties % install soon</div>
-      <div class="line line-3"><a class="gh-link" href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithDesign/ghostties</a></div>
+      <!-- line-2: 44 chars: https://github.com/SeanSmithDesign/ghostties -->
+      <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithDesign/ghostties</a></div>
+      <!-- line-3: 26 chars: - ghostties % install soon -->
+      <div class="line line-3">- ghostties % install soon</div>
+      <!-- line-4: 62 chars: + ghostties % v0.1.0-beta.12 · April 27, 2026 · [download now] -->
+      <div class="line line-4"><a href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.12/Ghostties.dmg" download>+ ghostties % v0.1.0-beta.12 &middot; April 27, 2026 &middot; [download now]</a></div>
     </div>
   </div>
 
-  <div class="cta">
-    <a class="cta-download" href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.12/Ghostties.dmg" download>
-      Download for macOS (Apple Silicon)
-    </a>
-    <div class="cta-meta">
-      v0.1.0-beta.12 · April 27, 2026<br>
-      macOS 14+, Apple Silicon. Beta — auto-updates via Sparkle.<br>
-      <a href="https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.12" target="_blank" rel="noopener">View release notes</a>
-    </div>
+  <!-- Bottom-left letter plate -->
+  <div class="letter-plate">
+    v0.1.0-beta.12 &middot; April 27, 2026<br>
+    macOS 13+ &middot; Apple Silicon &middot; Beta<br>
+    auto-updates via Sparkle
   </div>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy.html">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support.html">Support</a></span>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
     <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
       <svg viewBox="0 0 24 24" fill="currentColor">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
@@ -384,28 +369,28 @@
   <script>
     const scene = document.querySelector('.scene');
     const ghLink = document.querySelector('.gh-link');
-    const lines = document.querySelectorAll('.line');
+    const dlLink = document.querySelector('.line-4 a');
     let animating = false;
 
-    // Activate caret visibility at the right times
     function activateCarets() {
       const line1 = document.querySelector('.line-1');
       const line2 = document.querySelector('.line-2');
-      const line3 = document.querySelector('.line-3');
+      const line4 = document.querySelector('.line-4');
 
-      // Line 1 caret appears when it starts typing (1s), disappears when line 2 starts (4.2s)
+      // Line 1: caret appears at 1.0s, disappears when line 2 starts at 4.2s
       setTimeout(() => { line1.classList.add('caret-visible'); }, 1000);
       setTimeout(() => { line1.classList.remove('caret-visible'); }, 4200);
 
-      // Line 2 caret appears when it starts typing (4.2s), disappears when line 3 starts (5.5s)
+      // Line 2: caret appears at 4.2s, disappears when line 3 starts at 5.5s
       setTimeout(() => { line2.classList.add('caret-visible'); }, 4200);
       setTimeout(() => { line2.classList.remove('caret-visible'); }, 5500);
 
-      // Line 3 caret appears when it starts typing and stays (blinking)
-      setTimeout(() => { line3.classList.add('caret-visible'); }, 5500);
+      // Line 4: caret appears at 7.5s when typing starts
+      // Typing duration: 1.55s → typing ends at 9.05s, then blink stays on
+      setTimeout(() => { line4.classList.add('caret-visible'); }, 7500);
+      setTimeout(() => { line4.classList.add('caret-blink'); }, 9100);
     }
 
-    // Initial caret activation
     activateCarets();
 
     // Click to scatter
@@ -415,33 +400,33 @@
       scene.classList.add('scatter');
     });
 
-    // After scatter transition ends → restart the whole sequence
+    // After scatter → restart
     scene.addEventListener('transitionend', (e) => {
       if (!scene.classList.contains('scatter')) return;
-      // Only react to ghost transitions (not terminal opacity)
       if (!e.target.classList.contains('ghost')) return;
 
-      // Remove scatter
       scene.classList.remove('scatter');
 
-      // Clear caret classes
-      document.querySelector('.line-1').classList.remove('caret-visible');
-      document.querySelector('.line-2').classList.remove('caret-visible');
-      document.querySelector('.line-3').classList.remove('caret-visible');
+      // Clear caret state
+      const line1 = document.querySelector('.line-1');
+      const line2 = document.querySelector('.line-2');
+      const line4 = document.querySelector('.line-4');
+      line1.classList.remove('caret-visible');
+      line2.classList.remove('caret-visible');
+      line4.classList.remove('caret-visible', 'caret-blink');
 
-      // Reset animations: remove animate, force reflow, re-add
+      // Reset animations
       scene.classList.remove('animate');
       void scene.offsetWidth;
       scene.classList.add('animate');
 
-      // Re-activate carets for the new cycle
       activateCarets();
-
       animating = false;
     });
 
-    // Prevent scatter when clicking the GitHub link
+    // Don't scatter when clicking links
     ghLink.addEventListener('click', (e) => e.stopPropagation());
+    dlLink.addEventListener('click', (e) => e.stopPropagation());
   </script>
 </body>
 </html>

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Licenses — ghostties</title>
+  <link rel="icon" type="image/svg+xml" href="">
+  <script>
+    (function() {
+      var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];
+      var c = colors[Math.floor(Math.random() * colors.length)];
+      var svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
+        + '<path d="M4 2h8v1h2v1h1v10h-1v-1h-1v-1h-1v2h-1v-2h-1v1h-1v1h-1v-2h-1v2h-1v-1h-1v1H4v-1H3V3h1z" fill="' + c + '"/>'
+        + '<rect x="5" y="5" width="2" height="3" fill="white"/>'
+        + '<rect x="9" y="5" width="2" height="3" fill="white"/>'
+        + '<rect x="6" y="6" width="1" height="2" fill="#1a1a2e"/>'
+        + '<rect x="10" y="6" width="1" height="2" fill="#1a1a2e"/>'
+        + '</svg>';
+      var link = document.querySelector('link[rel="icon"]');
+      link.href = 'data:image/svg+xml;base64,' + btoa(svg);
+    })();
+  </script>
+  <meta name="description" content="Open-source licenses for Ghostties and its dependencies.">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    html, body {
+      min-height: 100%;
+      background: #1a1a2e;
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 64px 24px 96px;
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    .content {
+      width: 100%;
+      max-width: 600px;
+    }
+
+    .back {
+      display: inline-block;
+      margin-bottom: 40px;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.35);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .back:hover {
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    h1 {
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 12px;
+      color: #fff;
+    }
+
+    .lead {
+      font-size: 16px;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.65);
+      margin-bottom: 40px;
+    }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: rgba(255, 255, 255, 0.9);
+      margin-bottom: 8px;
+      margin-top: 48px;
+    }
+
+    h2:first-of-type {
+      margin-top: 0;
+    }
+
+    p {
+      font-size: 15px;
+      line-height: 1.65;
+      color: rgba(255, 255, 255, 0.65);
+      margin-bottom: 12px;
+    }
+
+    a {
+      color: rgba(255, 255, 255, 0.65);
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    a:hover {
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    pre {
+      font-family: 'SFMono-Regular', 'SF Mono', 'Fira Code', monospace;
+      font-size: 12px;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.45);
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 6px;
+      padding: 20px;
+      margin-top: 16px;
+      margin-bottom: 12px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .updated {
+      margin-top: 48px;
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.25);
+    }
+
+    footer {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 24px;
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.25);
+    }
+
+    footer a {
+      color: rgba(255, 255, 255, 0.25);
+      transition: color 0.2s;
+      text-decoration: none;
+    }
+
+    footer a:hover {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    footer svg {
+      width: 16px;
+      height: 16px;
+      display: block;
+    }
+
+    @media (max-width: 480px) {
+      body { padding: 48px 16px 88px; }
+      h1 { font-size: 22px; }
+      footer { padding: 12px 16px; font-size: 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="content">
+    <a class="back" href="/">&larr; ghostties</a>
+
+    <h1>Licenses</h1>
+    <p class="lead">Ghostties builds on several open-source projects. Their licenses are reproduced below.</p>
+
+    <h2>Ghostties</h2>
+    <p>Copyright &copy; 2026 <a href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">Sean Smith</a>. MIT License.</p>
+    <pre>MIT License
+
+Copyright (c) 2026 Sean Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+
+    <h2>Ghostty</h2>
+    <p>Ghostties is a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a> by Mitchell Hashimoto. Copyright &copy; 2024 Mitchell Hashimoto. MIT License.</p>
+    <pre>MIT License
+
+Copyright (c) 2024 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+
+    <h2>Chromium Embedded Framework (CEF)</h2>
+    <p>Ghostties includes CEF for the embedded browser panel. Copyright &copy; 2008&ndash;2024 Google LLC and contributors. <a href="https://bitbucket.org/chromiumembedded/cef" target="_blank" rel="noopener">BSD 3-Clause License.</a></p>
+    <pre>Copyright (c) 2008-2024 Marshall A. Greenblatt. Portions copyright (c) 2006-2009
+Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+Framework nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre>
+
+    <p class="updated">Last updated April 27, 2026</p>
+  </div>
+
+  <footer>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+      </svg>
+    </a>
+  </footer>
+</body>
+</html>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -190,9 +190,9 @@
     <p>None of this leaves your machine.</p>
 
     <h2>Network calls</h2>
-    <p>Ghostties checks for updates by fetching an XML file from GitHub Releases (<code>appcast-beta.xml</code> or <code>appcast-stable.xml</code>). That's the only network call the app makes on its own — no system info, no unique identifier, just an HTTP GET for the file.</p>
+    <p>Ghostties checks for updates by fetching <code>appcast-beta.xml</code> or <code>appcast-stable.xml</code> from <code>ghostties.org</code>. That's the only network call the app makes on its own — no system info, no unique identifier, just an HTTP GET for the file.</p>
     <p>You can turn updates off entirely with <code>auto-update = off</code> in your config.</p>
-    <p>One honest caveat: GitHub sees standard HTTP request metadata (your IP, user-agent) when the update check hits their servers. That's GitHub's logging, governed by <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">their privacy policy</a>, not ours.</p>
+    <p>The <code>ghostties.org</code> server (Vercel) may log standard HTTP request metadata per <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener">Vercel's privacy policy</a>.</p>
 
     <h2>The embedded browser</h2>
     <p>Ghostties includes a Chromium-based browser panel. It only loads URLs you type into it — no home page, no background fetches. Tabs default to <code>about:blank</code>.</p>
@@ -207,7 +207,7 @@
   </div>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy.html">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support.html">Support</a></span>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
     <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
       <svg viewBox="0 0 24 24" fill="currentColor">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,5 +1,11 @@
 {
   "buildCommand": "",
   "outputDirectory": ".",
-  "framework": null
+  "framework": null,
+  "rewrites": [
+    { "source": "/privacy", "destination": "/privacy.html" },
+    { "source": "/support", "destination": "/support.html" },
+    { "source": "/download", "destination": "/download.html" },
+    { "source": "/licenses", "destination": "/licenses.html" }
+  ]
 }


### PR DESCRIPTION
## Summary

- **Animation redesign:** 3-line terminal replaced with 4-line diff-style changelog. Red minus line fades in as context, then green plus line types out as the live download link. The entire green line is a clickable anchor pointing at the DMG. .cta button block removed.
- **Letter plate:** Fixed bottom-left plate showing version, macOS 13+, Apple Silicon, Beta, and Sparkle note. 11px SF Mono at 30% opacity.
- **Footer:** Added Licenses link to all pages. Footer links use clean /privacy, /support, /licenses paths backed by vercel.json rewrites.
- **New /download page:** Clean landing matching privacy/support aesthetic. Download button, system requirements, auto-update note, beta.10 caveat.
- **New /licenses page:** Full license text for Ghostties (MIT), Ghostty (MIT), and CEF (BSD 3-Clause).
- **vercel.json:** Added rewrites for /privacy, /support, /download, /licenses.
- **privacy.html:** Network calls now references ghostties.org/Vercel instead of GitHub. GitHub caveat paragraph removed.
- **support.html:** macOS 14 corrected to macOS 13 (Ventura). Ghostty/Ghostties known issue removed (fixed in beta.12).

## Test plan

- [ ] Open web/index.html — wait 10s for full 4-line sequence: white, white link, red minus, green plus with blinking caret. Ghosts vertically centered, no download button below scene.
- [ ] Click scene to scatter and restart animation
- [ ] Click line 2 GitHub URL — navigates without scatter
- [ ] Click green line 4 — triggers DMG download without scatter
- [ ] Letter plate visible bottom-left at fixed position
- [ ] Footer: copyright + Privacy + Support + Licenses on all pages
- [ ] Open web/download.html — download button, requirements, beta.10 note present
- [ ] Open web/licenses.html — three sections with full license text
- [ ] Open web/privacy.html — ghostties.org in network calls section
- [ ] Open web/support.html — macOS 13, no Ghostty permission known issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)