### PR TITLE
perf: cap unbounded WorkspaceStore.sessions growth (launch-time prune)

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
+++ b/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
@@ -265,6 +265,30 @@ struct WorkspacePersistence {
         try? FileManager.default.moveItem(at: url, to: backupURL)
     }
 
+    /// Safety net for `WorkspaceStore.pruneStaleSessionsAtLaunch()` — copies
+    /// the on-disk `workspace.json` to a sibling `workspace.json.pre-prune.bak`
+    /// (overwriting any previous backup) BEFORE the caller commits a
+    /// destructive prune. Unlike `backupCorruptFile(at:)` above, this uses
+    /// `copyItem` (not `moveItem`) — the original file must survive so the
+    /// caller's subsequent `persist()` call still overwrites it normally.
+    ///
+    /// Silent no-op if `workspace.json` doesn't exist yet on disk (fresh
+    /// install, or the test-only in-memory init path where
+    /// `persistenceDisabled` is `true` and nothing was ever written) — there's
+    /// nothing to back up.
+    static func backUpBeforePrune(prunedCount: Int) {
+        let url = fileURL
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        let backupURL = url.appendingPathExtension("pre-prune.bak")
+        try? FileManager.default.removeItem(at: backupURL)
+        do {
+            try FileManager.default.copyItem(at: url, to: backupURL)
+            logger.notice("Pruned \(prunedCount) stale session(s) at launch — backed up prior workspace.json to \(backupURL.path, privacy: .public)")
+        } catch {
+            logger.error("Failed to back up workspace.json before session prune: \(error.localizedDescription)")
+        }
+    }
+
     static func save(_ state: State) {
         let signpostState = Perf.signposter.beginInterval("workspace.save")
         defer { Perf.signposter.endInterval("workspace.save", signpostState) }

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -176,6 +176,109 @@ final class WorkspaceStore: ObservableObject {
         // Order: presets first, then built-in defaults, then custom templates.
         let customTemplates = state.templates.filter { !$0.isDefault }
         self.templates = presets + AgentTemplate.defaults + customTemplates
+
+        // `sessions` is never pruned — every agent session ever spawned stays
+        // in workspace.json forever, so this list grows unbounded over the
+        // app's lifetime (a few KB now, but it's a slow leak). Prune exactly
+        // once here, at the tail end of the real disk-load init, never on any
+        // runtime mutation path: at launch nothing has a live runtime yet, so
+        // pruning can never delete an in-flight session, whereas pruning
+        // during normal operation risks deleting a session that's actually
+        // running. This MUST be a method call (not inlined statements) — see
+        // `pruneStaleSessionsAtLaunch()` for why.
+        pruneStaleSessionsAtLaunch()
+    }
+
+    // MARK: - Session Pruning
+
+    /// Retention window for `pruneStaleSessionsAtLaunch()` — a session younger
+    /// than this (by `lastActiveAt`) is always kept, regardless of how many
+    /// other sessions its project has.
+    static let sessionRetentionWindow: TimeInterval = 30 * 24 * 60 * 60
+
+    /// Per-project floor for `pruneStaleSessionsAtLaunch()` — the most-recent
+    /// N sessions in a project are always kept, regardless of age. Together
+    /// with `sessionRetentionWindow` this gives a keep-if-**either** rule: a
+    /// session survives if it's recent enough OR it's one of its project's
+    /// top-N most-recently-active sessions. Only a session that fails BOTH
+    /// checks (stale *and* outside its project's recency floor) gets dropped.
+    /// This guarantees pruning can never touch a project's most useful recent
+    /// history even if that project has been dormant for months.
+    static let maxRetainedSessionsPerProject = 15
+
+    /// One-time launch prune for `sessions`. Called as the LAST statement of
+    /// the real (disk-load) `init()` — deliberately a plain method call
+    /// rather than inline statements in `init()`'s body. By the time `init()`
+    /// can call a method on `self`, the instance is fully initialized, so
+    /// this method's `self.sessions = ...` assignment goes through normal
+    /// "phase 2" semantics (the `didSet` on `sessions` fires exactly like it
+    /// does everywhere else in this class, and `persist()`'s capture list
+    /// picks up the pruned array). Doing this inline in `init()` instead would
+    /// leave it ambiguous whether `didSet` fires reliably given `sessions`
+    /// already has a declaration-site default.
+    ///
+    /// Policy (see `sessionRetentionWindow` / `maxRetainedSessionsPerProject`
+    /// above): a session is kept if EITHER (1) its `lastActiveAt` is within
+    /// the retention window (a `nil` `lastActiveAt` fails this condition —
+    /// treated as "never active"), OR (2) it ranks among its own project's
+    /// most-recent `maxRetainedSessionsPerProject` sessions by `lastActiveAt`
+    /// descending (nil ranks last). A session is pruned only when both fail.
+    /// `globalIndicatorStates` and `activeSinceTimestamps` are both ephemeral,
+    /// runtime-only, and empty at launch, so there's nothing to clean up in
+    /// them here.
+    internal func pruneStaleSessionsAtLaunch() {
+        // Group session indices by project so the recency ranking (condition 2)
+        // is computed independently per project — one project's dormant
+        // history must not push another project's sessions out of their own
+        // top-N.
+        var indicesByProject: [UUID: [Int]] = [:]
+        for (index, session) in sessions.enumerated() {
+            indicesByProject[session.projectId, default: []].append(index)
+        }
+
+        let now = currentTime()
+
+        // Indices that survive on the strength of the per-project recency
+        // floor alone (condition 2), independent of age.
+        var keptByRecencyCap: Set<Int> = []
+        for (_, indices) in indicesByProject {
+            // Decorate-sort-undecorate: rank by lastActiveAt descending, nil
+            // last, ties broken by original array position (index) so the
+            // ordering is fully deterministic without relying on a stable sort.
+            let ranked = indices.sorted { lhsIndex, rhsIndex in
+                let lhs = sessions[lhsIndex].lastActiveAt
+                let rhs = sessions[rhsIndex].lastActiveAt
+                switch (lhs, rhs) {
+                case let (lhs?, rhs?):
+                    if lhs == rhs { return lhsIndex < rhsIndex }
+                    return lhs > rhs
+                case (_?, nil): return true
+                case (nil, _?): return false
+                case (nil, nil): return lhsIndex < rhsIndex
+                }
+            }
+            for index in ranked.prefix(Self.maxRetainedSessionsPerProject) {
+                keptByRecencyCap.insert(index)
+            }
+        }
+
+        // Final keep decision per session, preserving the original overall
+        // order of `sessions` — the grouping/ranking above only decides
+        // membership, not the array's final order.
+        let kept = sessions.enumerated().filter { index, session in
+            let withinRetentionWindow: Bool = {
+                guard let lastActiveAt = session.lastActiveAt else { return false }
+                return now.timeIntervalSince(lastActiveAt) <= Self.sessionRetentionWindow
+            }()
+            return withinRetentionWindow || keptByRecencyCap.contains(index)
+        }.map(\.element)
+
+        // Nothing to prune — skip the assignment and disk write entirely so
+        // a launch with no stale sessions doesn't churn workspace.json.
+        guard kept.count < sessions.count else { return }
+
+        self.sessions = kept
+        persist()
     }
 
     // MARK: - Smart Sections

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -277,6 +277,14 @@ final class WorkspaceStore: ObservableObject {
         // a launch with no stale sessions doesn't churn workspace.json.
         guard kept.count < sessions.count else { return }
 
+        // Safety net: this is a silent, automatic, irreversible deletion that
+        // runs on the first post-update launch. Back up the pre-prune
+        // workspace.json to a sibling `.pre-prune.bak` file BEFORE committing
+        // the in-memory removal, so a user can recover manually if the
+        // policy ever proves wrong. No-op when there's nothing on disk yet
+        // (fresh install, or the test-only in-memory init path).
+        WorkspacePersistence.backUpBeforePrune(prunedCount: sessions.count - kept.count)
+
         self.sessions = kept
         persist()
     }

--- a/macos/Tests/Workspace/WorkspaceStorePruneTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStorePruneTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import Ghostty
+
+/// Tests for the launch-time stale-session prune (`pruneStaleSessionsAtLaunch()`).
+///
+/// Policy under test — a session is KEPT if EITHER:
+///   1. `lastActiveAt` is within `WorkspaceStore.sessionRetentionWindow` (30 days).
+///      A `nil` `lastActiveAt` does NOT satisfy this condition.
+///   2. It ranks among the most-recent `WorkspaceStore.maxRetainedSessionsPerProject`
+///      (15) sessions within its own project, by `lastActiveAt` descending (nil ranks
+///      last).
+/// A session is only dropped when BOTH conditions fail.
+///
+/// The prune only runs via the real disk-load `init()` in production, but the
+/// test-only `init(testingProjects:testingSessions:)` bypasses that path entirely —
+/// so these tests call `pruneStaleSessionsAtLaunch()` directly against a store built
+/// via the testing initializer, with `_setTestClock(_:)` pinning "now" for
+/// deterministic age math.
+struct WorkspaceStorePruneTests {
+    // MARK: - Fixtures
+
+    private let template = AgentTemplate.shell
+
+    private func makeProject(id: UUID = UUID(), name: String = "Proj") -> Project {
+        Project(id: id, name: name, rootPath: "/tmp/\(name)", isPinned: false)
+    }
+
+    private func makeSession(
+        id: UUID = UUID(),
+        name: String = "Session",
+        projectId: UUID,
+        lastActiveAt: Date?
+    ) -> AgentSession {
+        AgentSession(
+            id: id,
+            name: name,
+            templateId: template.id,
+            projectId: projectId,
+            lastActiveAt: lastActiveAt
+        )
+    }
+
+    // MARK: - Tests
+
+    /// 1. Beyond-15-and-stale sessions get pruned: 20 sessions in one project, all
+    /// 40 days old (stale — fails condition 1), spread by minutes so the recency
+    /// ranking is unambiguous. Only the 15 most-recent (by `lastActiveAt`) survive
+    /// condition 2's per-project cap; the other 5 are dropped.
+    @MainActor
+    @Test func beyondCapAndStaleSessionsArePruned() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        // Oldest session first, most recent last: index 0 is 40 days + 19 minutes
+        // ago, index 19 is 40 days ago exactly. Ranking descending by lastActiveAt
+        // puts index 19 first (most recent), index 0 last (least recent).
+        let sessions = (0..<20).map { i in
+            makeSession(
+                name: "S\(i)",
+                projectId: project.id,
+                lastActiveAt: now.addingTimeInterval(-40 * 24 * 60 * 60 - Double(19 - i) * 60)
+            )
+        }
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: sessions)
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.count == 15)
+        // The 15 most-recent by lastActiveAt (indices 5...19) must survive; the 5
+        // oldest (indices 0...4) must be dropped.
+        let keptNames = Set(store.sessions.map(\.name))
+        let expectedKept = Set((5..<20).map { "S\($0)" })
+        #expect(keptNames == expectedKept)
+    }
+
+    /// 2. All-recent sessions are never pruned even if the project has >15 of them:
+    /// condition 1 alone (30-day window) saves every one regardless of the 15-cap.
+    @MainActor
+    @Test func allRecentSessionsSurviveEvenBeyondCap() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let sessions = (0..<20).map { i in
+            makeSession(
+                name: "S\(i)",
+                projectId: project.id,
+                lastActiveAt: now.addingTimeInterval(-5 * 24 * 60 * 60)
+            )
+        }
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: sessions)
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.count == 20)
+    }
+
+    /// 3. A single very-stale project with exactly the cap or fewer is untouched:
+    /// 10 sessions, all 60 days old — condition 2 alone (top-15 == all 10, since
+    /// there are fewer than 15) keeps all of them.
+    @MainActor
+    @Test func staleProjectAtOrUnderCapIsUntouched() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let sessions = (0..<10).map { i in
+            makeSession(
+                name: "S\(i)",
+                projectId: project.id,
+                lastActiveAt: now.addingTimeInterval(-60 * 24 * 60 * 60 - Double(i) * 60)
+            )
+        }
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: sessions)
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.count == 10)
+    }
+
+    /// 4. Cross-project independence: project A has 20 stale (60-day) sessions,
+    /// project B has 3 stale (60-day) sessions. A's per-project ranking must not be
+    /// affected by B's sessions and vice versa — A drops to 15, B's 3 are untouched.
+    @MainActor
+    @Test func pruningIsIndependentPerProject() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let projectA = makeProject(name: "A")
+        let projectB = makeProject(name: "B")
+        let sessionsA = (0..<20).map { i in
+            makeSession(
+                name: "A\(i)",
+                projectId: projectA.id,
+                lastActiveAt: now.addingTimeInterval(-60 * 24 * 60 * 60 - Double(19 - i) * 60)
+            )
+        }
+        let sessionsB = (0..<3).map { i in
+            makeSession(
+                name: "B\(i)",
+                projectId: projectB.id,
+                lastActiveAt: now.addingTimeInterval(-60 * 24 * 60 * 60 - Double(2 - i) * 60)
+            )
+        }
+        let store = WorkspaceStore(
+            testingProjects: [projectA, projectB],
+            testingSessions: sessionsA + sessionsB
+        )
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        let remainingA = store.sessions.filter { $0.projectId == projectA.id }
+        let remainingB = store.sessions.filter { $0.projectId == projectB.id }
+        #expect(remainingA.count == 15)
+        #expect(remainingB.count == 3)
+    }
+
+    /// 5. No-op guard: nothing qualifies for pruning (a small set of recent
+    /// sessions), so `sessions` must be unchanged after the call — same count and
+    /// same ids, in the same order. This is the observable evidence for the
+    /// "skip the assignment/write when nothing would be pruned" guard; the disk
+    /// write itself isn't observable here because the testing initializer always
+    /// sets `persistenceDisabled = true` regardless of the guard.
+    @MainActor
+    @Test func noOpWhenNothingQualifiesForPruning() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let sessions = (0..<3).map { i in
+            makeSession(
+                name: "S\(i)",
+                projectId: project.id,
+                lastActiveAt: now.addingTimeInterval(-Double(i) * 60)
+            )
+        }
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: sessions)
+        store._setTestClock { now }
+        let idsBefore = store.sessions.map(\.id)
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.map(\.id) == idsBefore)
+        #expect(store.sessions.count == sessions.count)
+    }
+}

--- a/macos/Tests/Workspace/WorkspaceStorePruneTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStorePruneTests.swift
@@ -17,6 +17,12 @@ import Testing
 /// so these tests call `pruneStaleSessionsAtLaunch()` directly against a store built
 /// via the testing initializer, with `_setTestClock(_:)` pinning "now" for
 /// deterministic age math.
+///
+/// Coverage also includes the `nil` `lastActiveAt` path (sessions that predate
+/// the timestamp feature — always fails condition 1, ranks last in condition
+/// 2's per-project cap), the tie-break rule when multiple sessions share an
+/// identical `lastActiveAt`, and the exact `<=` boundary of
+/// `sessionRetentionWindow`.
 struct WorkspaceStorePruneTests {
     // MARK: - Fixtures
 
@@ -178,5 +184,134 @@ struct WorkspaceStorePruneTests {
 
         #expect(store.sessions.map(\.id) == idsBefore)
         #expect(store.sessions.count == sessions.count)
+    }
+
+    // MARK: - Nil `lastActiveAt` (sessions predating the timestamp feature)
+
+    /// 6. All-nil sessions in a project respect the cap deterministically: 20
+    /// sessions, every one with `lastActiveAt: nil` (always fails condition 1),
+    /// so the cap ranking is decided entirely by the tie-break (original array
+    /// index ascending, since there are no dates to differentiate). The first
+    /// 15 sessions in original array order survive; the last 5 are dropped.
+    @MainActor
+    @Test func allNilLastActiveAtSessionsKeepFirstFifteenByOriginalOrder() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let sessions = (0..<20).map { i in
+            makeSession(name: "S\(i)", projectId: project.id, lastActiveAt: nil)
+        }
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: sessions)
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.count == 15)
+        let keptNames = Set(store.sessions.map(\.name))
+        let expectedKept = Set((0..<15).map { "S\($0)" })
+        #expect(keptNames == expectedKept)
+    }
+
+    /// 7. A mix of nil and recent-dated sessions in one project (>15 total)
+    /// ranks/prunes as intended: a concrete date always ranks ahead of nil
+    /// (see the `(_?, nil): return true` branch in the cap comparator), so the
+    /// 3 dated sessions occupy the top of the per-project cap ranking, and the
+    /// 17 nil sessions fill the remaining cap slots in original array order.
+    /// The dated sessions here are also RECENT (within the 30-day retention
+    /// window), so condition 1 keeps them independently too — proving the
+    /// final kept set matches the cap ranking exactly, whichever condition is
+    /// responsible.
+    @MainActor
+    @Test func mixedNilAndRecentDatedSessionsRankDatedAheadOfNilByIndex() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let dated = (0..<3).map { i in
+            makeSession(
+                name: "D\(i)",
+                projectId: project.id,
+                lastActiveAt: now.addingTimeInterval(-Double(i + 1) * 24 * 60 * 60)
+            )
+        }
+        let nilSessions = (0..<17).map { i in
+            makeSession(name: "N\(i)", projectId: project.id, lastActiveAt: nil)
+        }
+        let store = WorkspaceStore(
+            testingProjects: [project],
+            testingSessions: dated + nilSessions
+        )
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        // Cap ranking: all 3 dated sessions first, then nil sessions in
+        // original array order. Top 15 = the 3 dated + the first 12 nil
+        // sessions (N0...N11); the remaining 5 nil sessions (N12...N16) are
+        // dropped.
+        #expect(store.sessions.count == 15)
+        let keptNames = Set(store.sessions.map(\.name))
+        let expectedKept = Set(["D0", "D1", "D2"]).union((0..<12).map { "N\($0)" })
+        #expect(keptNames == expectedKept)
+    }
+
+    // MARK: - Boundary Conditions
+
+    /// 8. Identical `lastActiveAt` timestamps across a >15-session project
+    /// break ties deterministically by original array index. All 20 sessions
+    /// here share the exact same stale (60-day-old) timestamp — condition 1
+    /// fails for every one of them, so the cap ranking is decided entirely by
+    /// the index tie-break, not by date. The first 15 by original order
+    /// survive; the last 5 are dropped.
+    @MainActor
+    @Test func identicalLastActiveAtTimestampsBreakTiesByOriginalIndex() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let staleDate = now.addingTimeInterval(-60 * 24 * 60 * 60)
+        let sessions = (0..<20).map { i in
+            makeSession(name: "S\(i)", projectId: project.id, lastActiveAt: staleDate)
+        }
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: sessions)
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.count == 15)
+        let keptNames = Set(store.sessions.map(\.name))
+        let expectedKept = Set((0..<15).map { "S\($0)" })
+        #expect(keptNames == expectedKept)
+    }
+
+    /// 9. A session whose `lastActiveAt` is EXACTLY `now - sessionRetentionWindow`
+    /// (30 days to the second) is kept — condition 1's boundary is inclusive
+    /// (`<=`). The 15 filler sessions here are all more recent, so they occupy
+    /// every slot of the per-project cap ahead of the boundary session, which
+    /// therefore ranks 16th (last) and fails condition 2 entirely. Its
+    /// survival can only come from condition 1's `<=` comparison landing
+    /// exactly on the boundary — this test exercises that exact-equality case,
+    /// which none of the other tests above (all comfortably inside or outside
+    /// the window) touch.
+    @MainActor
+    @Test func sessionExactlyAtRetentionWindowBoundaryIsKeptDespiteFailingCap() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let project = makeProject()
+        let fillers = (0..<WorkspaceStore.maxRetainedSessionsPerProject).map { i in
+            makeSession(
+                name: "Filler\(i)",
+                projectId: project.id,
+                lastActiveAt: now.addingTimeInterval(-Double(i + 1) * 60)
+            )
+        }
+        let boundary = makeSession(
+            name: "Boundary",
+            projectId: project.id,
+            lastActiveAt: now.addingTimeInterval(-WorkspaceStore.sessionRetentionWindow)
+        )
+        let store = WorkspaceStore(
+            testingProjects: [project],
+            testingSessions: fillers + [boundary]
+        )
+        store._setTestClock { now }
+
+        store.pruneStaleSessionsAtLaunch()
+
+        #expect(store.sessions.contains(where: { $0.id == boundary.id }))
     }
 }


### PR DESCRIPTION
## Summary

`WorkspaceStore.sessions` (workspace.json) has never been pruned — every agent session ever spawned stays in the list forever. Currently ~85 sessions / 28KB, a slow leak that grows unbounded over the app's lifetime and will eventually hurt load/persist perf. Pruning a session only removes it from the sidebar recents list; it never touches real agent work (git commits, files, terminal output all live outside this struct).

## Policy

A session is **kept** if EITHER:
1. `lastActiveAt` is within `WorkspaceStore.sessionRetentionWindow` (30 days). A `nil` `lastActiveAt` does not satisfy this (treated as "never active").
2. It ranks among its own project's most-recent `WorkspaceStore.maxRetainedSessionsPerProject` (15) sessions by `lastActiveAt` descending (nil ranks last).

A session is **pruned** only when both conditions fail. This means: keep everything touched in the last 30 days, AND always keep each project's most-recent 15 regardless of age.

## When it runs

Exactly **once, at app launch** — `pruneStaleSessionsAtLaunch()` is called as the last statement of the real disk-load `WorkspaceStore.init()`, never from `persist()` or any runtime mutation path (e.g. `recordActivity`). At launch nothing has a live runtime yet, so pruning can never delete an in-flight session; pruning during normal operation could delete a session that's actually running, so that path is deliberately excluded.

If nothing qualifies for pruning, the code skips the array assignment and `persist()` call entirely — no pointless disk write on a launch with no stale sessions.

## Tunables

```swift
static let sessionRetentionWindow: TimeInterval = 30 * 24 * 60 * 60
static let maxRetainedSessionsPerProject = 15
```

## Files changed

- `macos/Sources/Features/Ghostties/WorkspaceStore.swift` — the two constants + `pruneStaleSessionsAtLaunch()` + the one call site at the end of `init()`.
- `macos/Tests/Workspace/WorkspaceStorePruneTests.swift` (new) — 5 tests covering beyond-cap pruning, all-recent-survives-cap, small-stale-project untouched, cross-project independence, and the no-op guard.

## Testing

Built and ran via `xcodebuild test -only-testing:GhosttyTests/WorkspaceStorePruneTests` locally — all 5 tests **actually executed and passed** (not just compiled): `beyondCapAndStaleSessionsArePruned`, `allRecentSessionsSurviveEvenBeyondCap`, `staleProjectAtOrUnderCapIsUntouched`, `pruningIsIndependentPerProject`, `noOpWhenNothingQualifiesForPruning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)