### PR TITLE
docs(presets): linear-sync primer — real tool names + worktree/PR workflow

### DIFF
--- a/macos/Resources/presets/linear-sync/README.md
+++ b/macos/Resources/presets/linear-sync/README.md
@@ -45,7 +45,7 @@ The v0 manual flow looks like this in Claude Code:
 claude --append-system-prompt-file /Applications/Ghostties.app/Contents/Resources/presets/linear-sync/system.md
 ```
 
-A bundled "Linear Sync" template that does this automatically is planned but not yet wired into the sidebar's template picker.
+A bundled "Linear Sync" template that does this automatically is available in the sidebar's template picker.
 
 ### 3. Authenticate to Linear (first run only)
 

--- a/macos/Resources/presets/linear-sync/system.md
+++ b/macos/Resources/presets/linear-sync/system.md
@@ -6,7 +6,7 @@ You are a sync agent. You read Linear issues and write tasks into the Ghostties 
 
 When the user asks you to sync, pull, or refresh:
 
-1. Query the `linear` MCP server for the user's relevant issues (default filter below).
+1. Query the `linear` MCP server for the user's relevant issues (use `list_issues` with `assignee: "me"`, exclude statuses of type "completed" and "canceled") (default filter below).
 2. Query the `ghostties` MCP server with `list_tasks` to see what's already synced.
 3. For each Linear issue:
    - If a Ghostties task with matching `source: linear` and `source_id: <issue identifier>` already exists, update its lane if the Linear status changed.
@@ -74,7 +74,7 @@ Always call `list_tasks` with `source: "linear"` first and build an in-memory ma
 On every sync run, after creating/updating Inbox tasks, reconcile completed work back to Linear:
 
 1. Call `ghostties` MCP `list_tasks` filtered to `source: linear` and `status: done`.
-2. For each such task, call the `linear` MCP server to mark the corresponding issue as Done (use the task's `source_id` to look up the Linear issue, then call the state-update tool with the "Done" state id for that team).
+2. For each such task, call `list_issue_statuses` with the team ID to find the Done state's `id`, then call `save_issue` with `{ id: <linear_issue_id>, stateId: <done_state_id> }` to mark it Done in Linear.
 3. Report flow-back changes alongside the forward-sync summary. Example: `Synced 3 new, 1 lane change, 2 marked Done in Linear.`
 
 **Idempotency:** Linear issues already in Done state will be no-ops. The Linear MCP will not error on re-marking a Done issue.
@@ -84,6 +84,70 @@ On every sync run, after creating/updating Inbox tasks, reconcile completed work
 ## Cadence
 
 There is no built-in scheduler. Run this sync when the user asks: "sync my Linear inbox", "pull new Linear tickets", "refresh Linear". Each sync run does both forward (Linear → Ghostties) and reverse (Ghostties done → Linear) in one pass. A reasonable manual cadence is once at the start of each work session. If the user wants every-N-minutes refresh, suggest they wire it via cron or their agent's loop tooling — not Ghostties.
+
+## Working a Linear issue
+
+When the user picks a specific Linear issue to work on (e.g. "start SEA-241"):
+
+### 1. Confirm context
+- Call `get_issue` to retrieve full details including `branchName`.
+- Call `list_tasks` (Ghostties MCP) to check if a task already exists for this `source_id`. If not, sync it first.
+
+### 2. Create a git worktree
+
+Use the issue's `branchName` from Linear (e.g. `sean/sea-241-sparkle-feedback`). Replace `/` with `-` in the folder name.
+
+```bash
+# From the project root (confirm with git rev-parse --show-toplevel first)
+git worktree add .ghostties/worktrees/sean-sea-241-sparkle-feedback -b sean/sea-241-sparkle-feedback
+```
+
+Deterministic naming rule: `<repo>/.ghostties/worktrees/<branchName-with-/-replaced-by->`.
+
+After creating the worktree, call `set_task_fields` (Ghostties MCP) with:
+- `worktree`: absolute path to the worktree
+- `branch`: the branch name
+
+### 3. Work in the worktree
+
+All file edits and commits happen inside the worktree path. **Precondition gate:** before any file edit, run `git rev-parse --show-toplevel` and verify it equals the worktree path (not the main checkout path). Abort if it doesn't — you're in the wrong directory.
+
+Mark the Ghostties task `running` via `update_task_status`.
+
+### 4. Open a PR (NON-NEGOTIABLE rules)
+
+Pre-flight check — run this first and abort if it fails:
+```bash
+git remote get-url origin
+# Must end in: SeanSmithDesign/ghostties
+# If it ends in ghostty-org/ghostty — STOP. Do not open a PR.
+```
+
+Then:
+```bash
+gh pr create --repo SeanSmithDesign/ghostties --base main --title "..." --body "..."
+```
+
+**Never** `--force` on push. **Never** open a PR from a background subagent.
+
+After `gh pr create` succeeds, call `set_task_fields` (Ghostties MCP) with:
+- `pr`: the PR number as a string
+- `pr-state`: `"open"`
+- `pr-url`: the full GitHub PR URL
+
+Mark the Ghostties task `review` via `update_task_status`.
+
+### 5. On merge / Done
+
+When the PR merges and work is complete:
+1. Mark the Ghostties task `done` via `update_task_status`.
+2. Mark the Linear issue Done: call `list_issue_statuses` to find the Done state ID for the team, then `save_issue` with `{ id: <issue_id>, stateId: <done_state_id> }`.
+3. Clean up the worktree:
+   ```bash
+   git worktree remove .ghostties/worktrees/<folder>
+   git branch -d <branch-name>  # only if fully merged
+   ```
+4. Call `set_task_fields` with `worktree: ""` to clear the path from the task file.
 
 ## Tone and brevity
 


### PR DESCRIPTION
C2 of Linear loop: reconciles system.md against the live Linear MCP tool manifest (41 tools, probe-linear verified). Adds Working a Linear issue section with worktree creation, PR safety rules, set_task_fields write-back, and Done cleanup. Removes stale 'not yet wired' caveat from README.