### PR TITLE
docs(release): beta.19 changelog + web catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ First distributable build. Ghostties can now be installed and kept up to date au
 
 ---
 
+[0.1.0-beta.19]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.19
 [0.1.0-beta.18]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.18
 [0.1.0-beta.17]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.17
 [0.1.0-beta.16]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [0.1.0-beta.19] — 2026-07-05
+
+The workspace stays responsive when several agents are running at once.
+
+### Fixed
+
+- **Running multiple agents no longer pins the CPU.** With a few Claude Code sessions streaming at the same time, the workspace could peg a core and beachball the app until you force-quit it. The sidebar was rebuilding itself on every terminal-title change — many times a second, per session — and redoing that work for every project row whether or not anything had actually changed. Activity updates are now throttled, and the sidebar only redraws the rows that changed. The app keeps up under real multi-agent load.
+
+### Performance
+
+- Task list reloads incrementally — only the task files that changed are re-read, instead of re-parsing every task on any file-system event.
+
+---
+
 ## [0.1.0-beta.18] — 2026-06-19
 
 The first build delivered to existing users over the air — it confirms auto-updates work end to end. No other changes from beta.17.

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -238,6 +238,55 @@
       <p><strong style="color:rgba(255,255,255,0.6)">Beta.15 and earlier:</strong> Auto-updates aren't reliable yet in early betas. Download the latest release manually from the <a href="/download">download page</a>.</p>
     </div>
 
+    <!-- beta.19 -->
+    <div class="release">
+      <div class="release-heading">
+        <h3>v0.1.0-beta.19</h3>
+        <span class="date">July 5, 2026</span>
+      </div>
+      <p class="release-summary">The workspace stays responsive when several agents are running at once.</p>
+
+      <div class="release-section">
+        <h4>Fixed</h4>
+        <ul>
+          <li>Running multiple agents no longer pins the CPU &mdash; the sidebar was rebuilding itself on every terminal-title change and redoing that work for every project row whether or not anything had changed, which could peg a core and beachball the app until you force-quit it. Activity updates are now throttled and the sidebar only redraws the rows that changed.</li>
+        </ul>
+      </div>
+
+      <div class="release-section">
+        <h4>Performance</h4>
+        <ul>
+          <li>Task list reloads incrementally &mdash; only the task files that changed are re-read, instead of re-parsing every task on any file-system event.</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- beta.18 -->
+    <div class="release">
+      <div class="release-heading">
+        <h3>v0.1.0-beta.18</h3>
+        <span class="date">June 19, 2026</span>
+      </div>
+      <p class="release-summary">The first build delivered to existing users over the air &mdash; it confirms auto-updates work end to end.</p>
+    </div>
+
+    <!-- beta.17 -->
+    <div class="release">
+      <div class="release-heading">
+        <h3>v0.1.0-beta.17</h3>
+        <span class="date">June 19, 2026</span>
+      </div>
+      <p class="release-summary">Auto-updates work now, and the workspace sidebar no longer freezes the app.</p>
+
+      <div class="release-section">
+        <h4>Fixed</h4>
+        <ul>
+          <li>Auto-updates now work &mdash; &ldquo;Check for Updates&rdquo; was silently doing nothing in beta.16, and the in-app update notification never rendered in the workspace window. Ghostties now checks for updates in the background and shows a notification pill when a new version is ready.</li>
+          <li>Sidebar no longer freezes the app &mdash; opening the project sidebar could peg the CPU and beachball the window.</li>
+        </ul>
+      </div>
+    </div>
+
     <!-- beta.16 -->
     <div class="release">
       <div class="release-heading">


### PR DESCRIPTION
## Summary
- Adds a `## [0.1.0-beta.19]` entry to `CHANGELOG.md` documenting the fix for the multi-agent CPU-pinning/beachball bug (throttled activity updates, per-row sidebar diffing) plus the incremental task-list reload performance improvement.
- Backfills `web/changelog.html`, which had fallen behind at beta.16 — adds beta.19, beta.18, and beta.17 release blocks (newest first), matching the existing markup/entity conventions.
- Docs only — no source files touched.

## Test plan
- [x] `grep -n "beta.19" CHANGELOG.md` confirms the new entry sits above beta.18
- [x] `grep -n "v0.1.0-beta.1[6789]" web/changelog.html` confirms order: 19, 18, 17, 16
- [x] Verified balanced `<div>` structure for each new release block, matching the beta.16 pattern
- [x] `git diff --name-only` shows only `CHANGELOG.md` and `web/changelog.html` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186rtmwpGhJ8mUvX89SUTBD