### PR TITLE
fix(update): surface check-for-update progress + result feedback

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -89,6 +89,9 @@ class BaseTerminalController: NSWindowController,
     /// Cancellable for aggregating bell state across all surfaces in this controller.
     private var bellStateCancellable: AnyCancellable?
 
+    /// Cancellable that watches update state to show the overlay on windows that lack a titlebar accessory pill.
+    private var updateStateCancellable: AnyCancellable?
+
     /// An override title for the tab/window set by the user via prompt_tab_title.
     /// When set, this takes precedence over the computed title from the terminal.
     var titleOverride: String? {
@@ -1155,6 +1158,28 @@ class BaseTerminalController: NSWindowController,
 
         // Set our update overlay state
         updateOverlayIsVisible = defaultUpdateOverlayVisibility()
+
+        // On window styles that lack a titlebar accessory pill (hidden titlebar, tabbed,
+        // etc.), defaultUpdateOverlayVisibility() returns false because it was designed
+        // for standard TerminalWindow. We need the overlay to activate whenever update
+        // state is non-idle so the user gets spinner → result feedback on any window style.
+        //
+        // Only subscribe when the window does NOT support the update accessory — standard
+        // TerminalWindows already render the pill in the titlebar and must not double-render.
+        let needsOverlayFallback: Bool = {
+            guard window.styleMask.contains(.titled) else { return true }
+            guard let terminalWin = window as? TerminalWindow else { return true }
+            return !terminalWin.supportsUpdateAccessory
+        }()
+
+        if needsOverlayFallback, let updateViewModel = (NSApp.delegate as? AppDelegate)?.updateViewModel {
+            updateStateCancellable = updateViewModel.$state
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] newState in
+                    guard let self else { return }
+                    self.updateOverlayIsVisible = !newState.isIdle
+                }
+        }
     }
 
     func defaultUpdateOverlayVisibility() -> Bool {

--- a/macos/Sources/Features/Update/UpdateDriver.swift
+++ b/macos/Sources/Features/Update/UpdateDriver.swift
@@ -76,7 +76,10 @@ class UpdateDriver: NSObject, SPUUserDriver {
 
     func showUpdateNotFoundWithError(_ error: any Error,
                                      acknowledgement: @escaping () -> Void) {
-        viewModel.state = .notFound(.init(acknowledgement: acknowledgement))
+        let channel = (NSApp.delegate as? AppDelegate)?.ghostty.config.autoUpdateChannel
+        viewModel.state = .notFound(.init(
+            acknowledgement: acknowledgement,
+            channelIsStable: channel == .stable))
 
         if !hasUnobtrusiveTarget {
             standard.showUpdateNotFoundWithError(error, acknowledgement: acknowledgement)

--- a/macos/Sources/Features/Update/UpdatePopoverView.swift
+++ b/macos/Sources/Features/Update/UpdatePopoverView.swift
@@ -317,13 +317,26 @@ private struct NotFoundView: View {
     let notFound: UpdateState.NotFound
     let dismiss: DismissAction
 
+    private var title: String {
+        notFound.channelIsStable ? "No releases yet" : "You're up to date"
+    }
+
+    private var body_text: String {
+        if notFound.channelIsStable {
+            return "No releases on the stable channel yet — switch to the beta channel for pre-release builds."
+        } else {
+            let ver = notFound.displayVersion.isEmpty ? "" : " (v\(notFound.displayVersion))"
+            return "You're on the latest version\(ver) — beta channel."
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-                Text("No Updates Found")
+                Text(title)
                     .font(.system(size: 13, weight: .semibold))
 
-                Text("You're already running the latest version.")
+                Text(body_text)
                     .font(.system(size: 11))
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/macos/Sources/Features/Update/UpdateViewModel.swift
+++ b/macos/Sources/Features/Update/UpdateViewModel.swift
@@ -32,8 +32,13 @@ class UpdateViewModel: ObservableObject {
             return String(format: "Preparing: %.0f%%", extracting.progress * 100)
         case .installing(let install):
             return install.isAutoUpdate ? "Restart to Complete Update" : "Installing…"
-        case .notFound:
-            return "No Updates Available"
+        case .notFound(let v):
+            if v.channelIsStable {
+                return "No stable releases yet"
+            } else {
+                let ver = v.displayVersion.isEmpty ? "" : " (v\(v.displayVersion))"
+                return "You're on the latest\(ver)"
+            }
         case .error(let err):
             return err.error.localizedDescription
         }
@@ -94,8 +99,13 @@ class UpdateViewModel: ObservableObject {
             return "Extracting and preparing the update"
         case let .installing(install):
             return install.isAutoUpdate ? "Restart to Complete Update" : "Installing update and preparing to restart"
-        case .notFound:
-            return "You are running the latest version"
+        case .notFound(let v):
+            if v.channelIsStable {
+                return "No releases on the stable channel yet — switch to the beta channel for pre-release builds."
+            } else {
+                let ver = v.displayVersion.isEmpty ? "" : " (v\(v.displayVersion))"
+                return "You're on the latest version\(ver) — beta channel."
+            }
         case .error:
             return "An error occurred during the update process"
         }
@@ -261,6 +271,8 @@ enum UpdateState: Equatable {
 
     struct NotFound {
         let acknowledgement: () -> Void
+        var channelIsStable: Bool = false
+        var displayVersion: String = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
     }
 
     struct PermissionRequest {


### PR DESCRIPTION
## Summary

- Fixes root-cause visibility bug: `UpdatePill` was invisible on hidden-titlebar and tabbed window styles because `defaultUpdateOverlayVisibility()` is computed once at window load and not re-evaluated when update state changes later
- Ensures `UpdateOverlay` shows whenever state is non-idle on window styles that lack the titlebar accessory pill — no double-rendering on standard windows
- Extends `UpdateState.NotFound` with `channelIsStable` and `displayVersion`; populates in `UpdateDriver.showUpdateNotFoundWithError`
- Distinct copy: "You're on the latest (vX) — beta channel" vs "No releases on the stable channel yet — switch to beta"

## Test plan

- [ ] Click Check for Updates on a default (titled) window — spinner appears, then result
- [ ] Click Check for Updates on a hidden-titlebar window — spinner appears, then result (was completely invisible before)
- [ ] Standard window shows exactly ONE pill (no duplicate between titlebar accessory + overlay)
- [ ] With `ghostties.autoUpdateChannel = stable` in UserDefaults → not-found shows "No releases on the stable channel yet"
- [ ] With `tip` (default) → shows "You're on the latest (vX.Y.Z) — beta channel"

Closes SSD-241

🤖 Generated with [Claude Code](https://claude.com/claude-code)