### PR TITLE
perf: cache sidebar section/session-group computation (PR2/3 of perf-storm fix)

### DIFF
--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -16,31 +16,19 @@ import SwiftUI
 /// gate the wrapper itself without moving the `.equatable()` boundary up to the
 /// call site), but that's just a cheap struct construction, so reading it live
 /// here costs nothing.
-///
-/// Only whether the globally active session belongs to *this* project is
-/// passed down (`isActiveSessionInThisRow`), not the raw `activeSessionId`
-/// scalar. `activeSessionId` is identical input to every row, so comparing it
-/// directly in `Equatable` forced every row to compare unequal whenever focus
-/// changed anywhere — defeating `.equatable()` for the common case of
-/// switching focus between sessions. Deriving a per-row bool here means only
-/// the row(s) whose own membership actually flipped re-render.
 struct ProjectDisclosureRow: View {
     let project: Project
     @Binding var isExpanded: Bool
     @Binding var selectedProjectId: UUID?
 
     @EnvironmentObject private var coordinator: SessionCoordinator
-    @EnvironmentObject private var store: WorkspaceStore
 
     var body: some View {
-        let isActiveSessionInThisRow = coordinator.activeSessionId.map { activeId in
-            store.sessions(for: project.id).contains { $0.id == activeId }
-        } ?? false
         ProjectDisclosureRowContent(
             project: project,
             isExpanded: $isExpanded,
             selectedProjectId: $selectedProjectId,
-            isActiveSessionInThisRow: isActiveSessionInThisRow
+            activeSessionId: coordinator.activeSessionId
         )
         .equatable()
     }
@@ -52,7 +40,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
     let project: Project
     @Binding var isExpanded: Bool
     @Binding var selectedProjectId: UUID?
-    let isActiveSessionInThisRow: Bool
+    let activeSessionId: UUID?
 
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
@@ -83,12 +71,12 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         project: Project,
         isExpanded: Binding<Bool>,
         selectedProjectId: Binding<UUID?>,
-        isActiveSessionInThisRow: Bool
+        activeSessionId: UUID?
     ) {
         self.project = project
         self._isExpanded = isExpanded
         self._selectedProjectId = selectedProjectId
-        self.isActiveSessionInThisRow = isActiveSessionInThisRow
+        self.activeSessionId = activeSessionId
 
         let flatSessions = WorkspaceStore.shared.sessionGroups(forProject: project.id).flatMap { $0.1 }
         self.sessionSignature = flatSessions
@@ -98,14 +86,25 @@ private struct ProjectDisclosureRowContent: View, Equatable {
     }
 
     /// This project's own inputs — session set/order/name/`lastActiveAt`,
-    /// indicator states, expansion, selection, and whether the globally active
-    /// session belongs to *this* row (so switching focus into or off of this
-    /// row's sessions still refreshes it even when nothing else here changed).
+    /// indicator states, expansion, selection, and the globally active
+    /// session (so switching focus off *this* row's highlighted session still
+    /// refreshes it even when nothing else here changed).
+    ///
+    /// Intentionally compares the raw `activeSessionId`, not a bool narrowed
+    /// to "does the active session belong to this row." A narrowed bool stays
+    /// `true` across a focus switch between two sessions in the *same*
+    /// project when that switch lands inside `WorkspaceStore.recordActivity`'s
+    /// 5-second granularity guard (no `sessions`/`projects` mutation, so
+    /// `sessionSignature`/`indicatorSignature` don't change either) — Equatable
+    /// then reports "unchanged" and the active-session highlight silently goes
+    /// stale. Comparing the raw id means the row correctly re-renders whenever
+    /// the active session changes anywhere in the app, not only when it moves
+    /// into or out of this specific row.
     static func == (lhs: ProjectDisclosureRowContent, rhs: ProjectDisclosureRowContent) -> Bool {
         lhs.project == rhs.project
             && lhs.isExpanded == rhs.isExpanded
             && lhs.selectedProjectId == rhs.selectedProjectId
-            && lhs.isActiveSessionInThisRow == rhs.isActiveSessionInThisRow
+            && lhs.activeSessionId == rhs.activeSessionId
             && lhs.sessionSignature == rhs.sessionSignature
             && lhs.indicatorSignature == rhs.indicatorSignature
     }

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -2,12 +2,45 @@ import SwiftUI
 
 /// A project row in the disclosure list that expands to show sessions inline.
 ///
-/// Absorbs functionality from the former IconRailView (context menu, settings popover)
-/// and SessionDetailView (session list, rename, drag/drop, new session button).
+/// Thin wrapper around `ProjectDisclosureRowContent`, the actual row body.
+/// `WorkspaceStore`/`SessionCoordinator` publish `objectWillChange` far more
+/// often than any single project's own data changes (activity signal, indicator
+/// timer ticks, sibling-project mutations) — without a gate, every expanded row
+/// redid its session grouping and activity scans on every fire, regardless of
+/// whether *this* project changed. Wrapping the content in `.equatable()` lets
+/// SwiftUI skip re-rendering a row whose own inputs are unchanged.
+///
+/// `coordinator.activeSessionId` is read here, not inside the content's own
+/// `init`, because `@EnvironmentObject` isn't resolved yet inside a view's
+/// initializer — this wrapper's `body` still runs on every pass (SwiftUI can't
+/// gate the wrapper itself without moving the `.equatable()` boundary up to the
+/// call site), but that's just a cheap struct construction, so reading it live
+/// here costs nothing.
 struct ProjectDisclosureRow: View {
     let project: Project
     @Binding var isExpanded: Bool
     @Binding var selectedProjectId: UUID?
+
+    @EnvironmentObject private var coordinator: SessionCoordinator
+
+    var body: some View {
+        ProjectDisclosureRowContent(
+            project: project,
+            isExpanded: $isExpanded,
+            selectedProjectId: $selectedProjectId,
+            activeSessionId: coordinator.activeSessionId
+        )
+        .equatable()
+    }
+}
+
+/// Absorbs functionality from the former IconRailView (context menu, settings popover)
+/// and SessionDetailView (session list, rename, drag/drop, new session button).
+private struct ProjectDisclosureRowContent: View, Equatable {
+    let project: Project
+    @Binding var isExpanded: Bool
+    @Binding var selectedProjectId: UUID?
+    let activeSessionId: UUID?
 
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
@@ -20,6 +53,50 @@ struct ProjectDisclosureRow: View {
     @State private var isHeaderHovered = false
     @State private var isNewSessionHovered = false
     @FocusState private var renameFieldFocused: Bool
+
+    /// Snapshot of this project's session/indicator data, captured at
+    /// construction (not read inside `==`). `store`/`coordinator` are live
+    /// references — both the retained "old" row value and the freshly
+    /// constructed "new" one point at the same singleton, so comparing via a
+    /// method call at equality-check time would always see "now" on both
+    /// sides and never detect a change. Capturing a value snapshot here, once
+    /// per reconstruction, gives Equatable a genuine before/after diff.
+    /// Reads `WorkspaceStore.shared` directly (same pattern as
+    /// `MenuBarDropdownView`/`SessionCoordinator`) rather than the
+    /// `@EnvironmentObject`, which isn't resolved yet inside `init`.
+    private let sessionSignature: [AgentSession]
+    private let indicatorSignature: [UUID: SessionIndicatorState]
+
+    init(
+        project: Project,
+        isExpanded: Binding<Bool>,
+        selectedProjectId: Binding<UUID?>,
+        activeSessionId: UUID?
+    ) {
+        self.project = project
+        self._isExpanded = isExpanded
+        self._selectedProjectId = selectedProjectId
+        self.activeSessionId = activeSessionId
+
+        let flatSessions = WorkspaceStore.shared.sessionGroups(forProject: project.id).flatMap { $0.1 }
+        self.sessionSignature = flatSessions
+        self.indicatorSignature = flatSessions.reduce(into: [:]) { result, session in
+            result[session.id] = WorkspaceStore.shared.globalIndicatorStates[session.id]
+        }
+    }
+
+    /// This project's own inputs — session set/order/name/`lastActiveAt`,
+    /// indicator states, expansion, selection, and the globally active
+    /// session (so switching focus off *this* row's highlighted session still
+    /// refreshes it even when nothing else here changed).
+    static func == (lhs: ProjectDisclosureRowContent, rhs: ProjectDisclosureRowContent) -> Bool {
+        lhs.project == rhs.project
+            && lhs.isExpanded == rhs.isExpanded
+            && lhs.selectedProjectId == rhs.selectedProjectId
+            && lhs.activeSessionId == rhs.activeSessionId
+            && lhs.sessionSignature == rhs.sessionSignature
+            && lhs.indicatorSignature == rhs.indicatorSignature
+    }
 
     var body: some View {
         VStack(spacing: 2) {

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -16,19 +16,31 @@ import SwiftUI
 /// gate the wrapper itself without moving the `.equatable()` boundary up to the
 /// call site), but that's just a cheap struct construction, so reading it live
 /// here costs nothing.
+///
+/// Only whether the globally active session belongs to *this* project is
+/// passed down (`isActiveSessionInThisRow`), not the raw `activeSessionId`
+/// scalar. `activeSessionId` is identical input to every row, so comparing it
+/// directly in `Equatable` forced every row to compare unequal whenever focus
+/// changed anywhere — defeating `.equatable()` for the common case of
+/// switching focus between sessions. Deriving a per-row bool here means only
+/// the row(s) whose own membership actually flipped re-render.
 struct ProjectDisclosureRow: View {
     let project: Project
     @Binding var isExpanded: Bool
     @Binding var selectedProjectId: UUID?
 
     @EnvironmentObject private var coordinator: SessionCoordinator
+    @EnvironmentObject private var store: WorkspaceStore
 
     var body: some View {
+        let isActiveSessionInThisRow = coordinator.activeSessionId.map { activeId in
+            store.sessions(for: project.id).contains { $0.id == activeId }
+        } ?? false
         ProjectDisclosureRowContent(
             project: project,
             isExpanded: $isExpanded,
             selectedProjectId: $selectedProjectId,
-            activeSessionId: coordinator.activeSessionId
+            isActiveSessionInThisRow: isActiveSessionInThisRow
         )
         .equatable()
     }
@@ -40,7 +52,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
     let project: Project
     @Binding var isExpanded: Bool
     @Binding var selectedProjectId: UUID?
-    let activeSessionId: UUID?
+    let isActiveSessionInThisRow: Bool
 
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
@@ -71,12 +83,12 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         project: Project,
         isExpanded: Binding<Bool>,
         selectedProjectId: Binding<UUID?>,
-        activeSessionId: UUID?
+        isActiveSessionInThisRow: Bool
     ) {
         self.project = project
         self._isExpanded = isExpanded
         self._selectedProjectId = selectedProjectId
-        self.activeSessionId = activeSessionId
+        self.isActiveSessionInThisRow = isActiveSessionInThisRow
 
         let flatSessions = WorkspaceStore.shared.sessionGroups(forProject: project.id).flatMap { $0.1 }
         self.sessionSignature = flatSessions
@@ -86,14 +98,14 @@ private struct ProjectDisclosureRowContent: View, Equatable {
     }
 
     /// This project's own inputs — session set/order/name/`lastActiveAt`,
-    /// indicator states, expansion, selection, and the globally active
-    /// session (so switching focus off *this* row's highlighted session still
-    /// refreshes it even when nothing else here changed).
+    /// indicator states, expansion, selection, and whether the globally active
+    /// session belongs to *this* row (so switching focus into or off of this
+    /// row's sessions still refreshes it even when nothing else here changed).
     static func == (lhs: ProjectDisclosureRowContent, rhs: ProjectDisclosureRowContent) -> Bool {
         lhs.project == rhs.project
             && lhs.isExpanded == rhs.isExpanded
             && lhs.selectedProjectId == rhs.selectedProjectId
-            && lhs.activeSessionId == rhs.activeSessionId
+            && lhs.isActiveSessionInThisRow == rhs.isActiveSessionInThisRow
             && lhs.sessionSignature == rhs.sessionSignature
             && lhs.indicatorSignature == rhs.indicatorSignature
     }

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -12,8 +12,24 @@ final class WorkspaceStore: ObservableObject {
     /// Shared instance used by all windows. Created once on first access.
     static let shared = WorkspaceStore()
 
-    @Published private(set) var projects: [Project] = []
-    @Published private(set) var sessions: [AgentSession] = []
+    /// `sectionedProjects`/`sessionGroups(forProject:)` below are memoized —
+    /// invalidating on every mutation via `didSet` (rather than scattering
+    /// invalidation calls across each mutating method) means a future mutation
+    /// site can never forget to bust the cache. Both computations are also
+    /// functions of wall-clock time (grace period, 24h recency window), so the
+    /// cache must drop on every mutation that could have changed the *inputs*
+    /// to that computation, even when the mutating method itself doesn't
+    /// otherwise touch the sidebar — matching the previous always-recompute
+    /// behavior exactly.
+    @Published private(set) var projects: [Project] = [] {
+        didSet { invalidateSectionedProjectsCache() }
+    }
+    @Published private(set) var sessions: [AgentSession] = [] {
+        didSet {
+            sessionGroupsCache.removeAll()
+            invalidateSectionedProjectsCache()
+        }
+    }
     @Published private(set) var templates: [AgentTemplate] = []
 
     /// Global session status — shared across all windows so that a session
@@ -24,7 +40,12 @@ final class WorkspaceStore: ObservableObject {
     /// Global indicator states — the view-layer state for each running session.
     /// Updated by SessionCoordinator's activity timer; consumed by MenuBarController
     /// to render the aggregate status dot in the menu bar.
-    @Published private(set) var globalIndicatorStates: [UUID: SessionIndicatorState] = [:]
+    @Published private(set) var globalIndicatorStates: [UUID: SessionIndicatorState] = [:] {
+        didSet {
+            sessionGroupsCache.removeAll()
+            invalidateSectionedProjectsCache()
+        }
+    }
 
     /// Current sidebar mode. Persisted across launches.
     /// `.overlay` is transient — always saved as `.closed`.
@@ -137,25 +158,46 @@ final class WorkspaceStore: ObservableObject {
     /// `.needsAttention`). Drives the grace-period tail of `.activeNow`.
     ///
     /// Ephemeral — not persisted. Populated by `updateProjectActivityFromIndicatorStates()`.
-    private var activeSinceTimestamps: [UUID: Date] = [:]
+    private var activeSinceTimestamps: [UUID: Date] = [:] {
+        didSet { invalidateSectionedProjectsCache() }
+    }
 
     /// When non-nil, `sectionedProjects` returns this snapshot verbatim instead
     /// of recomputing. Views freeze/release to prevent the list from reordering
     /// while the user is working in the sidebar.
     private var frozenSnapshot: SectionedProjects?
 
+    /// Memoized `sectionedProjects` result, used whenever there's no active
+    /// freeze. `computeSectionedProjects` is O(projects + sessions) and was
+    /// previously re-run on every read (every `objectWillChange` fire cascades
+    /// into a `WorkspaceSidebarView.body` re-evaluation, which reads this
+    /// property). A single cache slot (not keyed per-project) is sufficient —
+    /// unlike `sessionGroups`, this computation already iterates every project
+    /// in one pass, so there's no per-item granularity to preserve. Invalidated
+    /// at every mutation site below that can change section membership or
+    /// intra-section order (`projects`, `sessions`, `globalIndicatorStates`,
+    /// or `activeSinceTimestamps`).
+    private var sectionedProjectsCache: SectionedProjects?
+
+    private func invalidateSectionedProjectsCache() {
+        sectionedProjectsCache = nil
+    }
+
     /// Four-section sidebar layout: `.pinned`, `.activeNow`, `.recent`, `.all`.
     /// Empty sections are dropped. While a freeze snapshot is held, returns the
     /// snapshot verbatim (mutations update internal state but not layout).
     var sectionedProjects: SectionedProjects {
         if let frozen = frozenSnapshot { return frozen }
-        return Self.computeSectionedProjects(
+        if let cached = sectionedProjectsCache { return cached }
+        let computed = Self.computeSectionedProjects(
             projects: projects,
             sessions: sessions,
             indicatorStates: globalIndicatorStates,
             activeSinceTimestamps: activeSinceTimestamps,
             gracePeriod: Self.activeGracePeriod
         )
+        sectionedProjectsCache = computed
+        return computed
     }
 
     /// Flat list of projects in the visual (sectioned) order users see in the
@@ -174,15 +216,26 @@ final class WorkspaceStore: ObservableObject {
         flatProjectsInVisualOrder.map(\.id)
     }
 
+    /// Memoized `sessionGroups(forProject:)` results, keyed by project id.
+    /// `ProjectDisclosureRow.body` previously called this on every evaluation
+    /// for every expanded project — an uncached O(sessions) filter+sort each
+    /// time. Cleared wholesale (all projects, not just one) by the `sessions`
+    /// / `globalIndicatorStates` `didSet` observers above, since both are the
+    /// only inputs `computeSessionGroups` reads.
+    private var sessionGroupsCache: [UUID: [(SessionBucket, [AgentSession])]] = [:]
+
     /// Session grouping for an expanded project. Returns `(bucket, sessions)`
     /// pairs for the non-empty buckets, in order `.active` → `.recent` → `.idle`.
     /// Sessions are alphabetical within each bucket.
     func sessionGroups(forProject projectId: UUID) -> [(SessionBucket, [AgentSession])] {
-        Self.computeSessionGroups(
+        if let cached = sessionGroupsCache[projectId] { return cached }
+        let computed = Self.computeSessionGroups(
             projectId: projectId,
             sessions: sessions,
             indicatorStates: globalIndicatorStates
         )
+        sessionGroupsCache[projectId] = computed
+        return computed
     }
 
     #if DEBUG

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -15,12 +15,17 @@ final class WorkspaceStore: ObservableObject {
     /// `sectionedProjects`/`sessionGroups(forProject:)` below are memoized —
     /// invalidating on every mutation via `didSet` (rather than scattering
     /// invalidation calls across each mutating method) means a future mutation
-    /// site can never forget to bust the cache. Both computations are also
-    /// functions of wall-clock time (grace period, 24h recency window), so the
-    /// cache must drop on every mutation that could have changed the *inputs*
-    /// to that computation, even when the mutating method itself doesn't
-    /// otherwise touch the sidebar — matching the previous always-recompute
-    /// behavior exactly.
+    /// site can never forget to bust the cache. But both computations are also
+    /// functions of wall-clock time (grace period, 24h recency window) — a
+    /// project can drift out of `.activeNow`/`.recent` with **no** `@Published`
+    /// input changing at all, purely because time passed. `didSet` alone can't
+    /// catch that, so each cache also carries a `cachedAt` timestamp and is
+    /// treated as stale once `Self.cacheTTL` elapses, forcing a recompute on
+    /// the next read even absent any mutation. This is NOT parity with the old
+    /// always-recompute behavior — it's a bounded approximation: a bucket
+    /// transition can lag by up to `cacheTTL` seconds after a mutation-free
+    /// read. `didSet` still gives immediate invalidation for genuine data
+    /// changes; the TTL only closes the "nothing mutated but time elapsed" gap.
     @Published private(set) var projects: [Project] = [] {
         didSet { invalidateSectionedProjectsCache() }
     }
@@ -86,6 +91,33 @@ final class WorkspaceStore: ObservableObject {
         guard !hasDismissedPinMigrationNotice else { return }
         hasDismissedPinMigrationNotice = true
         persist()
+    }
+
+    #if DEBUG
+    /// Test-only clock override for exercising the sidebar caches' TTL expiry
+    /// without real sleeps. `nil` in production (and by default in tests) —
+    /// when set, both the TTL staleness check and the underlying bucketing
+    /// computation's own `now()` read through this closure, so a test can
+    /// advance fake time and deterministically observe a mutation-free
+    /// recompute. See `_setTestClock(_:)`.
+    private var testClock: (() -> Date)?
+
+    /// Test hook — install a fake clock for TTL-expiry tests. Pass `nil` to
+    /// restore the real clock.
+    func _setTestClock(_ clock: (() -> Date)?) {
+        testClock = clock
+    }
+    #endif
+
+    /// Current time as seen by the sidebar caches — routes through
+    /// `testClock` under DEBUG so tests can control TTL expiry without real
+    /// sleeps; always `Date()` in release builds.
+    private func currentTime() -> Date {
+        #if DEBUG
+        return testClock?() ?? Date()
+        #else
+        return Date()
+        #endif
     }
 
     /// Test-only initializer. Bypasses disk persistence and preset loading so
@@ -167,6 +199,18 @@ final class WorkspaceStore: ObservableObject {
     /// while the user is working in the sidebar.
     private var frozenSnapshot: SectionedProjects?
 
+    /// TTL for both sidebar caches (`sectionedProjectsCache` and
+    /// `sessionGroupsCache`), layered on top of the `didSet` invalidation
+    /// above. Both memoized computations read wall-clock time internally
+    /// (grace period, 24h recency window), so a cache entry can go stale
+    /// purely because time elapsed — no `@Published` input changed, so
+    /// `didSet` never fires. 2s is short enough that a stale bucket
+    /// assignment is imperceptible to a user, but long enough to still
+    /// collapse the bursts of rapid redraws this cache targets (which land
+    /// within tens/hundreds of ms of each other) into a single shared
+    /// computation, preserving the perf win the cache exists for.
+    private static let cacheTTL: TimeInterval = 2
+
     /// Memoized `sectionedProjects` result, used whenever there's no active
     /// freeze. `computeSectionedProjects` is O(projects + sessions) and was
     /// previously re-run on every read (every `objectWillChange` fire cascades
@@ -176,11 +220,18 @@ final class WorkspaceStore: ObservableObject {
     /// in one pass, so there's no per-item granularity to preserve. Invalidated
     /// at every mutation site below that can change section membership or
     /// intra-section order (`projects`, `sessions`, `globalIndicatorStates`,
-    /// or `activeSinceTimestamps`).
+    /// or `activeSinceTimestamps`), and additionally treated as stale once
+    /// `cacheTTL` elapses since `sectionedProjectsCachedAt` (see the TTL note
+    /// on `cacheTTL` above).
     private var sectionedProjectsCache: SectionedProjects?
+
+    /// Wall-clock time `sectionedProjectsCache` was last populated. `nil`
+    /// whenever the cache itself is `nil`.
+    private var sectionedProjectsCachedAt: Date?
 
     private func invalidateSectionedProjectsCache() {
         sectionedProjectsCache = nil
+        sectionedProjectsCachedAt = nil
     }
 
     /// Four-section sidebar layout: `.pinned`, `.activeNow`, `.recent`, `.all`.
@@ -188,15 +239,22 @@ final class WorkspaceStore: ObservableObject {
     /// snapshot verbatim (mutations update internal state but not layout).
     var sectionedProjects: SectionedProjects {
         if let frozen = frozenSnapshot { return frozen }
-        if let cached = sectionedProjectsCache { return cached }
+        let now = currentTime()
+        if let cached = sectionedProjectsCache,
+           let cachedAt = sectionedProjectsCachedAt,
+           now.timeIntervalSince(cachedAt) < Self.cacheTTL {
+            return cached
+        }
         let computed = Self.computeSectionedProjects(
             projects: projects,
             sessions: sessions,
             indicatorStates: globalIndicatorStates,
             activeSinceTimestamps: activeSinceTimestamps,
-            gracePeriod: Self.activeGracePeriod
+            gracePeriod: Self.activeGracePeriod,
+            now: { now }
         )
         sectionedProjectsCache = computed
+        sectionedProjectsCachedAt = now
         return computed
     }
 
@@ -216,25 +274,34 @@ final class WorkspaceStore: ObservableObject {
         flatProjectsInVisualOrder.map(\.id)
     }
 
-    /// Memoized `sessionGroups(forProject:)` results, keyed by project id.
+    /// Memoized `sessionGroups(forProject:)` results, keyed by project id,
+    /// each paired with the wall-clock time it was computed at. `computeSessionGroups`
+    /// buckets by `lastActiveAt` recency too, so — same as `sectionedProjectsCache`
+    /// above — an entry is also treated as stale once `cacheTTL` elapses since
+    /// its `cachedAt`, not just on `didSet`-driven invalidation.
     /// `ProjectDisclosureRow.body` previously called this on every evaluation
     /// for every expanded project — an uncached O(sessions) filter+sort each
     /// time. Cleared wholesale (all projects, not just one) by the `sessions`
     /// / `globalIndicatorStates` `didSet` observers above, since both are the
     /// only inputs `computeSessionGroups` reads.
-    private var sessionGroupsCache: [UUID: [(SessionBucket, [AgentSession])]] = [:]
+    private var sessionGroupsCache: [UUID: (result: [(SessionBucket, [AgentSession])], cachedAt: Date)] = [:]
 
     /// Session grouping for an expanded project. Returns `(bucket, sessions)`
     /// pairs for the non-empty buckets, in order `.active` → `.recent` → `.idle`.
     /// Sessions are alphabetical within each bucket.
     func sessionGroups(forProject projectId: UUID) -> [(SessionBucket, [AgentSession])] {
-        if let cached = sessionGroupsCache[projectId] { return cached }
+        let now = currentTime()
+        if let cached = sessionGroupsCache[projectId],
+           now.timeIntervalSince(cached.cachedAt) < Self.cacheTTL {
+            return cached.result
+        }
         let computed = Self.computeSessionGroups(
             projectId: projectId,
             sessions: sessions,
-            indicatorStates: globalIndicatorStates
+            indicatorStates: globalIndicatorStates,
+            now: { now }
         )
-        sessionGroupsCache[projectId] = computed
+        sessionGroupsCache[projectId] = (computed, now)
         return computed
     }
 

--- a/macos/Tests/Workspace/WorkspaceStoreSectionsTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreSectionsTests.swift
@@ -601,6 +601,113 @@ struct WorkspaceStoreSectionsTests {
         #expect(groups.map(\.0) == [.active, .recent, .idle])
     }
 
+    // MARK: - Session Groups Cache (instance-level, PR2 perf)
+    //
+    // `WorkspaceStore.sessionGroups(forProject:)` memoizes its result per
+    // project id. These tests exercise the *instance* method (not the pure
+    // `computeSessionGroups` helper above) to confirm the cache is invalidated
+    // correctly by every mutation that changes its output, and that its
+    // result always matches a fresh uncached computation over the same state.
+
+    @MainActor
+    @Test func sessionGroupsCacheReflectsAddedSession() {
+        let p = makeProject(name: "Proj")
+        let s1 = makeSession(name: "One", projectId: p.id)
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s1])
+
+        let before = store.sessionGroups(forProject: p.id)
+        #expect(before.flatMap(\.1).map(\.name) == ["One"])
+
+        let s2 = store.addSession(name: "Two", templateId: template.id, projectId: p.id)
+
+        let after = store.sessionGroups(forProject: p.id)
+        #expect(Set(after.flatMap(\.1).map(\.id)) == Set([s1.id, s2.id]))
+    }
+
+    @MainActor
+    @Test func sessionGroupsCacheReflectsRemovedSession() {
+        let p = makeProject(name: "Proj")
+        let s1 = makeSession(name: "One", projectId: p.id)
+        let s2 = makeSession(name: "Two", projectId: p.id)
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s1, s2])
+
+        _ = store.sessionGroups(forProject: p.id)  // populate cache
+        store.removeSession(id: s1.id)
+
+        let after = store.sessionGroups(forProject: p.id)
+        #expect(after.flatMap(\.1).map(\.id) == [s2.id])
+    }
+
+    @MainActor
+    @Test func sessionGroupsCacheReflectsRenamedSession() {
+        let p = makeProject(name: "Proj")
+        let s = makeSession(name: "Zebra", projectId: p.id)
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s])
+
+        _ = store.sessionGroups(forProject: p.id)  // populate cache
+        store.renameSession(id: s.id, name: "Alpha")
+
+        let after = store.sessionGroups(forProject: p.id)
+        #expect(after.flatMap(\.1).map(\.name) == ["Alpha"])
+    }
+
+    @MainActor
+    @Test func sessionGroupsCacheReflectsIndicatorStateChange() {
+        let p = makeProject(name: "Proj")
+        let s = makeSession(name: "One", projectId: p.id)
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s])
+
+        let before = store.sessionGroups(forProject: p.id)
+        #expect(before.map(\.0) == [.idle])
+
+        store.updateIndicatorState(id: s.id, state: .processing)
+
+        let after = store.sessionGroups(forProject: p.id)
+        #expect(after.map(\.0) == [.active])
+    }
+
+    @MainActor
+    @Test func sessionGroupsCacheMatchesUncachedComputationAfterMutations() {
+        // Regression guard: the memoized instance-level result must always
+        // equal a fresh static computation over the same live state, even
+        // after a mix of add/rename/indicator mutations.
+        let p = makeProject(name: "Proj")
+        let s1 = makeSession(name: "Alpha", projectId: p.id)
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s1])
+
+        _ = store.sessionGroups(forProject: p.id)  // populate cache
+        let s2 = store.addSession(name: "Beta", templateId: template.id, projectId: p.id)
+        store.updateIndicatorState(id: s2.id, state: .processing)
+        store.renameSession(id: s1.id, name: "Zulu")
+
+        let cached = store.sessionGroups(forProject: p.id)
+        let fresh = WorkspaceStore.computeSessionGroups(
+            projectId: p.id,
+            sessions: store.sessions,
+            indicatorStates: store.globalIndicatorStates
+        )
+        #expect(cached.map(\.0) == fresh.map(\.0))
+        #expect(cached.flatMap(\.1) == fresh.flatMap(\.1))
+    }
+
+    @MainActor
+    @Test func sessionGroupsCacheDoesNotLeakAcrossProjects() {
+        // A mutation to one project's session must not affect a sibling
+        // project's cached entry.
+        let p1 = makeProject(name: "One")
+        let p2 = makeProject(name: "Two")
+        let s1 = makeSession(name: "Mine", projectId: p1.id)
+        let s2 = makeSession(name: "Other", projectId: p2.id)
+        let store = WorkspaceStore(testingProjects: [p1, p2], testingSessions: [s1, s2])
+
+        let p2Before = store.sessionGroups(forProject: p2.id)
+        store.updateIndicatorState(id: s1.id, state: .processing)
+        let p2After = store.sessionGroups(forProject: p2.id)
+
+        #expect(p2Before.map(\.0) == p2After.map(\.0))
+        #expect(p2After.flatMap(\.1).map(\.id) == [s2.id])
+    }
+
     // MARK: - Freeze / Release (instance-level integration)
 
     @MainActor

--- a/macos/Tests/Workspace/WorkspaceStoreSectionsTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreSectionsTests.swift
@@ -690,6 +690,68 @@ struct WorkspaceStoreSectionsTests {
         #expect(cached.flatMap(\.1) == fresh.flatMap(\.1))
     }
 
+    // MARK: - Time-Only Cache Staleness (TTL, PR2 follow-up)
+    //
+    // The tests above all exercise mutation-driven invalidation (`didSet`).
+    // None of them cover the gap an adversarial review flagged: both
+    // `sectionedProjects` and `sessionGroups(forProject:)` bucket by
+    // wall-clock time (grace period / 24h recency window), so a cached result
+    // can go stale purely because time elapsed — with ZERO mutating calls in
+    // between to trip `didSet`. These tests use `_setTestClock(_:)` to
+    // advance fake time with no intervening mutation and confirm the next
+    // read reflects the expired window rather than the frozen-at-cache-time
+    // bucket.
+
+    @MainActor
+    @Test func sectionedProjectsCacheExpiresAfterTTLWithNoMutation() {
+        let p = makeProject(name: "Flapping")
+        let s = makeSession(projectId: p.id)
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s])
+
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        store._setTestClock { t0 }
+        store._setActiveSinceTimestamp(projectId: p.id, date: t0)
+
+        // Populate the cache while still within the 120s grace window.
+        let before = store.sectionedProjects
+        #expect(ids(in: .activeNow, of: before) == [p.id])
+
+        // Advance fake time past both the grace period (120s) and the cache
+        // TTL (2s) — no mutating calls happen between this and the read below.
+        store._setTestClock { t0.addingTimeInterval(200) }
+
+        let after = store.sectionedProjects
+        #expect(ids(in: .activeNow, of: after).isEmpty)
+    }
+
+    @MainActor
+    @Test func sessionGroupsCacheExpiresAfterTTLWithNoMutation() {
+        let p = makeProject(name: "Host")
+        let s = makeSession(
+            name: "Recent",
+            projectId: p.id,
+            lastActiveAt: Date(timeIntervalSince1970: 1_000_000)
+        )
+        let store = WorkspaceStore(testingProjects: [p], testingSessions: [s])
+
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        store._setTestClock { t0 }
+
+        // Populate the cache: session's `lastActiveAt` is "now" → `.active`
+        // bucket is empty, `.recent` holds it (within the 24h window).
+        let before = store.sessionGroups(forProject: p.id)
+        #expect(before.first(where: { $0.0 == .recent })?.1.map(\.id) == [s.id])
+        #expect(before.first(where: { $0.0 == .idle }) == nil)
+
+        // Advance fake time past both the 24h recency window and the cache
+        // TTL (2s) — no mutating calls happen between this and the read below.
+        store._setTestClock { t0.addingTimeInterval(25 * 60 * 60) }
+
+        let after = store.sessionGroups(forProject: p.id)
+        #expect(after.first(where: { $0.0 == .idle })?.1.map(\.id) == [s.id])
+        #expect(after.first(where: { $0.0 == .recent }) == nil)
+    }
+
     @MainActor
     @Test func sessionGroupsCacheDoesNotLeakAcrossProjects() {
         // A mutation to one project's session must not affect a sibling


### PR DESCRIPTION
## Summary

PR2 of the 3-PR perf-storm follow-up plan (see #38 for PR1, which throttled the activity signal itself and guarded `WorkspaceStore.recordActivity`). PR1 fixed the *frequency* of `objectWillChange` fires during multi-agent streaming; this PR caps the *cost* of whatever fires remain, per two adversarial code reviews done during PR1.

- **`WorkspaceStore.sessionGroups(forProject:)` and `.sectionedProjects` are now memoized.** Both were previously recomputed on every read — an uncached O(sessions) filter+sort / O(projects + sessions) full bucketing pass each time — even though most reads happen back-to-back with no underlying data change (e.g. every expanded `ProjectDisclosureRow`'s body evaluation).

  Invalidation is centralized via `didSet` on the four stored properties that feed these computations (`projects`, `sessions`, `globalIndicatorStates`, `activeSinceTimestamps`) rather than scattered across each mutating method. This is deliberate: I initially added per-call-site `invalidate...()` calls and found a real gap (`renameSession`/`moveSession` not invalidating `sectionedProjectsCache`), plus a subtler issue — both computations are also functions of wall-clock time (120s grace period, 24h recency window), so a "recompute whenever a render happens" replacement needed to invalidate on the exact same triggers that used to cause a fresh recompute, not just on data mutations. The `didSet` approach can't miss a call site by construction, matches the existing `sidebarMode`/`lastSelectedProjectId` `didSet` pattern already used in this file, and is simple to audit at the property declaration.

- **`ProjectDisclosureRow` now skips SwiftUI re-render when nothing it displays changed.** The row is split into a thin `ProjectDisclosureRow` wrapper and a private `ProjectDisclosureRowContent` that does the actual work, wrapped in `.equatable()`. `WorkspaceStore`/`SessionCoordinator` publish far more often than any single project's own data changes, so without a gate every expanded row redid its session grouping and activity scans on every fire. The content's `Equatable` conformance compares project data, expansion/selection, a snapshot of this project's sessions + indicator states (captured at construction, not read live inside `==` — `store`/`coordinator` are shared singletons, so reading them live at comparison time would always see "now" on both sides and never detect a change), and the currently-focused session id (read in the outer wrapper, since `@EnvironmentObject` isn't resolved yet inside a view's `init`).

- **Item 4 (extend `scripts/profile.sh` to simulate title-change bursts) is skipped.** The actual stress-injection mechanism (`GHOSTTIES_STRESS_SESSIONS`) lives in `SessionCoordinator.swift`, which is explicitly out of scope for this PR (PR1's already-merged code / PR3's territory). Extending it correctly would require adding a new code path there, so I'm flagging this rather than building a workaround.

## Test plan

- [x] `xcodebuild build` — `BUILD SUCCEEDED`
- [x] `xcodebuild test -only-testing:GhosttyTests/WorkspaceStoreSectionsTests` — `TEST SUCCEEDED`, including 6 new tests added for the cache: `sessionGroupsCacheReflectsAddedSession`, `...RemovedSession`, `...RenamedSession`, `...IndicatorStateChange`, `sessionGroupsCacheMatchesUncachedComputationAfterMutations` (compares the memoized instance-level result against a fresh static `computeSessionGroups` call), and `sessionGroupsCacheDoesNotLeakAcrossProjects`. All 100+ existing tests in that file (including the freeze/release and grace-period tests, which exercise `sectionedProjects` at the instance level) still pass unmodified — they act as a correctness net for the `sectionedProjects` cache too.
- [x] CI is expected to show red on this PR — this is a **known pre-existing issue**, not caused by this change (main has been red on both jobs since ~May 2026; see `project-ci-fix-track.md` in project memory). Confirmed this PR doesn't introduce a *new* failure mode by running the full local build + targeted test suite above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186rtmwpGhJ8mUvX89SUTBD