### PR TITLE
docs(release): beta.20 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ First distributable build. Ghostties can now be installed and kept up to date au
 
 ---
 
+[0.1.0-beta.20]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.20
 [0.1.0-beta.19]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.19
 [0.1.0-beta.18]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.18
 [0.1.0-beta.17]: https://github.com/SeanSmithDesign/ghostties/releases/tag/v0.1.0-beta.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [0.1.0-beta.20] — 2026-07-17
+
+Make the workspace sidebar yours — resize it, cycle sessions from the keyboard, and manage recents with a right-click.
+
+### Added
+
+- **Drag to resize the sidebar.** Grab the sidebar's trailing edge and drag to the width you want. Each layout — project-first and task-first — remembers its own width, so switching modes restores the size you last set there. The width stays within sensible bounds so the terminal always keeps room.
+- **Cycle between running sessions from the keyboard.** Press `⌘⇧]` and `⌘⇧[` to move focus to the next or previous live session, in sidebar order, wrapping at the ends. In task-first mode the same shortcut steps through the task zones. Project cycling moves to `⌘⌃]` / `⌘⌃[`.
+- **Right-click a recent session to manage it.** Sessions-tab rows now have a context menu — Rename, Stop, Relaunch, Remove — matching the project view. Rename also works inline: the row's name becomes editable in place.
+
+### Performance
+
+- The recents list no longer grows forever. The sidebar used to keep a record of every session it had ever seen; it's now pruned once at launch — sessions untouched for 30 days drop off, while each project always keeps its 15 most recent. This never touches real agent work (commits, files, and terminal output all live elsewhere) — it only trims the sidebar's memory of old sessions, so the list stays fast the longer you use the app.
+
+---
+
 ## [0.1.0-beta.19] — 2026-07-05
 
 The workspace stays responsive when several agents are running at once.

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -238,6 +238,31 @@
       <p><strong style="color:rgba(255,255,255,0.6)">Beta.15 and earlier:</strong> Auto-updates aren't reliable yet in early betas. Download the latest release manually from the <a href="/download">download page</a>.</p>
     </div>
 
+    <!-- beta.20 -->
+    <div class="release">
+      <div class="release-heading">
+        <h3>v0.1.0-beta.20</h3>
+        <span class="date">July 17, 2026</span>
+      </div>
+      <p class="release-summary">Make the workspace sidebar yours &mdash; resize it, cycle sessions from the keyboard, and manage recents with a right-click.</p>
+
+      <div class="release-section">
+        <h4>Added</h4>
+        <ul>
+          <li>Drag to resize the sidebar &mdash; grab its trailing edge and drag to the width you want. Each layout (project-first and task-first) remembers its own width, so switching modes restores the size you last set there.</li>
+          <li>Cycle between running sessions from the keyboard &mdash; &#8984;&#8679;] and &#8984;&#8679;[ move focus to the next or previous live session, in sidebar order, wrapping at the ends. Project cycling moves to &#8984;&#8963;] / &#8984;&#8963;[.</li>
+          <li>Right-click a recent session to rename, stop, relaunch, or remove it &mdash; the Sessions tab now has the same context menu as the project view, plus inline rename in place.</li>
+        </ul>
+      </div>
+
+      <div class="release-section">
+        <h4>Performance</h4>
+        <ul>
+          <li>The recents list no longer grows forever &mdash; it&rsquo;s now pruned once at launch, dropping sessions untouched for 30 days while always keeping each project&rsquo;s 15 most recent. This never touches real agent work; it only trims the sidebar&rsquo;s memory of old sessions so the list stays fast over time.</li>
+        </ul>
+      </div>
+    </div>
+
     <!-- beta.19 -->
     <div class="release">
       <div class="release-heading">


### PR DESCRIPTION
Adds the `0.1.0-beta.20` section to **`CHANGELOG.md`** and **`web/changelog.html`** — the last step before tagging the release. Mirrors PR #41 (beta.19), which updated both files together.

## What's documented

The four PRs merged since beta.19:

| PR | Change | Category |
|----|--------|----------|
| #45 | Draggable sidebar resize (per-mode width persistence) | Added |
| #44 | `⌘⇧]` / `⌘⇧[` session cycling; project cycling → `⌘⌃]` / `⌘⌃[` | Added |
| #43 | Sessions-tab context menu + inline rename | Added |
| #42 | Launch-time recents prune (unbounded-growth cap) | Performance |

Theme line: *"Make the workspace sidebar yours — resize it, cycle sessions from the keyboard, and manage recents with a right-click."*

## Verification (this diff is docs-only, but the release it documents was checked)

- **#42 prune logic** — 9/9 `WorkspaceStorePruneTests` pass (incl. 30-day boundary, tie-breaking, nil-handling).
- **Full `GhosttyTests`** — 68 pass. One pre-existing red test (`UpdateViewModelTests.testNotFoundText`, updater string-drift from beta.19's PR #34) — unrelated to beta.20, parked.
- **Release build** — `xcodebuild -configuration Release` compiles clean.

## Notes

- Date is set to the drafting day (**2026-07-17**). If the release slips, bump the date in both files to the actual tag day before tagging.
- `#42` is framed under **Performance** as a user benefit ("the recents list no longer grows forever") with an explicit "never touches real agent work" reassurance.

## After merge

Tag to trigger the release build (CI regenerates the appcast; version comes from the tag):

```
git tag v0.1.0-beta.20 && git push origin v0.1.0-beta.20
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)