### PR TITLE
fix(ui): fullscreen icon layout, canvas corner radius, shadow tokens

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -262,8 +262,10 @@ class AppDelegate: NSObject,
         // Initial config loading
         ghosttyConfigDidChange(config: ghostty.config)
 
-        // Start our update checker.
+        // Start our update checker (skip in Debug builds to avoid Sparkle key validation errors).
+        #if !DEBUG
         updateController.startUpdater()
+        #endif
 
         // Register our service provider. This must happen after everything is initialized.
         NSApp.servicesProvider = ServiceProvider()

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -35,6 +35,12 @@ enum WorkspaceLayout {
     /// Returns nil before the window is on-screen or if the button isn't available.
     /// Call from NSView.layout() or window-delegate hooks, not from init.
     static func titlebarRowTopAnchorConstant(in view: NSView) -> CGFloat? {
+        // In fullscreen, there is no titlebar row — content extends edge-to-edge.
+        // Return 0 so toolbar buttons park at the top edge (they will be hidden
+        // by the fullscreen chrome).
+        if view.window?.styleMask.contains(.fullScreen) == true {
+            return 0
+        }
         guard let win = view.window,
               let close = win.standardWindowButton(.closeButton),
               close.window === win else { return nil }
@@ -51,6 +57,18 @@ enum WorkspaceLayout {
 
     /// Corner radius on the floating terminal panel (all four corners).
     static let terminalCornerRadius: CGFloat = 12
+
+    /// Shadow color applied to canvas shadow hosts (terminal + browser cards).
+    static let canvasShadowColor: CGColor = NSColor.black.cgColor
+
+    /// Shadow blur radius applied to canvas shadow hosts.
+    static let canvasShadowRadius: CGFloat = 8
+
+    /// Shadow offset applied to canvas shadow hosts (slight downward cast).
+    static let canvasShadowOffset: CGSize = CGSize(width: 0, height: -2)
+
+    /// Shadow opacity applied to canvas shadow hosts when the card is visible.
+    static let canvasShadowOpacity: Float = 0.15
 
     /// Inset around the terminal panel when sidebar is visible (floating card effect).
     /// The design uses 8pt on all four sides (top, bottom, left, right).

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -323,6 +323,7 @@ class WorkspaceViewContainer: NSView {
         // Clean up previous window's observers (handles view moving between windows).
         NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: NSWindow.didBecomeKeyNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSWindow.willEnterFullScreenNotification, object: fullScreenObservedWindow)
         NotificationCenter.default.removeObserver(self, name: NSWindow.didEnterFullScreenNotification, object: fullScreenObservedWindow)
         NotificationCenter.default.removeObserver(self, name: NSWindow.didExitFullScreenNotification, object: fullScreenObservedWindow)
 
@@ -360,6 +361,14 @@ class WorkspaceViewContainer: NSView {
         )
 
         // Re-measure toolbar row when fullscreen transitions change the titlebar geometry.
+        // willEnter fires before AppKit takes a snapshot for the animation, preventing
+        // a single-frame glitch during the enter-fullscreen transition.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowDidEnterOrExitFullScreen),
+            name: NSWindow.willEnterFullScreenNotification,
+            object: window
+        )
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(windowDidEnterOrExitFullScreen),
@@ -637,7 +646,7 @@ class WorkspaceViewContainer: NSView {
         }
 
         // Shadow + corner radius (non-animatable).
-        browserShadowHost.layer?.shadowOpacity = visible ? 0.15 : 0
+        browserShadowHost.layer?.shadowOpacity = visible ? WorkspaceLayout.canvasShadowOpacity : 0
 
         invalidateIntrinsicContentSize()
     }
@@ -907,24 +916,24 @@ class WorkspaceViewContainer: NSView {
         switch newMode {
         case .pinned:
             terminalContainer.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
-            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            terminalShadowHost.layer?.shadowOpacity = 0.15
+            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+            terminalShadowHost.layer?.shadowOpacity = WorkspaceLayout.canvasShadowOpacity
             terminalShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
             terminalShadowHost.layer?.backgroundColor = cardBackgroundCGColor
             browserShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
             browserShadowHost.layer?.backgroundColor = browserCardBackgroundCGColor
-            browserShadowHost.layer?.shadowOpacity = isBrowserVisible ? 0.15 : 0
+            browserShadowHost.layer?.shadowOpacity = isBrowserVisible ? WorkspaceLayout.canvasShadowOpacity : 0
             layer?.backgroundColor = canvasBackgroundCGColor
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .closed:
             terminalContainer.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
-            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            terminalShadowHost.layer?.shadowOpacity = 0.15
+            terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+            terminalShadowHost.layer?.shadowOpacity = WorkspaceLayout.canvasShadowOpacity
             terminalShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
             terminalShadowHost.layer?.backgroundColor = cardBackgroundCGColor
             browserShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
             browserShadowHost.layer?.backgroundColor = browserCardBackgroundCGColor
-            browserShadowHost.layer?.shadowOpacity = isBrowserVisible ? 0.15 : 0
+            browserShadowHost.layer?.shadowOpacity = isBrowserVisible ? WorkspaceLayout.canvasShadowOpacity : 0
             layer?.backgroundColor = canvasBackgroundCGColor
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .overlay:
@@ -1209,18 +1218,16 @@ class WorkspaceViewContainer: NSView {
         terminalContainer.wantsLayer = true
         terminalContainer.layer?.cornerRadius = hasCardInset ? WorkspaceLayout.terminalCornerRadius : 0
         terminalContainer.layer?.cornerCurve = .continuous
-        terminalContainer.layer?.maskedCorners = hasCardInset
-            ? [.layerMinXMinYCorner, .layerMaxXMinYCorner]  // top corners only (MinY = bottom in CA coords)
-            : [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         terminalContainer.layer?.masksToBounds = true
 
         // Configure shadow on the host layer. Must happen after addSubview so the
         // layer exists (wantsLayer in a property closure may not create it in time).
         terminalShadowHost.wantsLayer = true
-        terminalShadowHost.layer?.shadowColor = NSColor.black.cgColor
-        terminalShadowHost.layer?.shadowOpacity = hasCardInset ? 0.15 : 0
-        terminalShadowHost.layer?.shadowRadius = 8
-        terminalShadowHost.layer?.shadowOffset = CGSize(width: 0, height: -2)
+        terminalShadowHost.layer?.shadowColor = WorkspaceLayout.canvasShadowColor
+        terminalShadowHost.layer?.shadowOpacity = hasCardInset ? WorkspaceLayout.canvasShadowOpacity : 0
+        terminalShadowHost.layer?.shadowRadius = WorkspaceLayout.canvasShadowRadius
+        terminalShadowHost.layer?.shadowOffset = WorkspaceLayout.canvasShadowOffset
 
         // Card background behind the title bar region. No masksToBounds — shadow
         // must render outside the layer bounds.
@@ -1230,10 +1237,10 @@ class WorkspaceViewContainer: NSView {
 
         // Browser shadow host — identical layer config to terminal shadow host.
         browserShadowHost.wantsLayer = true
-        browserShadowHost.layer?.shadowColor = NSColor.black.cgColor
+        browserShadowHost.layer?.shadowColor = WorkspaceLayout.canvasShadowColor
         browserShadowHost.layer?.shadowOpacity = 0  // hidden initially
-        browserShadowHost.layer?.shadowRadius = 8
-        browserShadowHost.layer?.shadowOffset = CGSize(width: 0, height: -2)
+        browserShadowHost.layer?.shadowRadius = WorkspaceLayout.canvasShadowRadius
+        browserShadowHost.layer?.shadowOffset = WorkspaceLayout.canvasShadowOffset
         browserShadowHost.layer?.cornerRadius = hasCardInset ? WorkspaceLayout.terminalCornerRadius : 0
         browserShadowHost.layer?.cornerCurve = .continuous
         browserShadowHost.layer?.backgroundColor = hasCardInset ? browserCardBackgroundCGColor : nil

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -569,6 +569,16 @@ class TerminalWindow: NSWindow {
 
             let backgroundColor = preferredBackgroundColor ?? NSColor(surfaceConfig.backgroundColor)
             self.backgroundColor = backgroundColor.withAlphaComponent(1)
+
+            // MARK: - Ghostties fork fence (titlebar bg sync)
+            // In workspace mode, the window background shows through the transparent titlebar.
+            // Override to the canvas background so the titlebar strip matches the canvas.
+            if self.contentView is WorkspaceViewContainer {
+                let isDark = self.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                self.backgroundColor = isDark
+                    ? WorkspaceLayout.canvasBackgroundDark
+                    : WorkspaceLayout.canvasBackgroundLight
+            }
         }
     }
 


### PR DESCRIPTION
Three UI fixes from 2026-05-04 smoke test:

- **Bug A (fullscreen icons):** WorkspaceLayout returns 0 for titlebarRowTopAnchorConstant in fullscreen; WorkspaceViewContainer now also observes windowWillEnterFullScreenNotification to prevent a transition-frame glitch.
- **Bug C (corner radius):** terminalContainer now masks all four corners, matching the shadow host. Was masking top-only, leaving square bottom corners visible at small window sizes.
- **Bug D (shadow tokens):** Extracted canvasShadow* tokens to WorkspaceLayout and referenced from all five shadow-assignment sites, preventing drift between terminal and browser canvas shadows.