### PR TITLE
fix(sidebar): stop projectFirst beachball — pin LazyVStack width

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -534,6 +534,15 @@ class WorkspaceViewContainer: NSView {
                 .environmentObject(WorkspaceStore.shared)
                 .environmentObject(coordinator)
                 .ignoresSafeArea(.container, edges: .top)
+            // Pin to a concrete width so the nested LazyVStack inside
+            // WorkspaceSidebarView receives a definite cross-axis proposal.
+            // Without this the hosting view proposes .infinity, which sends
+            // LazyVStack.sizeThatFits into infinite measurement recursion —
+            // the same root cause fixed for taskFirst in sidebar-layout-hang-v0
+            // (commit 11530667b). Uses currentSidebarWidth so the user-resizable
+            // drag handle continues to work correctly.
+            .frame(width: currentSidebarWidth)
+            .frame(maxHeight: .infinity)
             hostingView.rootView = AnyView(view)
         }
     }


### PR DESCRIPTION
## The bug
Beta.16 froze with a beachball (100% CPU, main thread pegged forever). A live \`sample\` of the hung process caught the main thread spinning continuously in \`flushTransactions → placeSubviews → LazyStack.place → nested ForEach\` — the signature of **intrinsic SwiftUI measurement recursion**, not periodic invalidation.

## Root cause
\`WorkspaceSidebarView\`'s \`ScrollView → LazyVStack\` (nested ForEach) recurses forever during measurement when it receives an unconstrained (\`.infinity\`) cross-axis proposal. The **projectFirst** branch of \`applySidebarView()\` had no width constraint.

This exact bug class was already fixed for the **taskFirst** path in \`sidebar-layout-hang-v0\` (commit 11530667b) via \`.frame(width: WorkspaceLayout.taskSidebarWidth)\`. That fix was never ported to projectFirst — which is the default mode, so most users hit it.

## The fix
One line: pin the projectFirst branch with \`.frame(width: currentSidebarWidth)\`, mirroring taskFirst. Uses the **live, user-resizable** width (not a hardcoded constant), so the drag handle and resize UX are unchanged and no content is clipped.

## Verification
- \`xcodebuild\` Release/arm64: **BUILD SUCCEEDED**
- Runtime \`sample\` of the rebuilt app, projectFirst mode, window unfocused (the reliable trigger): **2521/2521 main-thread samples in \`mach_msg\`** — run loop fully idle, zero appearances of \`flushTransactions\`/\`placeSubviews\`/\`LazyStack.place\`. Hang confirmed gone.

## Diagnostic method
Four parallel investigation agents + two adversarial reviewers. The red-team correctly ruled out two plausible-but-wrong causes (the 1 Hz coordinator timer; an AppKit↔SwiftUI \`@Published\` write loop) using the CPU signature: a pegged-forever main thread is intrinsic recursion, not periodic invalidation. This kept us from shipping a \`sectionedProjects\` cache that would have *masked* the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)