### PR TITLE
fix(update): fork-controlled auto-update channel via UserDefaults

### DIFF
--- a/macos/Sources/Features/Settings/SettingsView.swift
+++ b/macos/Sources/Features/Settings/SettingsView.swift
@@ -13,10 +13,20 @@ struct SettingsView: View {
 
             VStack(alignment: .leading) {
                 Text("Coming Soon. 🚧").font(.title)
-                Text("You can't configure settings in the GUI yet. To modify settings, " +
-                     "edit the file at $HOME/.config/ghostty/config.ghostty and restart Ghostties.")
-                .multilineTextAlignment(.leading)
-                .lineLimit(nil)
+                Text("Settings live in a Ghostty config file (any standard search path, e.g. $HOME/.config/ghostty/config). Edit it and restart Ghostties.")
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(nil)
+                Text("Update channel — beta (pre-release) or stable:")
+                    .padding(.top, 6)
+                Text("defaults write com.seansmithdesign.ghostties ghostties.autoUpdateChannel tip")
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                Text("defaults write com.seansmithdesign.ghostties ghostties.autoUpdateChannel stable")
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                Text("(\"tip\" is the beta feed.)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding()

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -657,13 +657,29 @@ extension Ghostty {
 
         var autoUpdateChannel: AutoUpdateChannel {
             let defaultValue = AutoUpdateChannel.tip
-            guard let config = self.config else { return defaultValue }
-            var v: UnsafePointer<Int8>?
-            let key = "auto-update-channel"
-            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return defaultValue }
-            guard let ptr = v else { return defaultValue }
-            let str = String(cString: ptr)
-            return AutoUpdateChannel(rawValue: str) ?? defaultValue
+
+            // (a) Ghostties fork-controlled override. UserDefaults.standard
+            // resolves to the running app's bundle domain automatically
+            // (Release: com.seansmithdesign.ghostties,
+            //  Debug: com.seansmithdesign.ghostties.dev).
+            if let override = UserDefaults.standard.string(forKey: "ghostties.autoUpdateChannel"),
+               let channel = AutoUpdateChannel(rawValue: override) {
+                return channel
+            }
+
+            // (b) Upstream libghostty config, only if a config exists and sets it.
+            if let config = self.config {
+                var v: UnsafePointer<Int8>?
+                let key = "auto-update-channel"
+                if ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))),
+                   let ptr = v,
+                   let channel = AutoUpdateChannel(rawValue: String(cString: ptr)) {
+                    return channel
+                }
+            }
+
+            // (c) Band-aid default — keep beta updates working for standalone users.
+            return defaultValue
         }
 
         var autoSecureInput: Bool {


### PR DESCRIPTION
## Summary

- Adds a three-tier precedence chain to `autoUpdateChannel`: UserDefaults override → libghostty config → `.tip` default (band-aid stays)
- Standalone users can now set their update channel via `defaults write` without needing `~/.config/ghostty/config`
- Updates SettingsView copy to document the `defaults write` commands; drops the false claim that `config.ghostty` is the only path
- All changes are fork-controlled Swift only — no Zig/upstream changes

## Test plan

- [ ] `defaults write com.seansmithdesign.ghostties.dev ghostties.autoUpdateChannel stable` → relaunch → Sparkle hits `appcast-stable.xml`
- [ ] `defaults write ... tip` → relaunch → hits `appcast-beta.xml`
- [ ] `defaults delete ...` + no config file → falls back to `.tip` (beta appcast, band-aid intact)
- [ ] Invalid value → no crash, falls through to default

Closes SSD-263

🤖 Generated with [Claude Code](https://claude.com/claude-code)