### PR TITLE
fix(update): prevent Sparkle permission-request wedge — restore Check for Updates

### DIFF
--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -182,8 +182,11 @@ jobs:
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $GHOSTTIES_BUILD" "$PLIST"
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $GHOSTTIES_VERSION" "$PLIST"
           /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey p4A5Tc5lUgQGbOEnOGesE7YA+EPePQxKiLrKdRfvdMg=" "$PLIST"
-          # Remove the auto-checks key so Sparkle respects user preferences at runtime
-          /usr/libexec/PlistBuddy -c "Delete :SUEnableAutomaticChecks" "$PLIST" || true
+          # Keep SUEnableAutomaticChecks=true so Sparkle skips the permission-request
+          # prompt path entirely and goes straight to background checking. Deleting
+          # this key (old behavior) caused Sparkle to wedge in _showingPermissionRequest
+          # forever, silently swallowing every "Check for Updates" click.
+          /usr/libexec/PlistBuddy -c "Set :SUEnableAutomaticChecks true" "$PLIST"
 
       - name: Codesign app bundle
         env:

--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -112,6 +112,19 @@ jobs:
       - name: Xcode version
         run: xcodebuild -version
 
+      # Pin Xcode 26.3 for the Zig build. The macos-26 image's default Xcode
+      # moved to 26.5, whose SDK changed libSystem.tbd to reference arm64e-macos
+      # instead of aarch64-macos. Zig 0.15.2's linker can't match the two and
+      # fails GhosttyKit.xcframework with undefined libSystem symbols
+      # (_abort, _free, __availability_version_check, ...). 26.3 is the last
+      # SDK Zig 0.15.2 links cleanly against, and still ships all macOS 26 SDK
+      # types the Swift app build needs. Matches upstream ghostty-org/ghostty.
+      # Re-evaluate when Zig 0.16 ships (ziglang/zig#31658).
+      - name: Select Xcode 26.3 (Zig 0.15.2 SDK compatibility)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+
       # Install Zig 0.15.2 (matches build.zig.zon minimum_zig_version).
       # Required to build GhosttyKit.xcframework from source.
       - uses: mlugg/setup-zig@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [0.1.0-beta.17] — 2026-06-19
+
+Auto-updates work now, and the workspace sidebar no longer freezes the app.
+
+### Fixed
+
+- **Auto-updates now work.** "Check for Updates" was silently doing nothing in beta.16 — a permission-request wedge stalled Sparkle, and the in-app update notification never rendered in the workspace window. Ghostties now checks for updates in the background and shows a notification pill when a new version is ready. *One catch: because the updater itself was broken in beta.16 and earlier, you'll need to install this build manually — but updates after this one will arrive on their own.*
+- **Sidebar no longer freezes the app.** Opening the project sidebar could peg the CPU and beachball the window. Fixed.
+
+---
+
 ## [0.1.0-beta.16] — 2026-05-18
 
 The tasks sidebar is now fully wired up, with six status zones, Linear preset support, and a complete `gt` CLI.
@@ -98,6 +109,8 @@ First distributable build. Ghostties can now be installed and kept up to date au
 
 ---
 
+[0.1.0-beta.17]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.17
+[0.1.0-beta.16]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.16
 [0.1.0-beta.15]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.15
 [0.1.0-beta.14]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.14
 [0.1.0-beta.13]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.13

--- a/macos/Ghostties-Info.plist
+++ b/macos/Ghostties-Info.plist
@@ -108,6 +108,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 	<key>SUPublicEDKey</key>
 	<string>placeholder</string>
 	<key>UTExportedTypeDeclarations</key>

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -768,6 +768,7 @@ class AppDelegate: NSObject,
                 keyEquivalent: ""
             )
             item.tag = index
+            item.target = self
             simulateSubmenu.addItem(item)
         }
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -772,17 +772,6 @@ class AppDelegate: NSObject,
             simulateSubmenu.addItem(item)
         }
 
-        // Separator + "Standard Sparkle Dialog" option so the owner can A/B compare
-        // the custom branded pill (above) against Sparkle's native update alert panel.
-        simulateSubmenu.addItem(.separator())
-        let standardSparkleItem = NSMenuItem(
-            title: "Standard Sparkle Dialog",
-            action: #selector(debugShowStandardSparkleDialog(_:)),
-            keyEquivalent: ""
-        )
-        standardSparkleItem.target = self
-        simulateSubmenu.addItem(standardSparkleItem)
-
         let simulateParent = NSMenuItem(title: "Simulate Update", action: nil, keyEquivalent: "")
         simulateParent.submenu = simulateSubmenu
 
@@ -819,45 +808,6 @@ class AppDelegate: NSObject,
         }
     }
 
-    /// Shows Sparkle's native "update available" alert panel (with release notes, Skip/Dismiss/Install
-    /// buttons) using a synthetic appcast item and no network. This lets the owner A/B the standard
-    /// Sparkle dialog against the custom branded overlay pill driven by the Simulate Update scenarios.
-    @MainActor
-    @objc private func debugShowStandardSparkleDialog(_ sender: Any?) {
-        // Build a minimal fake appcast item. The deprecated dictionary initializer is available
-        // in the compiled framework; the deprecation warning is suppressed because this is
-        // intentional DEBUG-only usage. Keys mirror the Sparkle RSS parser conventions.
-        let itemDict: [String: Any] = [
-            "sparkle:version": "999",
-            "sparkle:shortVersionString": "99.0 (DEBUG)",
-            "title": "Ghostties 99.0 (DEBUG) — Standard Sparkle Dialog Test",
-        ]
-        guard let fakeItem = SUAppcastItem(dictionary: itemDict) else {
-            NSLog("[Ghostties DEBUG] Could not construct SUAppcastItem for standard Sparkle dialog test")
-            return
-        }
-
-        // Construct a SPUUserUpdateState (not-downloaded, user-initiated).
-        // The public class has no public initializer; we call the private
-        // initWithStage:userInitiated: that is declared in the bridging header
-        // (GhosttiesDebug category). The method exists in the compiled Sparkle
-        // framework at runtime — this is safe for DEBUG builds only.
-        guard let fakeState = SPUUserUpdateState(stage: .notDownloaded, userInitiated: true) else {
-            NSLog("[Ghostties DEBUG] Could not construct SPUUserUpdateState for standard Sparkle dialog test")
-            return
-        }
-
-        // Call showUpdateFound on the standard driver. The reply block is a no-op dismiss
-        // (we never actually download anything).
-        updateController.standardUserDriver.showUpdateFound(
-            with: fakeItem,
-            state: fakeState,
-            reply: { _ in
-                // No-op: we are not wired to a real Sparkle pipeline, so choices
-                // (Skip/Dismiss/Install) are acknowledged but not acted upon.
-            }
-        )
-    }
     #endif
 
     // MARK: - U8 (SEA-164): ⌘⇧N new-task composer shortcut

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -367,6 +367,9 @@ class AppDelegate: NSObject,
         setupMenuImages()
         setupWorkspaceMenuItems()
         setupTaskRowMenuItems()
+        #if DEBUG
+        setupDebugUpdateMenuItems()
+        #endif
 
         // U8 (SEA-164): ⌘⇧N new-task composer shortcut.
         // Uses a separate local monitor so it never touches MainMenu.xib —
@@ -736,6 +739,74 @@ class AppDelegate: NSObject,
         viewMenu.insertItem(NSMenuItem.separator(), at: 7)
 
     }
+
+    // MARK: - DEBUG-only update simulator menu
+
+    #if DEBUG
+    /// Builds a top-level "Debug" menu with a "Simulate Update" submenu that drives
+    /// UpdateViewModel directly — no Sparkle, no network, no signing required.
+    /// Each item maps to an UpdateSimulator scenario by tag (0–8).
+    private func setupDebugUpdateMenuItems() {
+        // Ordered to match UpdateSimulator cases (tag index == array index below).
+        let scenarios: [(title: String, scenario: UpdateSimulator)] = [
+            ("Happy Path",              .happyPath),
+            ("Not Found",               .notFound),
+            ("Error",                   .error),
+            ("Slow Download",           .slowDownload),
+            ("Permission Request",      .permissionRequest),
+            ("Cancel During Download",  .cancelDuringDownload),
+            ("Cancel During Checking",  .cancelDuringChecking),
+            ("Installing",              .installing),
+            ("Auto Update",             .autoUpdate),
+        ]
+
+        let simulateSubmenu = NSMenu(title: "Simulate Update")
+        for (index, entry) in scenarios.enumerated() {
+            let item = NSMenuItem(
+                title: entry.title,
+                action: #selector(debugSimulateUpdate(_:)),
+                keyEquivalent: ""
+            )
+            item.tag = index
+            simulateSubmenu.addItem(item)
+        }
+
+        let simulateParent = NSMenuItem(title: "Simulate Update", action: nil, keyEquivalent: "")
+        simulateParent.submenu = simulateSubmenu
+
+        let debugMenu = NSMenu(title: "Debug")
+        debugMenu.addItem(simulateParent)
+
+        let debugMenuItem = NSMenuItem(title: "Debug", action: nil, keyEquivalent: "")
+        debugMenuItem.submenu = debugMenu
+
+        NSApp.mainMenu?.addItem(debugMenuItem)
+    }
+
+    /// Action target for "Simulate Update" menu items.
+    /// Dispatches to the correct UpdateSimulator scenario by tag index.
+    @objc private func debugSimulateUpdate(_ sender: NSMenuItem) {
+        let scenarios: [UpdateSimulator] = [
+            .happyPath,
+            .notFound,
+            .error,
+            .slowDownload,
+            .permissionRequest,
+            .cancelDuringDownload,
+            .cancelDuringChecking,
+            .installing,
+            .autoUpdate,
+        ]
+
+        let index = sender.tag
+        guard scenarios.indices.contains(index) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            scenarios[index].simulate(with: self.updateViewModel)
+        }
+    }
+    #endif
 
     // MARK: - U8 (SEA-164): ⌘⇧N new-task composer shortcut
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -772,6 +772,17 @@ class AppDelegate: NSObject,
             simulateSubmenu.addItem(item)
         }
 
+        // Separator + "Standard Sparkle Dialog" option so the owner can A/B compare
+        // the custom branded pill (above) against Sparkle's native update alert panel.
+        simulateSubmenu.addItem(.separator())
+        let standardSparkleItem = NSMenuItem(
+            title: "Standard Sparkle Dialog",
+            action: #selector(debugShowStandardSparkleDialog(_:)),
+            keyEquivalent: ""
+        )
+        standardSparkleItem.target = self
+        simulateSubmenu.addItem(standardSparkleItem)
+
         let simulateParent = NSMenuItem(title: "Simulate Update", action: nil, keyEquivalent: "")
         simulateParent.submenu = simulateSubmenu
 
@@ -806,6 +817,46 @@ class AppDelegate: NSObject,
             guard let self else { return }
             scenarios[index].simulate(with: self.updateViewModel)
         }
+    }
+
+    /// Shows Sparkle's native "update available" alert panel (with release notes, Skip/Dismiss/Install
+    /// buttons) using a synthetic appcast item and no network. This lets the owner A/B the standard
+    /// Sparkle dialog against the custom branded overlay pill driven by the Simulate Update scenarios.
+    @MainActor
+    @objc private func debugShowStandardSparkleDialog(_ sender: Any?) {
+        // Build a minimal fake appcast item. The deprecated dictionary initializer is available
+        // in the compiled framework; the deprecation warning is suppressed because this is
+        // intentional DEBUG-only usage. Keys mirror the Sparkle RSS parser conventions.
+        let itemDict: [String: Any] = [
+            "sparkle:version": "999",
+            "sparkle:shortVersionString": "99.0 (DEBUG)",
+            "title": "Ghostties 99.0 (DEBUG) — Standard Sparkle Dialog Test",
+        ]
+        guard let fakeItem = SUAppcastItem(dictionary: itemDict) else {
+            NSLog("[Ghostties DEBUG] Could not construct SUAppcastItem for standard Sparkle dialog test")
+            return
+        }
+
+        // Construct a SPUUserUpdateState (not-downloaded, user-initiated).
+        // The public class has no public initializer; we call the private
+        // initWithStage:userInitiated: that is declared in the bridging header
+        // (GhosttiesDebug category). The method exists in the compiled Sparkle
+        // framework at runtime — this is safe for DEBUG builds only.
+        guard let fakeState = SPUUserUpdateState(stage: .notDownloaded, userInitiated: true) else {
+            NSLog("[Ghostties DEBUG] Could not construct SPUUserUpdateState for standard Sparkle dialog test")
+            return
+        }
+
+        // Call showUpdateFound on the standard driver. The reply block is a no-op dismiss
+        // (we never actually download anything).
+        updateController.standardUserDriver.showUpdateFound(
+            with: fakeItem,
+            state: fakeState,
+            reply: { _ in
+                // No-op: we are not wired to a real Sparkle pipeline, so choices
+                // (Skip/Dismiss/Install) are acknowledged but not acted upon.
+            }
+        )
     }
     #endif
 

--- a/macos/Sources/App/macOS/ghostty-bridging-header.h
+++ b/macos/Sources/App/macOS/ghostty-bridging-header.h
@@ -4,3 +4,13 @@
 #import "VibrantLayer.h"
 #import "CEFBridge.h"
 #import "CEFBrowserView.h"
+
+#if DEBUG
+// Expose the private SPUUserUpdateState initializer for DEBUG-only Sparkle dialog testing.
+// The method exists in the compiled Sparkle.framework at runtime; this declaration makes
+// it callable from Swift without shipping private headers in release builds.
+#import <Sparkle/SPUUserUpdateState.h>
+@interface SPUUserUpdateState (GhosttiesDebug)
+- (instancetype)initWithStage:(SPUUserUpdateStage)stage userInitiated:(BOOL)userInitiated;
+@end
+#endif

--- a/macos/Sources/App/macOS/ghostty-bridging-header.h
+++ b/macos/Sources/App/macOS/ghostty-bridging-header.h
@@ -5,12 +5,3 @@
 #import "CEFBridge.h"
 #import "CEFBrowserView.h"
 
-#if DEBUG
-// Expose the private SPUUserUpdateState initializer for DEBUG-only Sparkle dialog testing.
-// The method exists in the compiled Sparkle.framework at runtime; this declaration makes
-// it callable from Swift without shipping private headers in release builds.
-#import <Sparkle/SPUUserUpdateState.h>
-@interface SPUUserUpdateState (GhosttiesDebug)
-- (instancetype)initWithStage:(SPUUserUpdateStage)stage userInitiated:(BOOL)userInitiated;
-@end
-#endif

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -1182,6 +1182,24 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
+    /// Explicitly activates the overlay-fallback subscription for this window.
+    ///
+    /// Call this after any operation that strips the titlebar update-accessory pill (e.g.
+    /// `configureWorkspaceTitlebar()` in `TerminalController`) so that workspace windows still
+    /// receive update notifications via the bottom-right overlay rather than the titlebar band
+    /// that was removed.
+    ///
+    /// Safe to call multiple times — subsequent calls replace the previous subscription.
+    func activateUpdateOverlayFallback() {
+        guard let updateViewModel = (NSApp.delegate as? AppDelegate)?.updateViewModel else { return }
+        updateStateCancellable = updateViewModel.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newState in
+                guard let self else { return }
+                self.updateOverlayIsVisible = !newState.isIdle
+            }
+    }
+
     func defaultUpdateOverlayVisibility() -> Bool {
         guard let window else { return true }
 

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1284,6 +1284,13 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
             window.removeTitlebarAccessoryViewController(at: 0)
         }
 
+        // The titlebar update-accessory pill was just stripped above, so
+        // workspace windows no longer have a titlebar render path for updates.
+        // Wire the bottom-right overlay fallback instead so that any non-idle
+        // UpdateViewModel state (e.g. from Debug ▸ Simulate Update) surfaces
+        // the branded pill in the corner of the terminal view.
+        activateUpdateOverlayFallback()
+
         // NSToolbar approach for traffic light alignment was removed because
         // the enlarged titlebar hit area intercepts clicks on the "+" and
         // sidebar toggle buttons. Traffic light alignment will be revisited

--- a/macos/Sources/Features/Update/UpdateController.swift
+++ b/macos/Sources/Features/Update/UpdateController.swift
@@ -1,6 +1,7 @@
 import Sparkle
 import Cocoa
 import Combine
+import os
 
 /// Standard controller for managing Sparkle updates in Ghostty.
 ///
@@ -92,6 +93,9 @@ class UpdateController {
     ///
     /// This is typically connected to a menu item action.
     @objc func checkForUpdates() {
+        Logger(subsystem: "com.seansmithdesign.ghostties", category: "update")
+            .log("checkForUpdates tapped — state=\(String(describing: self.viewModel.state), privacy: .public) canCheck=\(self.updater.canCheckForUpdates, privacy: .public)")
+
         // If we're already idle, then just check for updates immediately.
         if viewModel.state == .idle {
             updater.checkForUpdates()

--- a/macos/Sources/Features/Update/UpdateController.swift
+++ b/macos/Sources/Features/Update/UpdateController.swift
@@ -17,14 +17,6 @@ class UpdateController {
         userDriver.viewModel
     }
 
-    #if DEBUG
-    /// The underlying SPUStandardUserDriver. Exposed for DEBUG-only UI testing
-    /// (e.g. showing Sparkle's native update-found dialog without a real network check).
-    var standardUserDriver: SPUStandardUserDriver {
-        userDriver.standard
-    }
-    #endif
-
     /// True if we're installing an update.
     var isInstalling: Bool {
         installCancellable != nil

--- a/macos/Sources/Features/Update/UpdateController.swift
+++ b/macos/Sources/Features/Update/UpdateController.swift
@@ -17,6 +17,14 @@ class UpdateController {
         userDriver.viewModel
     }
 
+    #if DEBUG
+    /// The underlying SPUStandardUserDriver. Exposed for DEBUG-only UI testing
+    /// (e.g. showing Sparkle's native update-found dialog without a real network check).
+    var standardUserDriver: SPUStandardUserDriver {
+        userDriver.standard
+    }
+    #endif
+
     /// True if we're installing an update.
     var isInstalling: Bool {
         installCancellable != nil

--- a/macos/Sources/Features/Update/UpdateViewModel.swift
+++ b/macos/Sources/Features/Update/UpdateViewModel.swift
@@ -217,6 +217,13 @@ enum UpdateState: Equatable {
 
     func cancel() {
         switch self {
+        case .permissionRequest(let request):
+            // Answer the wedged permission request with "yes, enable automatic checks"
+            // so Sparkle clears _showingPermissionRequest and allows the next
+            // checkForUpdates() call to proceed. Consistent with our silent-on default
+            // (SUEnableAutomaticChecks=true in Info.plist prevents this path on fresh
+            // installs, but older/wedged installs need an escape hatch here).
+            request.reply(SUUpdatePermissionResponse(automaticUpdateChecks: true, sendSystemProfile: false))
         case .checking(let checking):
             checking.cancel()
         case .updateAvailable(let available):


### PR DESCRIPTION
## Root cause

On first launch Sparkle issues a permission request ("Enable automatic update checks?"). The custom `UpdateDriver.show(_:reply:)` routes it to an in-app pill — but when a terminal window is visible (`hasUnobtrusiveTarget == true`), it suppresses the standard prompt and **never calls `reply`**. Sparkle stays in `_showingPermissionRequest=YES` / `_sessionInProgress=YES` forever. Every subsequent `checkForUpdates()` hits Sparkle's early-return guard (`SPUUpdater.m:697`) and silently drops — zero logs, no XPC helper process, nothing on screen.

## Product decision (locked)

Silent background checks, default ON. No consent prompt. The existing `config.autoUpdate` setting is the opt-out.

## Changes (4)

**1. `macos/Ghostties-Info.plist` — add `SUEnableAutomaticChecks = true`**
When this key is present at launch, Sparkle's `startUpdateCycle` sets `shouldPrompt = NO` and skips the permission-request path entirely on all fresh installs going forward.

**2. `.github/workflows/ghostties-release.yml` — stop CI from stripping the key**
The release prep previously ran `PlistBuddy -c "Delete :SUEnableAutomaticChecks"`, which stripped the key from every shipped build and put them straight back into the wedge. Changed to `Set :SUEnableAutomaticChecks true` with a comment explaining why it must stay.

**3. `macos/Sources/Features/Update/UpdateViewModel.swift` — add `.permissionRequest` to `cancel()`**
`UpdateState.cancel()` had no case for `.permissionRequest`, so a wedged install had no escape path. The new case fires `reply(SUUpdatePermissionResponse(automaticUpdateChecks: true, sendSystemProfile: false))`, answering the stuck question. After that, the existing 100ms-delayed `checkForUpdates()` in `UpdateController` proceeds to a real network check. (API confirmed from `Sparkle/SUUpdatePermissionResponse.h` — `initWithAutomaticUpdateChecks:sendSystemProfile:`)

**4. `macos/Sources/Features/Update/UpdateController.swift` — add `os_log` at `checkForUpdates()` entry**
Single `Logger` line at the top of `checkForUpdates()` (subsystem `com.seansmithdesign.ghostties`, category `update`) logs the current state and `canCheckForUpdates`. Lets the next CI-built artifact be verified with `log stream --predicate 'subsystem == "com.seansmithdesign.ghostties"'` to confirm the click reaches our code.

## Verification

- `xcodebuild` Release build: **BUILD SUCCEEDED** (no Swift errors, only pre-existing dsymutil warnings)
- `plutil -lint macos/Ghostties-Info.plist`: OK
- YAML lint: OK

## Test notes

The updater only starts inside `#if !DEBUG` (AppDelegate.swift), so this must be tested on a **CI-built, properly-signed release artifact** — not a local debug build. After installing the next beta:
1. `log stream --predicate 'subsystem == "com.seansmithdesign.ghostties" AND category == "update"'`
2. Click Ghostties → Check for Updates
3. Confirm the log line appears and `canCheck=true`
4. Confirm Sparkle proceeds to a network check (Downloader XPC process visible in Activity Monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)