### PR TITLE
Cmd+Shift+[/] session cycling; project cycling moves to Cmd+Ctrl+[/]

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -667,23 +667,43 @@ class AppDelegate: NSObject,
         browserItem.keyEquivalentModifierMask = [.command]
         browserItem.setImageIfDesired(systemSymbolName: "globe")
 
-        // "Next Project" — Cmd+Shift+]
+        // "Next Session" — Cmd+Shift+]. View-mode-aware: live sessions in
+        // project-first mode, task-cycling cursor in task-first mode.
         let nextItem = NSMenuItem(
-            title: "Next Project",
-            action: #selector(TerminalController.selectNextProject(_:)),
+            title: "Next Session",
+            action: #selector(TerminalController.selectNextSession(_:)),
             keyEquivalent: "]"
         )
         nextItem.keyEquivalentModifierMask = [.command, .shift]
         nextItem.setImageIfDesired(systemSymbolName: "chevron.right")
 
-        // "Previous Project" — Cmd+Shift+[
+        // "Previous Session" — Cmd+Shift+[
         let prevItem = NSMenuItem(
-            title: "Previous Project",
-            action: #selector(TerminalController.selectPreviousProject(_:)),
+            title: "Previous Session",
+            action: #selector(TerminalController.selectPreviousSession(_:)),
             keyEquivalent: "["
         )
         prevItem.keyEquivalentModifierMask = [.command, .shift]
         prevItem.setImageIfDesired(systemSymbolName: "chevron.left")
+
+        // "Next Project" — Cmd+Ctrl+]. Formerly Cmd+Shift+]; moved to make
+        // room for session cycling above.
+        let nextProjectItem = NSMenuItem(
+            title: "Next Project",
+            action: #selector(TerminalController.selectNextProject(_:)),
+            keyEquivalent: "]"
+        )
+        nextProjectItem.keyEquivalentModifierMask = [.command, .control]
+        nextProjectItem.setImageIfDesired(systemSymbolName: "chevron.right.2")
+
+        // "Previous Project" — Cmd+Ctrl+[
+        let prevProjectItem = NSMenuItem(
+            title: "Previous Project",
+            action: #selector(TerminalController.selectPreviousProject(_:)),
+            keyEquivalent: "["
+        )
+        prevProjectItem.keyEquivalentModifierMask = [.command, .control]
+        prevProjectItem.setImageIfDesired(systemSymbolName: "chevron.left.2")
 
         // "New Session" — Cmd+Shift+T
         let newSessionItem = NSMenuItem(
@@ -734,9 +754,11 @@ class AppDelegate: NSObject,
         viewMenu.insertItem(browserItem, at: 2)
         viewMenu.insertItem(nextItem, at: 3)
         viewMenu.insertItem(prevItem, at: 4)
-        viewMenu.insertItem(newSessionItem, at: 5)
-        viewMenu.insertItem(sidebarViewParent, at: 6)
-        viewMenu.insertItem(NSMenuItem.separator(), at: 7)
+        viewMenu.insertItem(nextProjectItem, at: 5)
+        viewMenu.insertItem(prevProjectItem, at: 6)
+        viewMenu.insertItem(newSessionItem, at: 7)
+        viewMenu.insertItem(sidebarViewParent, at: 8)
+        viewMenu.insertItem(NSMenuItem.separator(), at: 9)
 
     }
 

--- a/macos/Sources/Features/Ghostties/TaskSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/TaskSidebarView.swift
@@ -148,7 +148,7 @@ struct TaskSidebarView: View {
 
         guard let currentId = taskCyclingCursorId,
               let currentIndex = order.firstIndex(where: { $0.id == currentId }) else {
-            let target = order[0]
+            let target = offset > 0 ? order[0] : order[order.count - 1]
             taskCyclingCursorId = target.id
             withAnimation { proxy.scrollTo(target.id, anchor: .center) }
             return

--- a/macos/Sources/Features/Ghostties/TaskSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/TaskSidebarView.swift
@@ -21,13 +21,24 @@ struct TaskSidebarView: View {
     @ObservedObject private var composerStore: NewTaskComposerStore = .shared
 
     @EnvironmentObject private var workspaceStore: WorkspaceStore
+    /// Only used to guard the Cmd+Shift+]/[ notifications to this window
+    /// (same `containerView?.window` pattern `WorkspaceSidebarView` uses for
+    /// its project/session cycling) — task cycling itself never touches the
+    /// terminal or session state.
+    @EnvironmentObject private var coordinator: SessionCoordinator
     @Environment(\.colorScheme) private var colorScheme
+
+    /// Cursor for Cmd+Shift+]/[ task cycling (task-first mode). Tracks the
+    /// last task moved to; independent of native SwiftUI row focus (see
+    /// `selectAdjacentTask(offset:proxy:)` for the limitation this implies).
+    @State private var taskCyclingCursorId: String?
 
     var body: some View {
         VStack(spacing: 0) {
             // D22: header strip with [+ Start] button at top-right.
             sidebarHeader
 
+            ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
                     // Six-zone layout — locked order from the brief:
@@ -83,6 +94,15 @@ struct TaskSidebarView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .onReceive(NotificationCenter.default.publisher(for: .workspaceSelectNextTask)) { notification in
+                guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+                selectAdjacentTask(offset: 1, proxy: proxy)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .workspaceSelectPreviousTask)) { notification in
+                guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+                selectAdjacentTask(offset: -1, proxy: proxy)
+            }
+            }
 
             footer
         }
@@ -92,6 +112,52 @@ struct TaskSidebarView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openNewTaskComposer)) { _ in
             composerStore.open(workspaceStore: workspaceStore)
         }
+    }
+
+    // MARK: - Task cycling (Cmd+Shift+]/[, task-first mode)
+
+    /// Flat rendered order across all six zones, mirroring `body`'s zone
+    /// sequence: Inbox → Backlog → Active → Needs you → Review → Graveyard.
+    /// Session drafts in the Active zone are intentionally excluded — they
+    /// aren't `TaskItem`s and have no independent row-click identity.
+    private var flatTaskCycleOrder: [TaskItem] {
+        taskStore.sortedExternalInbox
+            + taskStore.backlog
+            + taskStore.active
+            + taskStore.needsYou
+            + taskStore.review
+            + taskStore.done
+    }
+
+    /// Moves the task-cycling cursor to the next/previous task in
+    /// `flatTaskCycleOrder`, wrapping at both ends, and scrolls it into view.
+    /// No-ops (no beep, no crash) when there are zero tasks.
+    ///
+    /// LIMITATION: this does not drive native SwiftUI keyboard focus
+    /// (`@FocusState` lives inside `TaskRowView`, which this view doesn't
+    /// own) so it doesn't move the visual focus ring or update
+    /// `RowFocusStore` — Return/⌘O still act on whichever row last had real
+    /// keyboard focus, independent of this cursor. It's scroll-to-reveal
+    /// only. It also can't scroll to a task currently rendered in the Active
+    /// zone: `ActiveZoneView` gives its merged rows a `"task:<id>"`-prefixed
+    /// `ForEach` identity rather than the bare task id, so `scrollTo` silently
+    /// no-ops for those rows specifically (still advances the cursor).
+    private func selectAdjacentTask(offset: Int, proxy: ScrollViewProxy) {
+        let order = flatTaskCycleOrder
+        guard !order.isEmpty else { return }
+
+        guard let currentId = taskCyclingCursorId,
+              let currentIndex = order.firstIndex(where: { $0.id == currentId }) else {
+            let target = order[0]
+            taskCyclingCursorId = target.id
+            withAnimation { proxy.scrollTo(target.id, anchor: .center) }
+            return
+        }
+
+        let newIndex = (currentIndex + offset + order.count) % order.count
+        let target = order[newIndex]
+        taskCyclingCursorId = target.id
+        withAnimation { proxy.scrollTo(target.id, anchor: .center) }
     }
 
     // MARK: - Header strip (D22)
@@ -183,18 +249,21 @@ struct TaskSidebarView: View {
 #if DEBUG
 #Preview("Task Sidebar — Light + Dark") {
     let ws = WorkspaceStore(testingProjects: [])
+    let coordinator = SessionCoordinator()
     HStack(spacing: 24) {
         TaskSidebarView(
             taskStore: TaskStore(),
             sessionDraftStore: SessionDraftStore()
         )
         .environmentObject(ws)
+        .environmentObject(coordinator)
         .preferredColorScheme(.light)
         TaskSidebarView(
             taskStore: TaskStore(),
             sessionDraftStore: SessionDraftStore()
         )
         .environmentObject(ws)
+        .environmentObject(coordinator)
         .preferredColorScheme(.dark)
     }
     .padding(24)

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -232,6 +232,30 @@ extension Notification.Name {
     /// The notification object is the originating NSWindow.
     static let workspaceSelectPreviousProject = Notification.Name("com.seansmithdesign.ghostties.workspace.selectPreviousProject")
 
+    /// Posted by TerminalController when the user presses Cmd+Shift+] in
+    /// project-first sidebar mode. The notification object is the originating
+    /// NSWindow. `WorkspaceSidebarView` observes this to cycle focus forward
+    /// through live (running) sessions in sidebar visual order.
+    static let workspaceSelectNextSession = Notification.Name("com.seansmithdesign.ghostties.workspace.selectNextSession")
+
+    /// Posted by TerminalController when the user presses Cmd+Shift+[ in
+    /// project-first sidebar mode. The notification object is the originating
+    /// NSWindow. `WorkspaceSidebarView` observes this to cycle focus backward
+    /// through live (running) sessions in sidebar visual order.
+    static let workspaceSelectPreviousSession = Notification.Name("com.seansmithdesign.ghostties.workspace.selectPreviousSession")
+
+    /// Posted by TerminalController when the user presses Cmd+Shift+] in
+    /// task-first sidebar mode. The notification object is the originating
+    /// NSWindow. `TaskSidebarView` observes this to move the task-cycling
+    /// cursor forward through the rendered zone order.
+    static let workspaceSelectNextTask = Notification.Name("com.seansmithdesign.ghostties.workspace.selectNextTask")
+
+    /// Posted by TerminalController when the user presses Cmd+Shift+[ in
+    /// task-first sidebar mode. The notification object is the originating
+    /// NSWindow. `TaskSidebarView` observes this to move the task-cycling
+    /// cursor backward through the rendered zone order.
+    static let workspaceSelectPreviousTask = Notification.Name("com.seansmithdesign.ghostties.workspace.selectPreviousTask")
+
     /// Posted by WorkspaceStore just before a project is removed.
     /// userInfo contains "projectId" (UUID). Coordinators observe this to close
     /// running sessions before the store deletes the project's records.

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -268,12 +268,18 @@ struct WorkspaceSidebarView: View {
 
         guard let currentId = coordinator.activeSessionId,
               let currentIndex = liveSessions.firstIndex(where: { $0.id == currentId }) else {
-            coordinator.focusSession(id: liveSessions[0].id)
+            let target = offset > 0 ? liveSessions[0] : liveSessions[liveSessions.count - 1]
+            coordinator.focusSession(id: target.id)
+            expandedProjectIds.insert(target.projectId)
+            selectedProjectId = target.projectId
             return
         }
 
         let newIndex = (currentIndex + offset + liveSessions.count) % liveSessions.count
-        coordinator.focusSession(id: liveSessions[newIndex].id)
+        let target = liveSessions[newIndex]
+        coordinator.focusSession(id: target.id)
+        expandedProjectIds.insert(target.projectId)
+        selectedProjectId = target.projectId
     }
 }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -124,6 +124,14 @@ struct WorkspaceSidebarView: View {
             guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
             selectAdjacentProject(offset: -1)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceSelectNextSession)) { notification in
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            selectAdjacentLiveSession(offset: 1)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceSelectPreviousSession)) { notification in
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            selectAdjacentLiveSession(offset: -1)
+        }
         .onReceive(NotificationCenter.default.publisher(for: .workspaceNewSession)) { notification in
             guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
             createNewSessionForSelectedProject()
@@ -237,6 +245,35 @@ struct WorkspaceSidebarView: View {
         let targetId = visualOrder[newIndex].id
         selectedProjectId = targetId
         expandedProjectIds.insert(targetId)
+    }
+
+    /// All *running* sessions (`coordinator.isRunning(id:)`), flattened in
+    /// sidebar visual order: projects in `flatProjectsInVisualOrder`, then
+    /// each project's sessions in their displayed order
+    /// (`sessionGroups(forProject:)`, same helper `ProjectDisclosureRow` uses
+    /// to render its own rows).
+    private var liveSessionsInVisualOrder: [AgentSession] {
+        store.flatProjectsInVisualOrder.flatMap { project in
+            store.sessionGroups(forProject: project.id).flatMap { $0.1 }
+        }.filter { coordinator.isRunning(id: $0.id) }
+    }
+
+    /// Cmd+Shift+]/[ in project-first mode. Cycles focus through live
+    /// (running) sessions only, wrapping at both ends. No-ops (no beep, no
+    /// crash) when there are zero live sessions; is a no-op when there is
+    /// exactly one.
+    private func selectAdjacentLiveSession(offset: Int) {
+        let liveSessions = liveSessionsInVisualOrder
+        guard !liveSessions.isEmpty else { return }
+
+        guard let currentId = coordinator.activeSessionId,
+              let currentIndex = liveSessions.firstIndex(where: { $0.id == currentId }) else {
+            coordinator.focusSession(id: liveSessions[0].id)
+            return
+        }
+
+        let newIndex = (currentIndex + offset + liveSessions.count) % liveSessions.count
+        coordinator.focusSession(id: liveSessions[newIndex].id)
     }
 }
 

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1315,6 +1315,29 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         NotificationCenter.default.post(name: .workspaceSelectPreviousProject, object: window)
     }
 
+    /// "Next Session" — Cmd+Shift+]. View-mode-aware: cycles live sessions in
+    /// project-first mode, or the task-cycling cursor in task-first mode.
+    /// Reads the same `ghostties.sidebarViewMode` defaults key used by
+    /// `toggleTaskView(_:)` / `validateMenuItem(_:)` above.
+    @IBAction func selectNextSession(_ sender: Any?) {
+        let mode = UserDefaults.standard.string(forKey: "ghostties.sidebarViewMode") ?? "projectFirst"
+        if mode == "taskFirst" {
+            NotificationCenter.default.post(name: .workspaceSelectNextTask, object: window)
+        } else {
+            NotificationCenter.default.post(name: .workspaceSelectNextSession, object: window)
+        }
+    }
+
+    /// "Previous Session" — Cmd+Shift+[. See `selectNextSession(_:)`.
+    @IBAction func selectPreviousSession(_ sender: Any?) {
+        let mode = UserDefaults.standard.string(forKey: "ghostties.sidebarViewMode") ?? "projectFirst"
+        if mode == "taskFirst" {
+            NotificationCenter.default.post(name: .workspaceSelectPreviousTask, object: window)
+        } else {
+            NotificationCenter.default.post(name: .workspaceSelectPreviousSession, object: window)
+        }
+    }
+
     @IBAction func newWorkspaceSession(_ sender: Any?) {
         NotificationCenter.default.post(name: .workspaceNewSession, object: window)
     }


### PR DESCRIPTION
## Summary
- Cmd+Shift+]/[ ("Next/Previous Session") is now view-mode-aware: in project-first sidebar mode it cycles focus through **live (running) sessions only**, in sidebar visual order, wrapping at both ends; in task-first mode it moves a cursor through the six rendered zones (Inbox → Backlog → Active → Needs You → Review → Graveyard) and scrolls the target into view.
- The previous "Next/Previous Project" behavior is unchanged in logic, just re-bound to Cmd+Ctrl+]/[.
- No existing Cmd+Ctrl+[/] binding was found in the fork's View menu or in upstream Ghostty's default keybinds (checked `src/input/Binding.zig`), so no collision to work around.

## Files changed
- `macos/Sources/Features/Ghostties/WorkspaceLayout.swift` — new notification names (`workspaceSelectNextSession`/`workspaceSelectPreviousSession`, `workspaceSelectNextTask`/`workspaceSelectPreviousTask`)
- `macos/Sources/Features/Terminal/TerminalController.swift` — new `selectNextSession(_:)`/`selectPreviousSession(_:)` IBActions, branching on `ghostties.sidebarViewMode`
- `macos/Sources/App/macOS/AppDelegate.swift` — renamed menu items to "Next/Previous Session" on Cmd+Shift+]/[; added new "Next/Previous Project" items on Cmd+Ctrl+]/[
- `macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift` — `selectAdjacentLiveSession(offset:)`: filters the sidebar's visual session order to `coordinator.isRunning(id:)` sessions, wraps, guards empty
- `macos/Sources/Features/Ghostties/TaskSidebarView.swift` — `selectAdjacentTask(offset:proxy:)`: cycles a cursor across the flat rendered task order and scrolls it into view via `ScrollViewReader`

## Known limitation (task-first mode)
`TaskRowView` owns native SwiftUI row focus (`@FocusState`) and I didn't touch that file. So task cycling moves an internal cursor and scrolls the target into view, but doesn't move the visual focus ring, and Return/⌘O still act on whichever row last had real keyboard focus — independent of this cursor. It also can't scroll to a task currently rendered in the **Active** zone specifically: `ActiveZoneView`'s `ForEach` gives merged rows a `"task:<id>"`-prefixed identity rather than the bare task id, so `scrollTo` silently no-ops there (the cursor still advances correctly). All other zones scroll correctly.

## Verification
- **Build**: `xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Debug build ONLY_ACTIVE_ARCH=YES ARCHS=arm64` → `** BUILD SUCCEEDED **` (confirmed after restoring this worktree's missing `GhosttyKit.xcframework`, `zig-out/share`, and `vendor/cef*` build artifacts from the sibling checkout — none of these are part of this diff)
- **Menu items**: grep of `AppDelegate.swift` confirms `"Next Session"`/`"Previous Session"` on `[.command, .shift]` and `"Next Project"`/`"Previous Project"` on `[.command, .control]`
- **Live-session cycling + wraparound + empty guard**: see `WorkspaceSidebarView.selectAdjacentLiveSession(offset:)` — filters to `coordinator.isRunning(id:)`, `guard !liveSessions.isEmpty else { return }`, modulo wraparound
- **Task-view dispatch path**: `TerminalController.selectNextSession/selectPreviousSession` reads `ghostties.sidebarViewMode` and posts `.workspaceSelectNextTask`/`.workspaceSelectPreviousTask` in task-first mode; `TaskSidebarView` observes both via `onReceive`, window-scoped the same way `WorkspaceSidebarView` scopes its notifications
- **Unit test**: skipped. The cycling logic lives in private methods on SwiftUI View structs (`selectAdjacentLiveSession`, `selectAdjacentTask`), matching the existing `selectAdjacentProject` pattern in this codebase, which also has no direct unit test — testing it would require exposing new internal seams beyond this task's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)