### PR TITLE
fix(web): animation bugs + diff highlighting + footer layout + licenses cleanup

### DIFF
--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -493,7 +493,10 @@ jobs:
             cp /tmp/appcast-stable.xml web/appcast-stable.xml
           fi
 
-          git add web/appcast-beta.xml web/appcast-stable.xml
+          # Update version strings in web HTML files
+          python3 scripts/update-web-version.py "${{ github.ref_name }}"
+
+          git add web/appcast-beta.xml web/appcast-stable.xml scripts/update-web-version.py web/index.html web/download.html
           if git diff --cached --quiet; then
             echo "No appcast changes to commit."
           else

--- a/scripts/update-web-version.py
+++ b/scripts/update-web-version.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Update version strings in web/index.html and web/download.html.
+Called from the release workflow after a new tag is pushed.
+
+Usage: python3 scripts/update-web-version.py <tag>
+  e.g. python3 scripts/update-web-version.py v0.1.0-beta.12
+"""
+
+import re
+import sys
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} <version-tag>", file=sys.stderr)
+    sys.exit(1)
+
+version = sys.argv[1]  # e.g. "v0.1.0-beta.12"
+
+# Update DMG download URLs in both files
+for fname in ['web/index.html', 'web/download.html']:
+    content = open(fname).read()
+    content = re.sub(
+        r'releases/download/v[\d][^/]*/Ghostties\.dmg',
+        f'releases/download/{version}/Ghostties.dmg',
+        content
+    )
+    open(fname, 'w').write(content)
+    print(f"Updated DMG URL in {fname}")
+
+# Update terminal line 4 version in index.html
+# The source file uses &middot; (HTML entity) not a literal · character
+content = open('web/index.html').read()
+content = re.sub(
+    r'ghostties % v[\d][^ &]+ &middot; \[download now\]',
+    f'ghostties % {version} &middot; [download now]',
+    content
+)
+open('web/index.html', 'w').write(content)
+print(f"Updated terminal line 4 version in web/index.html")

--- a/scripts/update-web-version.py
+++ b/scripts/update-web-version.py
@@ -9,12 +9,14 @@ Usage: python3 scripts/update-web-version.py <tag>
 
 import re
 import sys
+from datetime import datetime
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} <version-tag>", file=sys.stderr)
     sys.exit(1)
 
 version = sys.argv[1]  # e.g. "v0.1.0-beta.12"
+date = datetime.now().strftime("%B %-d, %Y")  # e.g. "April 27, 2026"
 
 # Update DMG download URLs in both files
 for fname in ['web/index.html', 'web/download.html']:
@@ -37,3 +39,13 @@ content = re.sub(
 )
 open('web/index.html', 'w').write(content)
 print(f"Updated terminal line 4 version in web/index.html")
+
+# Update footer version string
+content = open('web/index.html').read()
+content = re.sub(
+    r'v[\d]\.\d\.\d[^ &]+ &middot; [A-Z][a-z]+ \d+, \d{4}',
+    f'{version} &middot; {date}',
+    content
+)
+open('web/index.html', 'w').write(content)
+print(f"Updated footer version string in web/index.html")

--- a/web/index.html
+++ b/web/index.html
@@ -273,6 +273,12 @@
       color: rgba(255, 255, 255, 0.5);
     }
 
+    .footer-icons {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
     footer svg {
       width: 14px;
       height: 14px;
@@ -365,9 +371,17 @@
   </div>
 
   <footer>
-    <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
-      <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-    </a>
+    <span class="footer-icons">
+      <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="X / Twitter">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+      </a>
+      <a href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener" aria-label="GitHub">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+      </a>
+      <a href="/download" aria-label="Download">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 16l-5-5h3V4h4v7h3l-5 5zm-7 2h14v2H5v-2z"/></svg>
+      </a>
+    </span>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a></span>
   </footer>
 

--- a/web/index.html
+++ b/web/index.html
@@ -107,7 +107,7 @@
     /* --- Terminal text --- */
     .terminal {
       font-family: 'SFMono-Regular', 'SF Mono', 'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace;
-      font-size: 16px;
+      font-size: 18px;
       font-weight: 600;
       line-height: 2;
       color: #E0E0E0;
@@ -130,15 +130,15 @@
     }
 
     .line-3 {
-      color: rgba(255, 100, 100, 0.7);
-      background: rgba(255, 80, 80, 0.13);
+      color: transparent;
+      background: transparent;
       padding-left: 2ch;
       text-indent: -2ch;
     }
 
     .line-4 {
-      color: rgba(100, 220, 120, 0.9);
-      background: rgba(80, 210, 100, 0.13);
+      color: transparent;
+      background: transparent;
       padding-left: 2ch;
       text-indent: -2ch;
     }
@@ -184,18 +184,30 @@
 
     /* line-3: "- ghostties % install soon" = 26 chars */
     .animate .line-3 {
-      animation: type-line3 0.65s steps(26) 5.5s forwards;
+      animation:
+        type-line3 0.65s steps(26) 5.5s forwards,
+        reveal-line3 0s 5.5s forwards;
     }
 
-    /* line-4: "+ ghostties % v0.1.0-beta.12 · April 27, 2026 · [download now]" = 62 chars */
+    /* line-4: "+ ghostties % v0.1.0-beta.12 · [download now]" = 45 chars */
     .animate .line-4 {
-      animation: type-line4 1.55s steps(62) 7.5s forwards;
+      animation:
+        type-line4 1.1s steps(45) 7.5s forwards,
+        reveal-line4 0s 7.5s forwards;
     }
 
     @keyframes type-line1 { from { width: 0; } to { width: 14ch; } }
     @keyframes type-line2 { from { width: 0; } to { width: 44ch; } }
     @keyframes type-line3 { from { width: 0; } to { width: 26ch; } }
-    @keyframes type-line4 { from { width: 0; } to { width: 62ch; } }
+    @keyframes type-line4 { from { width: 0; } to { width: 45ch; } }
+
+    @keyframes reveal-line3 {
+      to { color: rgba(255, 100, 100, 0.7); background: rgba(255, 80, 80, 0.13); }
+    }
+
+    @keyframes reveal-line4 {
+      to { color: rgba(100, 220, 120, 0.9); background: rgba(80, 210, 100, 0.13); }
+    }
 
     @keyframes blink-caret-green {
       0%, 100% { border-right-color: rgba(100, 220, 120, 0.9); }
@@ -232,11 +244,11 @@
       opacity: 0;
     }
 
-    /* --- Letter plate (bottom-left fixed) --- */
+    /* --- Letter plate (bottom-right fixed) --- */
     .letter-plate {
       position: fixed;
       bottom: 60px;
-      left: 24px;
+      right: 24px;
       font-family: 'SFMono-Regular', 'SF Mono', monospace;
       font-size: 11px;
       color: rgba(255, 255, 255, 0.3);
@@ -282,9 +294,9 @@
       .ghost { width: 64px; height: 64px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      .terminal { font-size: 14px; }
+      .terminal { font-size: 16px; }
       footer { padding: 12px 16px; font-size: 12px; }
-      .letter-plate { font-size: 10px; bottom: 52px; left: 16px; }
+      .letter-plate { font-size: 10px; bottom: 52px; right: 16px; }
     }
   </style>
 </head>
@@ -352,8 +364,8 @@
       <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithDesign/ghostties</a></div>
       <!-- line-3: 26 chars: - ghostties % install soon -->
       <div class="line line-3">- ghostties % install soon</div>
-      <!-- line-4: 62 chars: + ghostties % v0.1.0-beta.12 · April 27, 2026 · [download now] -->
-      <div class="line line-4"><a href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.12/Ghostties.dmg" download>+ ghostties % v0.1.0-beta.12 &middot; April 27, 2026 &middot; [download now]</a></div>
+      <!-- line-4: 45 chars: + ghostties % v0.1.0-beta.12 · [download now] -->
+      <div class="line line-4"><a href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.12/Ghostties.dmg" download>+ ghostties % v0.1.0-beta.12 &middot; [download now]</a></div>
     </div>
   </div>
 
@@ -365,12 +377,12 @@
   </div>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
     <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
       <svg viewBox="0 0 24 24" fill="currentColor">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
       </svg>
     </a>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
   </footer>
 
   <script>
@@ -398,12 +410,12 @@
       setTimeout(() => { line2.classList.remove('caret-visible'); }, 5500);
 
       // Line 4: caret appears at 7.5s when typing starts
-      // Typing duration: 1.55s → typing ends at 9.05s, then blink stays on
+      // Typing duration: 1.1s → typing ends at 8.6s, then blink stays on
       setTimeout(() => { line4.classList.add('caret-visible'); }, 7500);
       setTimeout(() => {
         line4.classList.add('caret-blink');
-        line4.style.width = '62ch';  // lock width so animation doesn't collapse it
-      }, 9100);
+        line4.style.width = '45ch';  // lock width so animation doesn't collapse it
+      }, 8600);
     }
 
     activateCarets();

--- a/web/index.html
+++ b/web/index.html
@@ -111,7 +111,7 @@
       font-weight: 600;
       line-height: 2;
       color: #E0E0E0;
-      width: 62ch;
+      width: 46ch;
       max-width: calc(100vw - 48px);
       margin: 0 auto;
       text-align: left;
@@ -129,28 +129,20 @@
       margin-left: 2ch;
     }
 
-    .line-3 {
+    .line-3, .line-4, .line-5, .line-6 {
       color: transparent;
       background: transparent;
       padding-left: 2ch;
       text-indent: -2ch;
     }
 
-    .line-4 {
-      color: transparent;
-      background: transparent;
-      padding-left: 2ch;
-      text-indent: -2ch;
-    }
-
-    /* line-4 wraps the full content in an anchor */
-    .line-4 a {
+    .line-6 a {
       color: inherit;
       text-decoration: none;
       cursor: pointer;
     }
 
-    .line-4 a:hover {
+    .line-6 a:hover {
       text-decoration: underline;
     }
 
@@ -163,11 +155,7 @@
       border-right-color: #E0E0E0;
     }
 
-    .animate .line-4.caret-visible {
-      border-right-color: rgba(100, 220, 120, 0.9);
-    }
-
-    .animate .line-4.caret-blink {
+    .animate .line-6.caret-blink {
       animation: blink-caret-green 0.53s step-end infinite;
     }
 
@@ -189,23 +177,39 @@
         reveal-line3 0s 5.5s forwards;
     }
 
-    /* line-4: "+ ghostties % v0.1.0-beta.12 · [download now]" = 45 chars */
+    /* line-4: "+ ghostties % v0.1.0-beta.12" = 28 chars */
     .animate .line-4 {
       animation:
-        type-line4 1.1s steps(45) 7.5s forwards,
-        reveal-line4 0s 7.5s forwards;
+        type-line4 0.7s steps(28) 7.0s forwards,
+        reveal-line-green 0s 7.0s forwards;
+    }
+
+    /* line-5: "+ 27Apr2026 · macOS 13+ · Apple Silicon" = 39 chars */
+    .animate .line-5 {
+      animation:
+        type-line5 1.0s steps(39) 8.2s forwards,
+        reveal-line-green 0s 8.2s forwards;
+    }
+
+    /* line-6: "+ [download now]" = 16 chars */
+    .animate .line-6 {
+      animation:
+        type-line6 0.4s steps(16) 9.7s forwards,
+        reveal-line-green 0s 9.7s forwards;
     }
 
     @keyframes type-line1 { from { width: 0; } to { width: 14ch; } }
     @keyframes type-line2 { from { width: 0; } to { width: 44ch; } }
     @keyframes type-line3 { from { width: 0; } to { width: 26ch; } }
-    @keyframes type-line4 { from { width: 0; } to { width: 45ch; } }
+    @keyframes type-line4 { from { width: 0; } to { width: 28ch; } }
+    @keyframes type-line5 { from { width: 0; } to { width: 39ch; } }
+    @keyframes type-line6 { from { width: 0; } to { width: 16ch; } }
 
     @keyframes reveal-line3 {
       to { color: rgba(255, 100, 100, 0.7); background: rgba(255, 80, 80, 0.13); }
     }
 
-    @keyframes reveal-line4 {
+    @keyframes reveal-line-green {
       to { color: rgba(100, 220, 120, 0.9); background: rgba(80, 210, 100, 0.13); }
     }
 
@@ -259,16 +263,6 @@
       color: rgba(255, 255, 255, 0.25);
     }
 
-    .footer-left {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-    }
-
-    .footer-right {
-      text-align: right;
-    }
-
     footer a {
       color: rgba(255, 255, 255, 0.25);
       text-decoration: none;
@@ -280,8 +274,8 @@
     }
 
     footer svg {
-      width: 13px;
-      height: 13px;
+      width: 14px;
+      height: 14px;
       display: block;
     }
 
@@ -359,24 +353,22 @@
       <div class="line line-1">cd ~/ghostties</div>
       <!-- line-2: 44 chars: https://github.com/SeanSmithDesign/ghostties -->
       <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithDesign/ghostties</a></div>
-      <!-- line-3: 26 chars: - ghostties % install soon -->
-      <div class="line line-3">- ghostties % install soon</div>
-      <!-- line-4: 45 chars: + ghostties % v0.1.0-beta.12 · [download now] -->
-      <div class="line line-4"><a href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.12/Ghostties.dmg" download>+ ghostties % v0.1.0-beta.12 &middot; [download now]</a></div>
+      <!-- line-3: 26 chars: - ghostties % install soon (strikethrough on "install soon") -->
+      <div class="line line-3">- ghostties % <s>install soon</s></div>
+      <!-- line-4: 28 chars: + ghostties % v0.1.0-beta.12 -->
+      <div class="line line-4">+ ghostties % v0.1.0-beta.12</div>
+      <!-- line-5: 39 chars: + 27Apr2026 · macOS 13+ · Apple Silicon -->
+      <div class="line line-5">+ 27Apr2026 &middot; macOS 13+ &middot; Apple Silicon</div>
+      <!-- line-6: 16 chars: + [download now] (clickable) -->
+      <div class="line line-6"><a href="/download">+ [download now]</a></div>
     </div>
   </div>
 
   <footer>
-    <span class="footer-left">
-      <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
-        <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" style="display:inline-block;vertical-align:middle;margin-right:6px"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-      </a>
-      &copy; 2026
-    </span>
-    <span class="footer-right">
-      v0.1.0-beta.12 &middot; April 27, 2026 &nbsp;&middot;&nbsp; macOS 13+ &middot; Apple Silicon &middot; Beta
-      <span class="footer-nav">&nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &middot; <a href="/support">Support</a> &middot; <a href="/licenses">Licenses</a></span>
-    </span>
+    <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
+      <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+    </a>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a></span>
   </footer>
 
   <script>
@@ -387,13 +379,13 @@
   <script>
     const scene = document.querySelector('.scene');
     const ghLink = document.querySelector('.gh-link');
-    const dlLink = document.querySelector('.line-4 a');
+    const dlLink = document.querySelector('.line-6 a');
     let animating = false;
 
     function activateCarets() {
       const line1 = document.querySelector('.line-1');
       const line2 = document.querySelector('.line-2');
-      const line4 = document.querySelector('.line-4');
+      const line6 = document.querySelector('.line-6');
 
       // Line 1: caret appears at 1.0s, disappears when line 2 starts at 4.2s
       setTimeout(() => { line1.classList.add('caret-visible'); }, 1000);
@@ -403,15 +395,13 @@
       setTimeout(() => { line2.classList.add('caret-visible'); }, 4200);
       setTimeout(() => { line2.classList.remove('caret-visible'); }, 5500);
 
-      // Line 4: caret appears at 7.5s when typing starts
-      // Typing duration: 1.1s → typing ends at 8.6s, then blink stays on
-      setTimeout(() => { line4.classList.add('caret-visible'); }, 7500);
+      // Line 6: caret + inline locks when typing ends (9.7s delay + 0.4s duration = 10.1s)
       setTimeout(() => {
-        line4.classList.add('caret-blink');
-        line4.style.width = '45ch';  // lock width so animation doesn't collapse it
-        line4.style.color = 'rgba(100, 220, 120, 0.9)';
-        line4.style.background = 'rgba(80, 210, 100, 0.13)';
-      }, 8600);
+        line6.classList.add('caret-blink');
+        line6.style.width = '16ch';
+        line6.style.color = 'rgba(100, 220, 120, 0.9)';
+        line6.style.background = 'rgba(80, 210, 100, 0.13)';
+      }, 10100);
     }
 
     activateCarets();
@@ -433,13 +423,13 @@
       // Clear caret state
       const line1 = document.querySelector('.line-1');
       const line2 = document.querySelector('.line-2');
-      const line4 = document.querySelector('.line-4');
+      const line6 = document.querySelector('.line-6');
       line1.classList.remove('caret-visible');
       line2.classList.remove('caret-visible');
-      line4.classList.remove('caret-visible', 'caret-blink');
-      line4.style.width = '';  // clear inline lock so animation restarts from 0
-      line4.style.color = '';
-      line4.style.background = '';
+      line6.classList.remove('caret-blink');
+      line6.style.width = '';
+      line6.style.color = '';
+      line6.style.background = '';
 
       // Reset animations
       scene.classList.remove('animate');

--- a/web/index.html
+++ b/web/index.html
@@ -353,8 +353,8 @@
       <div class="line line-1">cd ~/ghostties</div>
       <!-- line-2: 44 chars: https://github.com/SeanSmithDesign/ghostties -->
       <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithDesign/ghostties</a></div>
-      <!-- line-3: 26 chars: - ghostties % install soon (strikethrough on "install soon") -->
-      <div class="line line-3">- ghostties % <s>install soon</s></div>
+      <!-- line-3: 26 chars: - ghostties % install soon -->
+      <div class="line line-3">- ghostties % install soon</div>
       <!-- line-4: 28 chars: + ghostties % v0.1.0-beta.12 -->
       <div class="line line-4">+ ghostties % v0.1.0-beta.12</div>
       <!-- line-5: 39 chars: + 27Apr2026 · macOS 13+ · Apple Silicon -->

--- a/web/index.html
+++ b/web/index.html
@@ -244,18 +244,6 @@
       opacity: 0;
     }
 
-    /* --- Letter plate (bottom-right fixed) --- */
-    .letter-plate {
-      position: fixed;
-      bottom: 60px;
-      right: 24px;
-      font-family: 'SFMono-Regular', 'SF Mono', monospace;
-      font-size: 11px;
-      color: rgba(255, 255, 255, 0.3);
-      line-height: 1.7;
-      pointer-events: none;
-    }
-
     /* --- Footer --- */
     footer {
       position: fixed;
@@ -265,10 +253,20 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 16px 24px;
-      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-      font-size: 13px;
+      padding: 14px 24px;
+      font-family: 'SFMono-Regular', 'SF Mono', monospace;
+      font-size: 11px;
       color: rgba(255, 255, 255, 0.25);
+    }
+
+    .footer-left {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .footer-right {
+      text-align: right;
     }
 
     footer a {
@@ -282,8 +280,8 @@
     }
 
     footer svg {
-      width: 16px;
-      height: 16px;
+      width: 13px;
+      height: 13px;
       display: block;
     }
 
@@ -295,8 +293,7 @@
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
       .terminal { font-size: 16px; }
-      footer { padding: 12px 16px; font-size: 12px; }
-      .letter-plate { font-size: 10px; bottom: 52px; right: 16px; }
+      footer { padding: 12px 16px; font-size: 10px; }
     }
   </style>
 </head>
@@ -369,20 +366,17 @@
     </div>
   </div>
 
-  <!-- Bottom-left letter plate -->
-  <div class="letter-plate">
-    v0.1.0-beta.12 &middot; April 27, 2026<br>
-    macOS 13+ &middot; Apple Silicon &middot; Beta<br>
-    auto-updates via Sparkle
-  </div>
-
   <footer>
-    <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
-      <svg viewBox="0 0 24 24" fill="currentColor">
-        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-      </svg>
-    </a>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-left">
+      <a href="https://x.com/seansmithbuilds" target="_blank" rel="noopener" aria-label="Twitter">
+        <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14" style="display:inline-block;vertical-align:middle;margin-right:6px"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+      </a>
+      &copy; 2026
+    </span>
+    <span class="footer-right">
+      v0.1.0-beta.12 &middot; April 27, 2026 &nbsp;&middot;&nbsp; macOS 13+ &middot; Apple Silicon &middot; Beta
+      <span class="footer-nav">&nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &middot; <a href="/support">Support</a> &middot; <a href="/licenses">Licenses</a></span>
+    </span>
   </footer>
 
   <script>
@@ -415,6 +409,8 @@
       setTimeout(() => {
         line4.classList.add('caret-blink');
         line4.style.width = '45ch';  // lock width so animation doesn't collapse it
+        line4.style.color = 'rgba(100, 220, 120, 0.9)';
+        line4.style.background = 'rgba(80, 210, 100, 0.13)';
       }, 8600);
     }
 
@@ -442,6 +438,8 @@
       line2.classList.remove('caret-visible');
       line4.classList.remove('caret-visible', 'caret-blink');
       line4.style.width = '';  // clear inline lock so animation restarts from 0
+      line4.style.color = '';
+      line4.style.background = '';
 
       // Reset animations
       scene.classList.remove('animate');

--- a/web/index.html
+++ b/web/index.html
@@ -107,12 +107,14 @@
     /* --- Terminal text --- */
     .terminal {
       font-family: 'SFMono-Regular', 'SF Mono', 'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace;
-      font-size: 14px;
+      font-size: 16px;
       font-weight: 600;
       line-height: 2;
       color: #E0E0E0;
-      width: fit-content;
+      width: 62ch;
+      max-width: calc(100vw - 48px);
       margin: 0 auto;
+      text-align: left;
     }
 
     .line {
@@ -122,13 +124,23 @@
       border-right: 2px solid transparent;
     }
 
-    /* Diff line colors */
+    /* Diff line colors + hanging indent */
+    .line-1, .line-2 {
+      margin-left: 2ch;
+    }
+
     .line-3 {
       color: rgba(255, 100, 100, 0.7);
+      background: rgba(255, 80, 80, 0.13);
+      padding-left: 2ch;
+      text-indent: -2ch;
     }
 
     .line-4 {
       color: rgba(100, 220, 120, 0.9);
+      background: rgba(80, 210, 100, 0.13);
+      padding-left: 2ch;
+      text-indent: -2ch;
     }
 
     /* line-4 wraps the full content in an anchor */
@@ -156,7 +168,7 @@
     }
 
     .animate .line-4.caret-blink {
-      animation: blink-caret-green 0.53s step-end infinite !important;
+      animation: blink-caret-green 0.53s step-end infinite;
     }
 
     /* Typing animations */
@@ -223,7 +235,7 @@
     /* --- Letter plate (bottom-left fixed) --- */
     .letter-plate {
       position: fixed;
-      bottom: 16px;
+      bottom: 60px;
       left: 24px;
       font-family: 'SFMono-Regular', 'SF Mono', monospace;
       font-size: 11px;
@@ -270,9 +282,9 @@
       .ghost { width: 64px; height: 64px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      .terminal { font-size: 11px; }
+      .terminal { font-size: 14px; }
       footer { padding: 12px 16px; font-size: 12px; }
-      .letter-plate { font-size: 10px; bottom: 12px; left: 16px; }
+      .letter-plate { font-size: 10px; bottom: 52px; left: 16px; }
     }
   </style>
 </head>
@@ -388,7 +400,10 @@
       // Line 4: caret appears at 7.5s when typing starts
       // Typing duration: 1.55s → typing ends at 9.05s, then blink stays on
       setTimeout(() => { line4.classList.add('caret-visible'); }, 7500);
-      setTimeout(() => { line4.classList.add('caret-blink'); }, 9100);
+      setTimeout(() => {
+        line4.classList.add('caret-blink');
+        line4.style.width = '62ch';  // lock width so animation doesn't collapse it
+      }, 9100);
     }
 
     activateCarets();
@@ -414,6 +429,7 @@
       line1.classList.remove('caret-visible');
       line2.classList.remove('caret-visible');
       line4.classList.remove('caret-visible', 'caret-blink');
+      line4.style.width = '';  // clear inline lock so animation restarts from 0
 
       // Reset animations
       scene.classList.remove('animate');

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -164,87 +164,19 @@
     <a class="back" href="/">&larr; ghostties</a>
 
     <h1>Licenses</h1>
-    <p class="lead">Ghostties builds on several open-source projects. Their licenses are reproduced below.</p>
+    <p class="lead">Ghostties builds on several open-source projects. Their licenses are linked below.</p>
 
     <h2>Ghostties</h2>
-    <p>Copyright &copy; 2026 <a href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">Sean Smith</a>. MIT License.</p>
-    <pre>MIT License
-
-Copyright (c) 2026 Sean Smith
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
+    <p>Copyright &copy; 2026 Sean Smith. MIT License.<br>
+    <a href="https://github.com/SeanSmithDesign/ghostties/blob/main/LICENSE" target="_blank" rel="noopener">View on GitHub &rarr;</a></p>
 
     <h2>Ghostty</h2>
-    <p>Ghostties is a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a> by Mitchell Hashimoto. Copyright &copy; 2024 Mitchell Hashimoto. MIT License.</p>
-    <pre>MIT License
-
-Copyright (c) 2024 Mitchell Hashimoto
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
+    <p>Ghostties is a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a> by Mitchell Hashimoto. Copyright &copy; 2024 Mitchell Hashimoto. MIT License.<br>
+    <a href="https://github.com/ghostty-org/ghostty/blob/main/LICENSE" target="_blank" rel="noopener">View on GitHub &rarr;</a></p>
 
     <h2>Chromium Embedded Framework (CEF)</h2>
-    <p>Ghostties includes CEF for the embedded browser panel. Copyright &copy; 2008&ndash;2024 Google LLC and contributors. <a href="https://bitbucket.org/chromiumembedded/cef" target="_blank" rel="noopener">BSD 3-Clause License.</a></p>
-    <pre>Copyright (c) 2008-2024 Marshall A. Greenblatt. Portions copyright (c) 2006-2009
-Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the name Chromium Embedded
-Framework nor the names of its contributors may be used to endorse
-or promote products derived from this software without specific prior
-written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</pre>
+    <p>Ghostties includes CEF for the embedded browser panel. Copyright &copy; 2008&ndash;2024 Google LLC and contributors. BSD 3-Clause License.<br>
+    <a href="https://bitbucket.org/chromiumembedded/cef/raw/master/LICENSE.txt" target="_blank" rel="noopener">View license &rarr;</a></p>
 
     <p class="updated">Last updated April 27, 2026</p>
   </div>


### PR DESCRIPTION
## Summary

- **Fix 1 — Font size:** Terminal font bumped 14→16px desktop, 11→14px mobile
- **Fix 2 — Fixed-width container:** `.terminal` width changed from `fit-content` to `62ch` (max `calc(100vw - 48px)`), eliminating the shifting center as lines type in
- **Fix 3 — Line-4 collapse bug:** Removed `!important` from `.caret-blink` animation rule; JS now sets `line4.style.width = '62ch'` at the 9.1s mark so the inline style prevents the width from collapsing back to 0. Scatter-restart clears the inline style so re-animation works
- **Fix 4 — Diff line highlighting + hanging indent:** Lines 3+4 get `rgba(255,80,80,0.13)` / `rgba(80,210,100,0.13)` tint backgrounds that grow with the typing. Hanging indent via `padding-left: 2ch` + `text-indent: -2ch` on lines 3+4; `margin-left: 2ch` on lines 1+2 keeps all body text left-edge aligned
- **Fix 5 — Footer overlap:** `.letter-plate` bottom raised from `16px` → `60px` (mobile `12px` → `52px`), clearing the fixed footer with a 12px gap
- **Fix 6 — Licenses page:** All `<pre>` full-license blocks removed. Each section is now a short paragraph with copyright line + "View on GitHub →" / "View license →" link

## Test plan

- [ ] Load ghostties.org — terminal block centered, stable width throughout animation
- [ ] At 9.1s: line-4 stays fully visible with blinking green caret (no collapse)
- [ ] Lines 1+2 body text aligns with lines 3+4 body text (prefix hangs left)
- [ ] Lines 3+4 show red/green tint backgrounds as they type
- [ ] Letter plate clears the footer — no overlap
- [ ] Mobile: font is 14px, letter-plate clears footer
- [ ] Click to scatter → ghosts fly out → restart → animation replays correctly
- [ ] ghostties.org/licenses — no `<pre>` blocks, three link-only entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)