### PR TITLE
feat(ui): source-dot tokens + honest sidebar footer

### DIFF
--- a/macos/Sources/Features/Ghostties/GraveyardRowExpansionState.swift
+++ b/macos/Sources/Features/Ghostties/GraveyardRowExpansionState.swift
@@ -82,15 +82,4 @@ struct GraveyardExpansionContent {
 }
 
 // MARK: - TaskSource display name
-
-private extension TaskSource {
-    var displayName: String {
-        switch self {
-        case .linear:  return "linear"
-        case .github:  return "github"
-        case .sentry:  return "sentry"
-        case .shell:   return "shell"
-        case .unknown: return "unknown"
-        }
-    }
-}
+// `displayName` is defined on `TaskSource` in `TaskModel.swift`.

--- a/macos/Sources/Features/Ghostties/TaskModel.swift
+++ b/macos/Sources/Features/Ghostties/TaskModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GhosttiesCore
+import SwiftUI
 
 /// Task priority levels. Bridged directly from `GhosttiesCore.TaskPriority`
 /// so the raw values, `Codable` conformance, and `CaseIterable` conformance
@@ -50,6 +51,28 @@ enum TaskSource: String, Codable {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)
         self = TaskSource(rawValue: raw.lowercased()) ?? .unknown
+    }
+
+    /// Human-readable label for the source. Used in chip text and tooltips.
+    var displayName: String {
+        switch self {
+        case .linear:  return "linear"
+        case .github:  return "github"
+        case .sentry:  return "sentry"
+        case .shell:   return "shell"
+        case .unknown: return "unknown"
+        }
+    }
+
+    /// Color for the source dot in sidebar rows. Tokens live in `WorkspaceLayout`.
+    var dotColor: Color {
+        switch self {
+        case .shell:   return WorkspaceLayout.sourceDotShell
+        case .linear:  return WorkspaceLayout.sourceDotLinear
+        case .github:  return WorkspaceLayout.sourceDotGitHub
+        case .sentry:  return WorkspaceLayout.sourceDotSentry
+        case .unknown: return WorkspaceLayout.sourceDotUnknown
+        }
     }
 }
 

--- a/macos/Sources/Features/Ghostties/TaskRowView.swift
+++ b/macos/Sources/Features/Ghostties/TaskRowView.swift
@@ -443,13 +443,12 @@ struct TaskRowView: View {
         }
     }
 
-    /// v0: all fixtures use `project: ghostties` — render a single sage dot
-    /// (`#8aa96a`, muted olive/sage). Desaturated from the original lime
-    /// `#7cb342` to sit more quietly against the warm chrome. Future
-    /// revisions will map project → color.
+    /// Source dot: color reflects the task's originating source (shell, linear,
+    /// github, sentry). Tokens live in `WorkspaceLayout` via `TaskSource.dotColor`.
     private var projectGlyph: some View {
         Circle()
-            .fill(Color(red: 0.541, green: 0.663, blue: 0.416))
+            .fill(task.source.dotColor)
+            .help(task.source.displayName)
     }
 
     private var statusSymbolName: String {

--- a/macos/Sources/Features/Ghostties/TaskSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/TaskSidebarView.swift
@@ -149,30 +149,8 @@ struct TaskSidebarView: View {
     // MARK: - Footer
 
     private var footer: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(Color(red: 0.541, green: 0.663, blue: 0.416))
-                .frame(width: 5, height: 5)
-
-            Text("3 sources")
-                .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-
-            Text("·").foregroundStyle(Color.primary.opacity(0.28))
-
-            Text("linear")
-                .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-
-            Text("·").foregroundStyle(Color.primary.opacity(0.28))
-
-            Text("gh")
-                .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-
-            Text("·").foregroundStyle(Color.primary.opacity(0.28))
-
-            Text("sentry")
+        HStack(spacing: 0) {
+            Text("tasks · \(taskStore.tasks.count)")
                 .font(.system(size: 10.5, design: .monospaced))
                 .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
 

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -166,6 +166,27 @@ enum WorkspaceLayout {
     /// and project rows. Combined with `sidebarIconColumnWidth` this yields the
     /// common x-position for icons and labels.
     static let sidebarRowLeadingPadding: CGFloat = 8
+
+    // MARK: - Source-dot colors
+
+    /// Source-dot color for shell-spawned tasks. Muted sage — existing token,
+    /// kept consistent with the `statusSymbolColor` sage used in `TaskRowView`.
+    static let sourceDotShell = Color(red: 0.541, green: 0.663, blue: 0.416)
+
+    /// Source-dot color for Linear-originated tasks. Desaturated indigo.
+    static let sourceDotLinear = Color(red: 0.431, green: 0.416, blue: 0.682)
+
+    /// Source-dot color for GitHub-originated tasks. Neutral graphite.
+    static let sourceDotGitHub = Color(red: 0.541, green: 0.541, blue: 0.561)
+
+    /// Source-dot color for Sentry-originated tasks. Muted plum.
+    static let sourceDotSentry = Color(red: 0.604, green: 0.431, blue: 0.557)
+
+    /// Source-dot color when source is unknown. System tertiary label.
+    static let sourceDotUnknown = Color(nsColor: .tertiaryLabelColor)
+
+    /// Muted red for CI failure state — distinct from terracotta.
+    static let ciFailColor = Color(nsColor: .systemRed).opacity(0.7)
 }
 
 // MARK: - Animation Tokens (D18)


### PR DESCRIPTION
## Summary

- Adds per-source dot color tokens to `WorkspaceLayout` (indigo for Linear, graphite for GitHub, plum for Sentry, sage for shell) — all muted/desaturated, never terracotta
- Promotes `TaskSource.displayName` from a private `GraveyardRowExpansionState` extension into `TaskModel.swift` as a shared property; adds `TaskSource.dotColor` backed by the new tokens
- Replaces hardcoded sage color on the source/project glyph in `TaskRowView` with `task.source.dotColor`; adds `.help(task.source.displayName)` tooltip on the glyph
- Removes the fake "3 sources · linear · gh · sentry" footer text from `TaskSidebarView`; replaces with honest `"tasks · N"` live count in SF Mono, keeps gear icon

## Test plan

- [ ] Build passes (`xcodebuild build … ONLY_ACTIVE_ARCH=YES ARCHS=arm64`)
- [ ] Shell task rows show sage dot; Linear task rows show indigo dot
- [ ] Hovering the source dot shows the correct source name tooltip
- [ ] Footer reads "tasks · N" with the actual task count, no fake source list
- [ ] No regression on Graveyard expansion chips (still shows `source · id` correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)