### PR TITLE
feat(mcp): set_task_fields + worktree/PR schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ default.profraw
 # Session-hybrid: anonymous terminal session state; ephemeral, per-machine.
 .ghostties/sessions.json
 .ghostties/sessions.json.tmp
+.ghostties/worktrees/
 .vercel
 
 # Local session artifacts

--- a/cli/Sources/ghostties-mcp/Tools.swift
+++ b/cli/Sources/ghostties-mcp/Tools.swift
@@ -186,6 +186,7 @@ func allTools() -> [Tool] {
         appendTaskNotesTool(),
         writeSessionNotesTool(),
         getInboxTool(),
-        setTaskProjectTool()
+        setTaskProjectTool(),
+        setTaskFieldsTool()
     ]
 }

--- a/cli/Sources/ghostties-mcp/Tools/SetTaskFields.swift
+++ b/cli/Sources/ghostties-mcp/Tools/SetTaskFields.swift
@@ -1,0 +1,81 @@
+import Foundation
+import GhosttiesCore
+
+private let allowedKeys: Set<String> = ["worktree", "pr", "pr-state", "pr-url", "branch"]
+
+func setTaskFieldsTool() -> Tool {
+    Tool(
+        name: "set_task_fields",
+        description: "Write worktree/PR metadata back to a task file after an agent creates a PR. Allowed keys: worktree, pr, pr-state, pr-url, branch.",
+        inputSchema: S.object(
+            properties: [
+                ("taskId", S.string("Task id or unambiguous prefix.")),
+                ("fields", .object([
+                    "type": .string("object"),
+                    "description": .string("Fields to update. Allowed keys: worktree, pr, pr-state, pr-url, branch."),
+                    "properties": .object([
+                        "worktree":  .object(["type": .string("string"), "description": .string("Absolute path to the git worktree for this task.")]),
+                        "pr":        .object(["type": .string("string"), "description": .string("PR number (as string).")]),
+                        "pr-state":  .object(["type": .string("string"), "description": .string("PR state (e.g. open, merged, closed).")]),
+                        "pr-url":    .object(["type": .string("string"), "description": .string("Full URL of the pull request.")]),
+                        "branch":    .object(["type": .string("string"), "description": .string("Branch name associated with this task.")])
+                    ]),
+                    "additionalProperties": .bool(false)
+                ]))
+            ],
+            required: ["taskId", "fields"]
+        ),
+        handler: { args, resolver in
+            guard let taskIdArg = args["taskId"]?.string, !taskIdArg.isEmpty else {
+                return .error("missing required argument: taskId")
+            }
+            guard case .object(let fieldsObj) = args["fields"] else {
+                return .error("missing required argument: fields")
+            }
+            if fieldsObj.isEmpty {
+                return .error("fields must contain at least one key to update")
+            }
+
+            // Validate all keys before writing anything.
+            let unknownKeys = fieldsObj.keys.filter { !allowedKeys.contains($0) }
+            if !unknownKeys.isEmpty {
+                let sorted = unknownKeys.sorted().joined(separator: ", ")
+                let allowed = allowedKeys.sorted().joined(separator: ", ")
+                return .error("unknown field key(s): \(sorted). Allowed keys are: \(allowed)")
+            }
+
+            let dir: URL
+            do { dir = try resolver.resolve() }
+            catch { return .error(error.localizedDescription) }
+
+            let store = TaskStore(directory: dir)
+            do {
+                let (task, url) = try store.resolve(idOrPrefix: taskIdArg)
+
+                var pairs = task.frontmatter
+                var updatedKeys: [String] = []
+                for key in fieldsObj.keys.sorted() {
+                    if let val = fieldsObj[key]?.string {
+                        pairs = Frontmatter.set(key, val, in: pairs)
+                        updatedKeys.append(key)
+                    }
+                }
+                let now = isoTimestamp()
+                pairs = Frontmatter.set("updated", now, in: pairs)
+
+                try store.write(pairs: pairs, body: task.body, to: url)
+                Log.info("set_task_fields: updated \(updatedKeys.joined(separator: ", ")) on \(task.id)")
+
+                return .json(.object([
+                    "success": .bool(true),
+                    "taskId": .string(task.id),
+                    "updatedFields": .array(updatedKeys.map(JSONValue.string))
+                ]))
+            } catch let err as CLIError {
+                return .error(err.errorDescription ?? "set_task_fields failed")
+            } catch {
+                return .error(error.localizedDescription)
+            }
+        }
+    )
+}

--- a/cli/Tests/GhosttiesCoreTests/CrossSurfaceCoherenceTests.swift
+++ b/cli/Tests/GhosttiesCoreTests/CrossSurfaceCoherenceTests.swift
@@ -40,12 +40,14 @@ final class CrossSurfaceCoherenceTests: XCTestCase {
         "severity",
         "pr",
         "pr-state",         // NOT prState
+        "pr-url",           // full URL written by set_task_fields MCP tool
         "ci",
         "completed",
         "updated",          // not read by macOS parser today but written by CLI + MCP
         "priority",         // not read by macOS parser today but written by MCP
         "project-path",     // NOT projectPath; macOS uses kebab-case for parity
-        "template"
+        "template",
+        "worktree"          // path to git worktree, written by set_task_fields MCP tool
     ]
 
     /// The on-disk `status:` values the macOS TaskStatus enum accepts. Mirrors
@@ -418,6 +420,62 @@ final class CrossSurfaceCoherenceTests: XCTestCase {
         // The sidebar exclusion rule: !isDone || !isExternal → admitted only if NOT done.
         XCTAssertFalse(!isDone, // would be true only if NOT done — i.e. admissible to Inbox
                        "a done task must NOT pass the inbox admission guard (status != .done)")
+    }
+
+    /// Write a fixture with `worktree` and `pr-url` fields (written by the
+    /// `set_task_fields` MCP tool after an agent creates a PR), reload it via
+    /// `TaskStore.loadFile`, and assert both fields survive the round-trip on
+    /// all three surfaces (GhosttiesCore store, raw frontmatter bytes, Frontmatter
+    /// key parser).
+    func test_coherence_worktreeAndPR_allSurfaces() throws {
+        let store = TaskStore(directory: tmpDir)
+        let pairs: [(String, String)] = [
+            ("title", "Worktree PR coherence task"),
+            ("source", "linear"),
+            ("source-id", "SEA-COHERENCE-2"),
+            ("project", "ghostties"),
+            ("created", "2026-05-18T10:00:00Z"),
+            ("status", "running"),
+            ("branch", "feat/linear-loop-worktree-schema"),
+            ("worktree", "/some/path"),
+            ("pr-url", "https://github.com/SeanSmithDesign/ghostties/pull/99")
+        ]
+        let url = try store.create(id: "worktree-pr-coherence", pairs: pairs, body: "\n")
+
+        // Surface (a): GhosttiesCore TaskStore — confirm the file was created.
+        guard let task = store.loadFile(at: url) else {
+            XCTFail("TaskStore.loadFile returned nil for a file we just created"); return
+        }
+        // Confirm the identity fields round-trip (worktree/pr-url are not yet
+        // modelled as typed fields in GhosttiesCore.Task, but the raw frontmatter
+        // pairs must survive intact for the macOS surface to read them).
+        XCTAssertEqual(task.id, "SEA-COHERENCE-2")
+        XCTAssertEqual(task.branch, "feat/linear-loop-worktree-schema")
+
+        // Surface (b): raw frontmatter bytes — exact key/value strings.
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(raw.contains("worktree: /some/path"),
+                      "on-disk frontmatter must contain 'worktree: /some/path'; got:\n\(raw)")
+        XCTAssertTrue(raw.contains("pr-url: https://github.com/SeanSmithDesign/ghostties/pull/99"),
+                      "on-disk frontmatter must contain the pr-url; got:\n\(raw)")
+
+        // Surface (c): Frontmatter key round-trip — confirm no casing drift.
+        let parsed = Frontmatter.split(raw)
+        XCTAssertNotNil(parsed, "Frontmatter.split must succeed on the written file")
+        let readWorktree = Frontmatter.value(for: "worktree", in: parsed!.pairs)
+        let readPRURL    = Frontmatter.value(for: "pr-url",   in: parsed!.pairs)
+        XCTAssertEqual(readWorktree, "/some/path",
+                       "Frontmatter.value(for: 'worktree') must return the verbatim path")
+        XCTAssertEqual(readPRURL, "https://github.com/SeanSmithDesign/ghostties/pull/99",
+                       "Frontmatter.value(for: 'pr-url') must return the verbatim URL")
+
+        // Verify both keys are in the known-to-macOS-parser set (guards against
+        // silent schema drift — if this fails, macOSOptionalKeys needs updating).
+        let knownKeys = Self.macOSRequiredKeys.union(Self.macOSOptionalKeys)
+        XCTAssertTrue(knownKeys.contains("worktree"),
+                      "'worktree' must be declared in macOSOptionalKeys")
+        XCTAssertTrue(knownKeys.contains("pr-url"),
+                      "'pr-url' must be declared in macOSOptionalKeys")
     }
 
     /// Write a fixture with Linear source fields, reload via `TaskStore.loadFile`,

--- a/macos/Sources/Features/Ghostties/OrphanTriageStore.swift
+++ b/macos/Sources/Features/Ghostties/OrphanTriageStore.swift
@@ -205,7 +205,9 @@ final class OrphanTriageStore: ObservableObject {
                     severity: task.severity,
                     pr: task.pr,
                     prState: task.prState,
+                    prURL: task.prURL,
                     ci: task.ci,
+                    worktree: task.worktree,
                     completed: task.completed,
                     events: task.events
                 )

--- a/macos/Sources/Features/Ghostties/TaskModel.swift
+++ b/macos/Sources/Features/Ghostties/TaskModel.swift
@@ -120,7 +120,15 @@ struct TaskItem: Identifiable, Codable, Equatable {
     let severity: String?
     let pr: Int?
     let prState: String?
+    /// Full URL of the pull request (e.g. `https://github.com/SeanSmithDesign/ghostties/pull/99`).
+    /// Written by the `set_task_fields` MCP tool after an agent creates a PR.
+    /// Read-only in the sidebar; not surfaced in UI yet but stored for future display use.
+    let prURL: String?
     let ci: String?
+    /// Absolute path to the git worktree for this task (e.g. `/some/path`).
+    /// Written by the `set_task_fields` MCP tool after an agent creates a worktree.
+    /// Read-only in the sidebar; stored for future display use.
+    let worktree: String?
     let completed: Date?
     let events: [TaskEvent]?
 
@@ -143,7 +151,9 @@ struct TaskItem: Identifiable, Codable, Equatable {
         case severity
         case pr
         case prState = "pr-state"
+        case prURL = "pr-url"
         case ci
+        case worktree
         case completed
         case events
     }
@@ -176,7 +186,9 @@ struct TaskItem: Identifiable, Codable, Equatable {
         severity = try c.decodeIfPresent(String.self, forKey: .severity)
         pr = try c.decodeIfPresent(Int.self, forKey: .pr)
         prState = try c.decodeIfPresent(String.self, forKey: .prState)
+        prURL = try c.decodeIfPresent(String.self, forKey: .prURL)
         ci = try c.decodeIfPresent(String.self, forKey: .ci)
+        worktree = try c.decodeIfPresent(String.self, forKey: .worktree)
         completed = try c.decodeIfPresent(Date.self, forKey: .completed)
         events = try c.decodeIfPresent([TaskEvent].self, forKey: .events)
     }
@@ -201,7 +213,9 @@ struct TaskItem: Identifiable, Codable, Equatable {
         severity: String?,
         pr: Int?,
         prState: String?,
+        prURL: String? = nil,
         ci: String?,
+        worktree: String? = nil,
         completed: Date?,
         events: [TaskEvent]?
     ) {
@@ -223,7 +237,9 @@ struct TaskItem: Identifiable, Codable, Equatable {
         self.severity = severity
         self.pr = pr
         self.prState = prState
+        self.prURL = prURL
         self.ci = ci
+        self.worktree = worktree
         self.completed = completed
         self.events = events
     }

--- a/macos/Sources/Features/Ghostties/TaskStore.swift
+++ b/macos/Sources/Features/Ghostties/TaskStore.swift
@@ -500,7 +500,9 @@ enum TaskFixtureParser {
             severity: yaml["severity"],
             pr: yaml["pr"].flatMap(Int.init),
             prState: yaml["pr-state"],
+            prURL: yaml["pr-url"].flatMap { $0.isEmpty ? nil : $0 },
             ci: yaml["ci"],
+            worktree: yaml["worktree"].flatMap { $0.isEmpty ? nil : $0 },
             completed: yaml["completed"].flatMap(parseISODate),
             events: (events?.isEmpty == true) ? nil : events
         )

--- a/macos/Tests/Ghostties/TaskModelTests.swift
+++ b/macos/Tests/Ghostties/TaskModelTests.swift
@@ -115,6 +115,32 @@ final class TaskModelTests: XCTestCase {
         XCTAssertEqual(TaskStatus.done.rawValue, "done")
     }
 
+    // MARK: - Worktree and PR URL fields
+
+    /// Parser test: a task file with `worktree` and `pr-url` frontmatter must
+    /// parse both fields correctly and expose them as non-nil with correct values.
+    func testParseWorktreeAndPRURLFields() {
+        let markdown = """
+        ---
+        title: Worktree PR task
+        source: linear
+        source-id: SEA-WORKTREE-1
+        branch: feat/linear-loop-worktree-schema
+        project: ghostties
+        created: 2026-05-18T10:00:00Z
+        status: running
+        worktree: /some/path
+        pr-url: https://github.com/SeanSmithDesign/ghostties/pull/99
+        ---
+        """
+        let item = TaskFixtureParser.parse(markdown: markdown, filename: "sea-worktree-1")
+        XCTAssertNotNil(item, "parser must succeed for a task with worktree and pr-url fields")
+        XCTAssertEqual(item?.worktree, "/some/path",
+                       "worktree field must be parsed from 'worktree:' frontmatter key")
+        XCTAssertEqual(item?.prURL, "https://github.com/SeanSmithDesign/ghostties/pull/99",
+                       "prURL field must be parsed from 'pr-url:' frontmatter key")
+    }
+
     // MARK: - Non-md file filtering via TaskStore
 
     func testStoreIgnoresNonMarkdownFiles() async throws {


### PR DESCRIPTION
## Summary

Slice C of Linear loop: adds the MCP write-back path so agents can record worktree and PR metadata onto task files after creating a PR.

- **C3 — `set_task_fields` MCP tool** (`cli/Sources/ghostties-mcp/Tools/SetTaskFields.swift`): new tool that writes `worktree`, `pr`, `pr-state`, `pr-url`, and `branch` fields to a task file. Validates key names against the allowlist, rejects unknowns with a clear error message listing allowed keys. Returns success JSON with updated field names.
- **C4 — Cross-surface coherence test**: adds `worktree` and `pr-url` to `macOSOptionalKeys` in `CrossSurfaceCoherenceTests.swift`; adds `test_coherence_worktreeAndPR_allSurfaces` verifying all three surfaces (GhosttiesCore store, raw frontmatter, Frontmatter key parser) round-trip both fields without error or casing drift.
- **C5 — Sidebar read fields**: adds `worktree: String?` and `prURL: String?` (read from `pr-url:` key) to `TaskItem` in the macOS target — both parsed by `TaskFixtureParser`, exposed with nil defaults on the memberwise init for backward compat. Adds `testParseWorktreeAndPRURLFields` to `TaskModelTests.swift`.
- **C6 — `.gitignore`**: adds `.ghostties/worktrees/` so agent-created worktree directories are never accidentally committed.

C2 (primer update) deferred pending live Linear probe.

## Test plan

- [x] `cd cli && swift build` — Build complete, 0 errors
- [x] `swift test --filter GhosttiesCoreTests` — 61 tests, 0 failures
- [x] `xcodebuild build` macOS target — BUILD SUCCEEDED
- [x] `xcodebuild test` macOS target — TEST SUCCEEDED
- [x] `git check-ignore -v .ghostties/worktrees/test-branch` — confirmed ignored at `.gitignore:44`

🤖 Generated with [Claude Code](https://claude.com/claude-code)