### PR TITLE
chore: rename-account cleanup in user-facing URLs

### DIFF
--- a/macos/Resources/presets/linear-sync/system.md
+++ b/macos/Resources/presets/linear-sync/system.md
@@ -119,13 +119,13 @@ Mark the Ghostties task `running` via `update_task_status`.
 Pre-flight check — run this first and abort if it fails:
 ```bash
 git remote get-url origin
-# Must end in: SeanSmithDesign/ghostties
+# Must end in: SeanSmithWorks/ghostties
 # If it ends in ghostty-org/ghostty — STOP. Do not open a PR.
 ```
 
 Then:
 ```bash
-gh pr create --repo SeanSmithDesign/ghostties --base main --title "..." --body "..."
+gh pr create --repo SeanSmithWorks/ghostties --base main --title "..." --body "..."
 ```
 
 **Never** `--force` on push. **Never** open a PR from a background subagent.

--- a/macos/Sources/Features/Ghostties/OnboardingSheet.swift
+++ b/macos/Sources/Features/Ghostties/OnboardingSheet.swift
@@ -68,7 +68,7 @@ struct OnboardingSheet: View {
                             Text("GitHub:")
                                 .font(.system(size: 12))
                                 .foregroundStyle(.secondary)
-                            Link("github.com/SeanSmithDesign/ghostties", destination: URL(string: "https://github.com/SeanSmithDesign/ghostties")!)
+                            Link("github.com/SeanSmithWorks/ghostties", destination: URL(string: "https://github.com/SeanSmithWorks/ghostties")!)
                                 .font(.system(size: 12))
                         }
                     }

--- a/web/download.html
+++ b/web/download.html
@@ -221,7 +221,7 @@
 
     <h2>Current release</h2>
     <div class="download-block">
-      <a class="download-btn" href="https://github.com/SeanSmithDesign/ghostties/releases/download/v0.1.0-beta.20/Ghostties.dmg" download>
+      <a class="download-btn" href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.20/Ghostties.dmg" download>
         Download v0.1.0-beta.20 for macOS
       </a>
       <div class="download-meta">
@@ -232,7 +232,7 @@
 
     <p>Beta release &mdash; auto-updates via Sparkle once installed.</p>
 
-    <a class="all-releases" href="https://github.com/SeanSmithDesign/ghostties/releases" target="_blank" rel="noopener">View all releases on GitHub &rarr;</a>
+    <a class="all-releases" href="https://github.com/SeanSmithWorks/ghostties/releases" target="_blank" rel="noopener">View all releases on GitHub &rarr;</a>
     <br>
     <a class="all-releases" href="/changelog">What&rsquo;s new in each release &rarr;</a>
 

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -168,7 +168,7 @@
 
     <h2>Ghostties</h2>
     <p>Copyright &copy; 2026 Sean Smith. MIT License.<br>
-    <a href="https://github.com/SeanSmithDesign/ghostties/blob/main/LICENSE" target="_blank" rel="noopener">View on GitHub &rarr;</a></p>
+    <a href="https://github.com/SeanSmithWorks/ghostties/blob/main/LICENSE" target="_blank" rel="noopener">View on GitHub &rarr;</a></p>
 
     <h2>Ghostty</h2>
     <p>Ghostties is a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a> by Mitchell Hashimoto. Copyright &copy; 2024 Mitchell Hashimoto. MIT License.<br>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -201,7 +201,7 @@
     <p>When Ghostties asks for Accessibility, Screen Recording, or other permissions, those grants stay on your machine. Nothing is transmitted.</p>
 
     <h2>Open source</h2>
-    <p>All code is at <a href="https://github.com/SeanSmithDesign/ghostties" target="_blank" rel="noopener">github.com/SeanSmithDesign/ghostties</a>. Built on upstream <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a> (MIT-licensed).</p>
+    <p>All code is at <a href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener">github.com/SeanSmithWorks/ghostties</a>. Built on upstream <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a> (MIT-licensed).</p>
 
     <p class="updated">Last updated April 26, 2026</p>
   </div>

--- a/web/support.html
+++ b/web/support.html
@@ -191,7 +191,7 @@
     <p class="lead">Ghostties is in beta. If something breaks or feels wrong, we'd like to know.</p>
 
     <h2>Found a bug?</h2>
-    <p><a href="https://github.com/SeanSmithDesign/ghostties/issues" target="_blank" rel="noopener">Open an issue on GitHub.</a> Include your macOS version (Apple menu &rarr; About This Mac), Ghostties version (Ghostties menu &rarr; About Ghostties), and what you were doing when it broke.</p>
+    <p><a href="https://github.com/SeanSmithWorks/ghostties/issues" target="_blank" rel="noopener">Open an issue on GitHub.</a> Include your macOS version (Apple menu &rarr; About This Mac), Ghostties version (Ghostties menu &rarr; About Ghostties), and what you were doing when it broke.</p>
 
     <h2>System requirements</h2>
     <ul>
@@ -206,7 +206,7 @@
     <p>Quit the app, delete <code>~/Library/Application Support/com.seansmithdesign.ghostties/</code>, then relaunch. This wipes workspaces and preferences but leaves your project-local task notes (<code>.ghostties/tasks/</code>) alone.</p>
 
     <h2>Contact</h2>
-    <p>For now, <a href="https://github.com/SeanSmithDesign/ghostties/issues" target="_blank" rel="noopener">GitHub Issues</a> is the best path. Email and Discord support coming once we're out of beta.</p>
+    <p>For now, <a href="https://github.com/SeanSmithWorks/ghostties/issues" target="_blank" rel="noopener">GitHub Issues</a> is the best path. Email and Discord support coming once we're out of beta.</p>
 
     <p class="updated">Last updated April 26, 2026</p>
   </div>


### PR DESCRIPTION
Updates GitHub account references from SeanSmithDesign to SeanSmithWorks in six user-facing files: web/download.html, web/support.html, web/privacy.html, web/licenses.html, macos/Sources/Features/Ghostties/OnboardingSheet.swift, macos/Resources/presets/linear-sync/system.md. Test-fixture/doc-comment example URLs (CrossSurfaceCoherenceTests.swift, TaskModelTests.swift, TaskModel.swift) were intentionally left unchanged.