### PR TITLE
Sessions tab: context menu + inline rename

### DIFF
--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -11,6 +11,10 @@ struct RecentsListView: View {
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
 
+    @State private var editingSessionId: UUID?
+    @State private var editingName: String = ""
+    @FocusState private var renameFieldFocused: Bool
+
     var body: some View {
         VStack(spacing: 0) {
             newSessionRow
@@ -107,16 +111,40 @@ struct RecentsListView: View {
     // MARK: - Session Row
 
     private func sessionRow(for session: AgentSession) -> some View {
-        let projectName = store.projects
-            .first { $0.id == session.projectId }?.name ?? "Unknown"
+        let project = store.projects.first { $0.id == session.projectId }
+        let projectName = project?.name ?? "Unknown"
         let indicatorState = store.globalIndicatorStates[session.id] ?? .inactive
         return RecentsRowView(
             session: session,
             projectName: projectName,
             indicatorState: indicatorState,
             isActive: coordinator.activeSessionId == session.id,
-            onTap: { coordinator.focusSession(id: session.id) }
+            isEditing: editingSessionId == session.id,
+            editingName: editingSessionId == session.id ? $editingName : .constant(""),
+            isRenameFocused: $renameFieldFocused,
+            onTap: { coordinator.focusSession(id: session.id) },
+            onCommitRename: { commitRename(session: session) },
+            onCancelRename: { cancelRename() }
         )
+        .contextMenu {
+            Button("Rename") {
+                beginRename(session: session)
+            }
+            Divider()
+            if coordinator.isRunning(id: session.id) {
+                Button("Stop") {
+                    coordinator.closeSession(id: session.id)
+                }
+            } else {
+                Button("Relaunch") {
+                    relaunchSession(session, project: project)
+                }
+                Button("Remove", role: .destructive) {
+                    coordinator.clearRuntime(id: session.id)
+                    store.removeSession(id: session.id)
+                }
+            }
+        }
     }
 
     // MARK: - Empty State
@@ -164,6 +192,46 @@ struct RecentsListView: View {
         }()
         Task {
             await coordinator.createQuickSession(for: project, template: resolved)
+        }
+    }
+
+    // MARK: - Rename
+
+    private func beginRename(session: AgentSession) {
+        editingName = session.name
+        editingSessionId = session.id
+        DispatchQueue.main.async {
+            renameFieldFocused = true
+        }
+    }
+
+    private func commitRename(session: AgentSession) {
+        let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty, trimmed != session.name {
+            store.renameSession(id: session.id, name: trimmed)
+        }
+        editingSessionId = nil
+    }
+
+    private func cancelRename() {
+        editingSessionId = nil
+    }
+
+    // MARK: - Relaunch
+
+    private func relaunchSession(_ session: AgentSession, project: Project?) {
+        guard let project,
+              let template = store.templates.first(where: { $0.id == session.templateId }) else {
+            // Template or project was deleted — cannot relaunch.
+            print("Warning: Template or project for session '\(session.name)' not found (templateId: \(session.templateId))")
+            return
+        }
+
+        // No pre-check needed — SessionCoordinator.createSession() calls
+        // buildCommand() itself and handles missing prompt files gracefully.
+        coordinator.clearRuntime(id: session.id)
+        Task {
+            await coordinator.createSession(session: session, template: template, project: project)
         }
     }
 

--- a/macos/Sources/Features/Ghostties/RecentsRowView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsRowView.swift
@@ -10,7 +10,12 @@ struct RecentsRowView: View {
     let projectName: String
     let indicatorState: SessionIndicatorState
     let isActive: Bool
+    var isEditing: Bool = false
+    @Binding var editingName: String
+    var isRenameFocused: FocusState<Bool>.Binding
     let onTap: () -> Void
+    var onCommitRename: () -> Void = {}
+    var onCancelRename: () -> Void = {}
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
@@ -25,10 +30,22 @@ struct RecentsRowView: View {
 
             // Session name + project name stacked
             VStack(alignment: .leading, spacing: 1) {
-                Text(session.name)
-                    .font(.system(size: 12))
-                    .foregroundStyle(Color.primary)
-                    .lineLimit(1)
+                if isEditing {
+                    TextField("Session name", text: $editingName)
+                        .font(.system(size: 12))
+                        .textFieldStyle(.plain)
+                        .focused(isRenameFocused)
+                        .onSubmit { onCommitRename() }
+                        .onExitCommand { onCancelRename() }
+                        .onChange(of: isRenameFocused.wrappedValue) { focused in
+                            if !focused, isEditing { onCommitRename() }
+                        }
+                } else {
+                    Text(session.name)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color.primary)
+                        .lineLimit(1)
+                }
 
                 Text(projectName)
                     .font(.system(size: 10))
@@ -52,7 +69,10 @@ struct RecentsRowView: View {
         .background(rowBackground)
         .contentShape(Rectangle())
         .onHover { isHovered = $0 }
-        .onTapGesture(perform: onTap)
+        .onTapGesture {
+            guard !isEditing else { return }
+            onTap()
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(isActive ? [.isSelected] : [])


### PR DESCRIPTION
## Summary
- Adds a right-click context menu to Sessions-tab rows: **Rename**, **Stop**, **Relaunch**, **Remove** — matching the project-view menu's wording, ordering, and show/hide conditions, minus Move Up/Down (this list is time-sorted, not manually ordered).
- Adds inline rename support to `RecentsRowView` (TextField swap for the session-name label), reusing the same commit/cancel semantics as `SessionRow` in the project view.
- Context menu is attached at the `RecentsListView` call site (not inside `RecentsRowView`), mirroring how `ProjectDisclosureRow` attaches its menu — eager attachment, no new lazy-menu abstraction.

## Files changed
- `macos/Sources/Features/Ghostties/RecentsRowView.swift` — inline-rename TextField support, guards `onTap` while editing so the TextField doesn't lose focus to the row's tap gesture.
- `macos/Sources/Features/Ghostties/RecentsListView.swift` — context menu attachment + editing state (`editingSessionId`, `editingName`, `renameFieldFocused`) + action handlers (`beginRename`, `commitRename`, `cancelRename`, `relaunchSession`).

## Verification

**Build passes** — `xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Debug build ONLY_ACTIVE_ARCH=YES ARCHS=arm64` exited 0:
```
** BUILD SUCCEEDED **
```

**Menu present with correct conditions** (`RecentsListView.swift`):
```swift
.contextMenu {
    Button("Rename") {
        beginRename(session: session)
    }
    Divider()
    if coordinator.isRunning(id: session.id) {
        Button("Stop") {
            coordinator.closeSession(id: session.id)
        }
    } else {
        Button("Relaunch") {
            relaunchSession(session, project: project)
        }
        Button("Remove", role: .destructive) {
            coordinator.clearRuntime(id: session.id)
            store.removeSession(id: session.id)
        }
    }
}
```
Rename always shown; Stop gated on `isRunning`; Relaunch/Remove gated on `!isRunning`; no Move Up/Down items.

**Inline rename wired end-to-end** (`RecentsRowView.swift`):
```swift
if isEditing {
    TextField("Session name", text: $editingName)
        .font(.system(size: 12))
        .textFieldStyle(.plain)
        .focused(isRenameFocused)
        .onSubmit { onCommitRename() }
        .onExitCommand { onCancelRename() }
        .onChange(of: isRenameFocused.wrappedValue) { focused in
            if !focused, isEditing { onCommitRename() }
        }
}
```
and (`RecentsListView.swift`):
```swift
private func commitRename(session: AgentSession) {
    let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
    if !trimmed.isEmpty, trimmed != session.name {
        store.renameSession(id: session.id, name: trimmed)
    }
    editingSessionId = nil
}

private func cancelRename() {
    editingSessionId = nil
}
```
Commits via `store.renameSession(id:name:)`; escape and blur both cancel/commit correctly; empty/unchanged names are ignored.

**Actions call the same APIs as the project view** — side-by-side:

| Action | ProjectDisclosureRow.swift | RecentsListView.swift (new) |
|---|---|---|
| Stop | `coordinator.closeSession(id: session.id)` | `coordinator.closeSession(id: session.id)` |
| Relaunch | `coordinator.clearRuntime(id:)` + `coordinator.createSession(session:template:project:)` | same |
| Remove | `coordinator.clearRuntime(id:)` + `store.removeSession(id:)` | same |
| Rename | `store.renameSession(id:name:)` | same |

## Test plan
- [x] Build succeeds (`xcodebuild` Debug, arm64, exit 0)
- [ ] Manual: right-click a running session in Sessions tab → Rename inline-edits, Stop appears (no Relaunch/Remove)
- [ ] Manual: right-click a stopped session → Relaunch/Remove appear (no Stop), Remove deletes the row, Relaunch re-creates the runtime
- [ ] Manual: Escape cancels an in-progress rename; Return/blur commits it

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>