### PR TITLE
test(ci): fix stale MCP tool-count assertion to unblock cli/ job

### DIFF
--- a/cli/Tests/GhosttiesMCPTests/MCPProtocolTests.swift
+++ b/cli/Tests/GhosttiesMCPTests/MCPProtocolTests.swift
@@ -127,7 +127,7 @@ final class MCPProtocolTests: XCTestCase {
         XCTAssertEqual(serverInfo?["name"] as? String, "ghostties-mcp")
     }
 
-    func testToolsListReturnsElevenToolsWithSchemas() throws {
+    func testToolsListReturnsExpectedToolsWithSchemas() throws {
         let responses = try driveServer([
             ["jsonrpc": "2.0", "id": 1, "method": "initialize",
              "params": ["protocolVersion": "2024-11-05", "capabilities": [:],
@@ -140,13 +140,12 @@ final class MCPProtocolTests: XCTestCase {
             XCTFail("tools/list did not return a tools array")
             return
         }
-        XCTAssertEqual(tools.count, 11, "expected 11 tools, got \(tools.count)")
 
         let expectedNames: Set<String> = [
             "list_tasks", "get_task", "create_task", "update_task_status",
             "get_active", "get_needs_you", "read_task_notes",
             "append_task_notes", "get_inbox", "write_session_notes",
-            "set_task_project"
+            "set_task_project", "set_task_fields"
         ]
         let actualNames = Set(tools.compactMap { $0["name"] as? String })
         XCTAssertEqual(actualNames, expectedNames)


### PR DESCRIPTION
## Goal
Get CI green again. \`main\` has been red on both jobs for ~a month.

## Change
- \`cli/Tests/GhosttiesMCPTests/MCPProtocolTests.swift\`: the stale \`testToolsListReturnsElevenToolsWithSchemas\` asserted 11 MCP tools; the server now exposes 12 (\`set_task_fields\` shipped in beta.16). Renamed to a count-agnostic \`testToolsListReturnsExpectedToolsWithSchemas\`, dropped the brittle count assertion, added \`set_task_fields\` to the expected set. (Ports the fix from the unmerged \`fix/stale-mcp-tools-test\`, commit 52192aee8.)

## Verification
- \`swift test --parallel\` in \`cli/\`: **106/106 passed, exit 0, ~45s, no hang** locally.

## Note
This PR's CI run is also the empirical check on the rest: today's runs showed the \`macOS App (xcodebuild test)\` job hung on host-app launch (exit 65) and the cli/ job hung at \`TasksDirectoryTests\` — despite the relevant code reading as already-gated/refactored on main. Watching this run will confirm whether those are actually resolved on current main or whether residual infra hangs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)