### PR TITLE
fix(macos): reclaim Cmd+Shift+[/] for session cycling in all sidebar views

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -379,6 +379,12 @@ class AppDelegate: NSObject,
         // propagate to Ghostty's new_window handler.
         setupNewTaskComposerShortcut()
 
+        // Reclaims ⌘⇧[ / ⌘⇧] for session cycling — see
+        // `setupSessionCyclingShortcut()` for why this needs its own monitor
+        // (Ghostty's default `previous_tab`/`next_tab` keybinds otherwise win
+        // the chord before our "Next/Previous Session" menu items ever fire).
+        setupSessionCyclingShortcut()
+
         // Setup signal handlers
         setupSignals()
 
@@ -871,6 +877,58 @@ class AppDelegate: NSObject,
 
             // D17: return nil to swallow — must not propagate to new_window.
             return nil
+        }
+    }
+
+    /// Reclaims ⌘⇧[ / ⌘⇧] for session cycling ("Next/Previous Session" in the
+    /// View menu) in every sidebar view.
+    ///
+    /// **Root cause of the Projects-view no-op bug this fixes:** Ghostty's
+    /// default keybinds (`src/config/Config.zig` around line 7038-7047) bind
+    /// these exact chords to `previous_tab`/`next_tab`. `NSWindow` asks its
+    /// content view hierarchy's `performKeyEquivalent(with:)` BEFORE it asks
+    /// `NSApp.mainMenu`, and `SurfaceView_AppKit.performKeyEquivalent` (see
+    /// that file, `override func performKeyEquivalent`) recognizes the chord
+    /// as a Ghostty binding, calls `self.keyDown(with:)` to run
+    /// `previous_tab`/`next_tab` itself, and returns `true` — so our "Next/
+    /// Previous Session" menu items (added in `setupWorkspaceMenuItems()`)
+    /// never get a turn. `NSEvent.addLocalMonitorForEvents` runs before
+    /// AppKit's key-equivalent dispatch entirely, so intercepting here and
+    /// returning `nil` reliably wins the race — same pattern as
+    /// `setupNewTaskComposerShortcut()` above, which solves the identical
+    /// problem for ⌘⇧N vs. `new_window`.
+    ///
+    /// Unlike the ⌘⇧N monitor, this one is NOT gated on sidebar view mode —
+    /// the whole point is that Cmd+Shift+[/] must cycle sessions identically
+    /// in the Projects tab, Sessions tab, and task-first mode, so the chord
+    /// is reclaimed unconditionally and dispatched through the responder
+    /// chain via `NSApp.sendAction`, exactly like a menu-item click would.
+    /// This is also why it can't regress on custom user keybinds: Ghostty's
+    /// config never gets a chance to see this chord at all, regardless of
+    /// what `previous_tab`/`next_tab` (or anything else) is bound to.
+    ///
+    /// Uses `characters(byApplyingModifiers: [])` rather than
+    /// `charactersIgnoringModifiers` to read the base key — `[`/`]` are
+    /// symbol keys, so `charactersIgnoringModifiers` still honors Shift and
+    /// would report `{`/`}` for this exact chord, not `[`/`]`.
+    private func setupSessionCyclingShortcut() {
+        _ = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection([.command, .shift, .control, .option])
+                    == [.command, .shift]
+            else { return event }
+
+            switch event.characters(byApplyingModifiers: []) {
+            case "]":
+                NSApp.sendAction(#selector(TerminalController.selectNextSession(_:)), to: nil, from: nil)
+                return nil
+
+            case "[":
+                NSApp.sendAction(#selector(TerminalController.selectPreviousSession(_:)), to: nil, from: nil)
+                return nil
+
+            default:
+                return event
+            }
         }
     }
 

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -545,6 +545,38 @@ final class SessionCoordinator: ObservableObject {
         (sessionTrees[id] != nil || browserManagers[id] != nil) && statuses[id] == .running
     }
 
+    /// Whether a session has a live surface tree or browser manager, regardless
+    /// of its running/completed/exited/killed status. Broader than `isRunning`
+    /// on purpose — used for Cmd+Shift+[/] session cycling so the list matches
+    /// what the sidebar actually shows (browser-tab mental model), not just
+    /// currently-running processes. Do not use in place of `isRunning`; other
+    /// call sites depend on its stricter running-only semantics.
+    func hasLiveSurface(id: UUID) -> Bool {
+        sessionTrees[id] != nil || browserManagers[id] != nil
+    }
+
+    /// Focuses the next/previous session in `sessions` relative to
+    /// `activeSessionId`, wrapping at both ends. No-ops (returns `nil`, no
+    /// beep, no crash) when `sessions` is empty. Shared by
+    /// `WorkspaceSidebarView` (Projects + Sessions tabs) and `TaskSidebarView`
+    /// (task-first mode) so Cmd+Shift+[/] cycles the active terminal
+    /// identically in all three sidebar views.
+    func focusAdjacentLiveSession(offset: Int, in sessions: [AgentSession]) -> AgentSession? {
+        guard !sessions.isEmpty else { return nil }
+
+        guard let currentId = activeSessionId,
+              let currentIndex = sessions.firstIndex(where: { $0.id == currentId }) else {
+            let target = offset > 0 ? sessions[0] : sessions[sessions.count - 1]
+            focusSession(id: target.id)
+            return target
+        }
+
+        let newIndex = (currentIndex + offset + sessions.count) % sessions.count
+        let target = sessions[newIndex]
+        focusSession(id: target.id)
+        return target
+    }
+
     /// Close a session's surface tree. All processes in the tree are terminated.
     func closeSession(id: UUID) {
         // Browser session path.

--- a/macos/Sources/Features/Ghostties/TaskSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/TaskSidebarView.swift
@@ -28,9 +28,16 @@ struct TaskSidebarView: View {
     @EnvironmentObject private var coordinator: SessionCoordinator
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Cursor for Cmd+Shift+]/[ task cycling (task-first mode). Tracks the
-    /// last task moved to; independent of native SwiftUI row focus (see
-    /// `selectAdjacentTask(offset:proxy:)` for the limitation this implies).
+    /// Cursor for task cycling. Tracks the last task moved to; independent of
+    /// native SwiftUI row focus (see `selectAdjacentTask(offset:proxy:)` for
+    /// the limitation this implies).
+    ///
+    /// NOTE: Cmd+Shift+]/[ no longer drives this — that chord now cycles the
+    /// active terminal session in every sidebar view (see the
+    /// `.workspaceSelectNextSession` / `.workspaceSelectPreviousSession`
+    /// `.onReceive` handlers in `body`). `selectAdjacentTask` and its
+    /// `.workspaceSelectNextTask` / `.workspaceSelectPreviousTask` wiring stay
+    /// in place, unreachable until they're given their own binding.
     @State private var taskCyclingCursorId: String?
 
     var body: some View {
@@ -111,6 +118,22 @@ struct TaskSidebarView: View {
         // U8: Observe the notification that AppDelegate's ⌘⇧N monitor posts.
         .onReceive(NotificationCenter.default.publisher(for: .openNewTaskComposer)) { _ in
             composerStore.open(workspaceStore: workspaceStore)
+        }
+        // Cmd+Shift+]/[ session cycling (browser-tab mental model), same
+        // chord and same `SessionCoordinator.focusAdjacentLiveSession(offset:in:)`
+        // helper `WorkspaceSidebarView` uses for the Projects/Sessions tabs.
+        // Task-first mode has no project rows to expand/select, so this just
+        // switches the active terminal — the task-cycling cursor below
+        // (`selectAdjacentTask`) no longer owns this chord.
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceSelectNextSession)) { notification in
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            let liveSessions = workspaceStore.sessionsInVisualOrder(coordinator: coordinator)
+            _ = coordinator.focusAdjacentLiveSession(offset: 1, in: liveSessions)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceSelectPreviousSession)) { notification in
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            let liveSessions = workspaceStore.sessionsInVisualOrder(coordinator: coordinator)
+            _ = coordinator.focusAdjacentLiveSession(offset: -1, in: liveSessions)
         }
     }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -247,37 +247,15 @@ struct WorkspaceSidebarView: View {
         expandedProjectIds.insert(targetId)
     }
 
-    /// All *running* sessions (`coordinator.isRunning(id:)`), flattened in
-    /// sidebar visual order: projects in `flatProjectsInVisualOrder`, then
-    /// each project's sessions in their displayed order
-    /// (`sessionGroups(forProject:)`, same helper `ProjectDisclosureRow` uses
-    /// to render its own rows).
-    private var liveSessionsInVisualOrder: [AgentSession] {
-        store.flatProjectsInVisualOrder.flatMap { project in
-            store.sessionGroups(forProject: project.id).flatMap { $0.1 }
-        }.filter { coordinator.isRunning(id: $0.id) }
-    }
-
-    /// Cmd+Shift+]/[ in project-first mode. Cycles focus through live
-    /// (running) sessions only, wrapping at both ends. No-ops (no beep, no
-    /// crash) when there are zero live sessions; is a no-op when there is
-    /// exactly one.
+    /// Cmd+Shift+]/[ in Projects/Sessions tabs. Cycles focus through every
+    /// session with a live surface (`store.sessionsInVisualOrder(coordinator:)`
+    /// — not just `.running` ones, so cycling matches the browser-tab mental
+    /// model and what's actually visible in the sidebar), wrapping at both
+    /// ends. No-ops (no beep, no crash) when there are zero live sessions; is
+    /// a no-op when there is exactly one.
     private func selectAdjacentLiveSession(offset: Int) {
-        let liveSessions = liveSessionsInVisualOrder
-        guard !liveSessions.isEmpty else { return }
-
-        guard let currentId = coordinator.activeSessionId,
-              let currentIndex = liveSessions.firstIndex(where: { $0.id == currentId }) else {
-            let target = offset > 0 ? liveSessions[0] : liveSessions[liveSessions.count - 1]
-            coordinator.focusSession(id: target.id)
-            expandedProjectIds.insert(target.projectId)
-            selectedProjectId = target.projectId
-            return
-        }
-
-        let newIndex = (currentIndex + offset + liveSessions.count) % liveSessions.count
-        let target = liveSessions[newIndex]
-        coordinator.focusSession(id: target.id)
+        let liveSessions = store.sessionsInVisualOrder(coordinator: coordinator)
+        guard let target = coordinator.focusAdjacentLiveSession(offset: offset, in: liveSessions) else { return }
         expandedProjectIds.insert(target.projectId)
         selectedProjectId = target.projectId
     }

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -416,6 +416,17 @@ final class WorkspaceStore: ObservableObject {
         return computed
     }
 
+    /// All sessions with a live surface (visible in the sidebar, regardless of
+    /// running/completed/exited/killed status), flattened in the same visual
+    /// order as `flatProjectsInVisualOrder` + `sessionGroups(forProject:)`.
+    /// Powers Cmd+Shift+[/] session cycling — see
+    /// `SessionCoordinator.focusAdjacentLiveSession(offset:in:)`.
+    func sessionsInVisualOrder(coordinator: SessionCoordinator) -> [AgentSession] {
+        flatProjectsInVisualOrder.flatMap { project in
+            sessionGroups(forProject: project.id).flatMap { $0.1 }
+        }.filter { coordinator.hasLiveSurface(id: $0.id) }
+    }
+
     #if DEBUG
     /// Test hook — seed the grace-period tracker directly. Production code must
     /// use `updateProjectActivityFromIndicatorStates()` instead.

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1315,27 +1315,24 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         NotificationCenter.default.post(name: .workspaceSelectPreviousProject, object: window)
     }
 
-    /// "Next Session" — Cmd+Shift+]. View-mode-aware: cycles live sessions in
-    /// project-first mode, or the task-cycling cursor in task-first mode.
-    /// Reads the same `ghostties.sidebarViewMode` defaults key used by
-    /// `toggleTaskView(_:)` / `validateMenuItem(_:)` above.
+    /// "Next Session" — Cmd+Shift+]. Cycles the active terminal session — the
+    /// same behavior in every sidebar view (Projects, Sessions, task-first).
+    /// `WorkspaceSidebarView` and `TaskSidebarView` both observe
+    /// `.workspaceSelectNextSession` and call
+    /// `SessionCoordinator.focusAdjacentLiveSession(offset:in:)`.
+    ///
+    /// Reachable via the "Next Session" menu item (mouse click) or the
+    /// `AppDelegate.setupSessionCyclingShortcut()` local event monitor, which
+    /// reclaims the Cmd+Shift+]/[ chord from Ghostty's default
+    /// `next_tab`/`previous_tab` keybinds before the terminal surface's
+    /// `performKeyEquivalent` can consume it.
     @IBAction func selectNextSession(_ sender: Any?) {
-        let mode = UserDefaults.standard.string(forKey: "ghostties.sidebarViewMode") ?? "projectFirst"
-        if mode == "taskFirst" {
-            NotificationCenter.default.post(name: .workspaceSelectNextTask, object: window)
-        } else {
-            NotificationCenter.default.post(name: .workspaceSelectNextSession, object: window)
-        }
+        NotificationCenter.default.post(name: .workspaceSelectNextSession, object: window)
     }
 
     /// "Previous Session" — Cmd+Shift+[. See `selectNextSession(_:)`.
     @IBAction func selectPreviousSession(_ sender: Any?) {
-        let mode = UserDefaults.standard.string(forKey: "ghostties.sidebarViewMode") ?? "projectFirst"
-        if mode == "taskFirst" {
-            NotificationCenter.default.post(name: .workspaceSelectPreviousTask, object: window)
-        } else {
-            NotificationCenter.default.post(name: .workspaceSelectPreviousSession, object: window)
-        }
+        NotificationCenter.default.post(name: .workspaceSelectPreviousSession, object: window)
     }
 
     @IBAction func newWorkspaceSession(_ sender: Any?) {


### PR DESCRIPTION
Fixes the beta.20 session-cycling shortcut (#44), which did not work in the case that matters most: while a terminal has keyboard focus.

## Root cause

PR #44's commit message claimed "no existing binding collision found in the fork menu or upstream default keybinds." That claim was wrong.

`src/config/Config.zig:7038-7047` binds, as macOS defaults:
- `cmd+shift+[` → `previous_tab`
- `cmd+shift+]` → `next_tab`

`SurfaceView_AppKit.swift:1296` overrides `performKeyEquivalent`, and AppKit consults the view hierarchy **before** `NSApp.mainMenu`. The surface recognized the chord as a Ghostty binding, ran the native tab action, and returned `true` — so the fork's "Next/Previous Session" menu items never fired.

Critically, that override is gated on focus (`SurfaceView_AppKit.swift:1307`):

```swift
if !focused { return false }
```

This is why the bug looked intermittent. With focus in the sidebar the chord reached the menu and worked; with focus in a terminal — i.e. actually mid-conversation with an agent, the whole point of the feature — it was swallowed.

## Changes

1. **Reclaim the chord** — new `AppDelegate.setupSessionCyclingShortcut()`, an `NSEvent.addLocalMonitorForEvents` monitor following the existing `setupNewTaskComposerShortcut()` precedent (written for the same class of problem: ⌘⇧N vs `new_window`). Local monitors run ahead of AppKit's key-equivalent dispatch, so cycling now fires regardless of focus or of the user's ghostty keybind config. Uses `characters(byApplyingModifiers: [])` rather than `charactersIgnoringModifiers` — the latter honors Shift and reports `{`/`}` for this chord.

2. **Cycle all sessions with a live surface, not just running ones** — the list filtered on `isRunning`, which requires `status == .running`. Any agent that had finished its turn silently dropped out, so the cycle often collapsed to zero or one and no-op'd. New `SessionCoordinator.hasLiveSurface(id:)` + `WorkspaceStore.sessionsInVisualOrder(coordinator:)`. `isRunning` itself is unchanged; other call sites are unaffected.

3. **One cycling path for all three views** — `TerminalController` no longer branches on `sidebarViewMode`. Projects, Sessions, and task-first all post the same notification. Previously task-first used this chord to move a task *scroll cursor* rather than switch terminals.

`Cmd+Ctrl+[/]` (project cycling) is untouched.

## Tradeoff

Ghostty's native tab switching loses `cmd+shift+[/]`. Deliberate — Ghostties uses the sidebar for this — and reversible.

## Verification

Manually verified against a Debug build (`Ghostties Dev.app`): cycling works with focus inside a live agent terminal in **Projects**, **Sessions**, and **task-first** views.

No screenshot attached — the change is a keystroke dispatch path, and a still frame can't evidence it. The observable acceptance was the live keyboard test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56fpyBVGdrYaaMNBJZM9o