### PR TITLE
chore: ignore zig-pkg/ cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 zig-cache/
 .zig-cache/
 zig-out/
+zig-pkg/
 build-cmake/
 CMakeCache.txt
 CMakeFiles/


### PR DESCRIPTION
Adds `zig-pkg/` to .gitignore — a regenerable local Zig package cache that was showing up as untracked noise in git status. No code changes.