### PR TITLE
fix(sparkle): skip updater start in Debug builds

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -262,8 +262,10 @@ class AppDelegate: NSObject,
         // Initial config loading
         ghosttyConfigDidChange(config: ghostty.config)
 
-        // Start our update checker.
+        // Start our update checker (skip in Debug builds to avoid Sparkle key validation errors).
+        #if !DEBUG
         updateController.startUpdater()
+        #endif
 
         // Register our service provider. This must happen after everything is initialized.
         NSApp.servicesProvider = ServiceProvider()


### PR DESCRIPTION
Sparkle validation of the placeholder EdDSA key toasts an error on every Dev build launch. Guard startUpdater() with #if !DEBUG so Debug builds never hit Sparkle's key check.