### PR TITLE
perf(sidebar): guard 1 Hz WorkspaceStore publishes against no-change ticks

### DIFF
--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -965,24 +965,31 @@ final class SessionCoordinator: ObservableObject {
 
                     // SEA-214: Only send objectWillChange when state actually changed,
                     // suppressing the 7-view full-sidebar re-render that fired every second.
+                    //
+                    // Store writes (WorkspaceStore) are moved inside the same changed-branch
+                    // so the @Published dict assignments and updateProjectActivity only run
+                    // when the aggregate state actually shifted. The guards in
+                    // WorkspaceStore.updateIndicatorState / updateSessionStatus are a
+                    // belt-and-suspenders second layer but this avoids even the dict lookup
+                    // churn on no-change ticks.
                     Perf.publishIfChanged(
                         "sessionCoordinator.tick",
                         current: current,
                         cached: &self.cachedIndicatorStates
                     ) {
                         self.objectWillChange.send()
-                    }
 
-                    // Push each running session's indicator state to the global store
-                    // so the menu bar icon can reflect the aggregate status.
-                    for (id, state) in current {
-                        WorkspaceStore.shared.updateIndicatorState(id: id, state: state)
-                    }
+                        // Push each running session's indicator state to the global store
+                        // so the menu bar icon can reflect the aggregate status.
+                        for (id, state) in current {
+                            WorkspaceStore.shared.updateIndicatorState(id: id, state: state)
+                        }
 
-                    // Refresh the per-project grace-period tracker so projects
-                    // whose sessions emit output at <1Hz still keep their
-                    // `.activeNow` slot for the full grace window.
-                    WorkspaceStore.shared.updateProjectActivityFromIndicatorStates()
+                        // Refresh the per-project grace-period tracker so projects
+                        // whose sessions emit output at <1Hz still keep their
+                        // `.activeNow` slot for the full grace window.
+                        WorkspaceStore.shared.updateProjectActivityFromIndicatorStates()
+                    }
                     Perf.signposter.endInterval("sessionCoordinator.tick", tickState)
                 }
             }

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -450,7 +450,13 @@ final class WorkspaceStore: ObservableObject {
     // MARK: - Session Status
 
     /// Update a single session's global status (called by coordinators).
+    ///
+    /// Writing `@Published` dict unconditionally fires `objectWillChange` even when
+    /// the value is unchanged. Guard first so 1 Hz timer ticks that see no transition
+    /// don't trigger downstream SwiftUI re-renders. (Belt-and-suspenders with the
+    /// `Perf.publishIfChanged` guard in `SessionCoordinator.startActivityTimer`.)
     func updateSessionStatus(id: UUID, status: SessionStatus) {
+        guard globalStatuses[id] != status else { return }
         globalStatuses[id] = status
     }
 
@@ -462,7 +468,13 @@ final class WorkspaceStore: ObservableObject {
     // MARK: - Indicator State (Menu Bar)
 
     /// Update a session's view-layer indicator state for menu bar consumption.
+    ///
+    /// Writing `@Published` dict unconditionally fires `objectWillChange` even when
+    /// the value is unchanged. Guard first so 1 Hz timer ticks that see no transition
+    /// don't trigger downstream SwiftUI re-renders. (Belt-and-suspenders with the
+    /// `Perf.publishIfChanged` guard in `SessionCoordinator.startActivityTimer`.)
     func updateIndicatorState(id: UUID, state: SessionIndicatorState) {
+        guard globalIndicatorStates[id] != state else { return }
         globalIndicatorStates[id] = state
     }
 


### PR DESCRIPTION
## What
Stops the session activity timer from firing \`WorkspaceStore.objectWillChange\` every second when nothing actually changed. Closes the gap SEA-214 left: that fix de-duped \`SessionCoordinator.objectWillChange\` but not the separate \`WorkspaceStore\` writes the same timer makes.

## Changes
- **WorkspaceStore.swift** — \`updateIndicatorState\` and \`updateSessionStatus\` now guard against no-change writes (\`SessionIndicatorState\`/\`SessionStatus\` already Equatable). A \`@Published\` dict assignment fires \`objectWillChange\` even when the value is identical; these guards prevent that on quiet ticks.
- **SessionCoordinator.swift** — the per-tick store-write loop + \`updateProjectActivityFromIndicatorStates()\` moved inside the existing \`Perf.publishIfChanged\` gate, so on a steady-state tick (no session transitions) they don't run at all.

Real active→waiting transitions still publish — nothing is suppressed on a genuine state change.

## Verification
- \`xcodebuild\` Release/arm64: **BUILD SUCCEEDED**
- Runtime reduction (fewer publishes/sec) is build-verified only; observing the actual drop needs live running sessions in Instruments (the \`"no-op publish suppressed"\` Points-of-Interest event). Logic is minimal and independent of the hang fix in #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)