### PR TITLE
fix(macos): stop the sidebar claiming every idle Claude session needs you

### DIFF
--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -95,6 +95,14 @@ final class SessionCoordinator: ObservableObject {
     /// terminal output line when detecting "needs attention" prompts.
     private var lastSurfaceTitle: [UUID: String] = [:]
 
+#if DEBUG
+    /// Test-only override for `isAgentKindSession`'s store lookup, so tests
+    /// can exercise the agent-kind branch of `indicatorState(for:)` against
+    /// an isolated `WorkspaceStore` instead of `WorkspaceStore.shared` (which
+    /// persists to the real `workspace.json`). nil in production.
+    var agentKindLookupStoreForTesting: WorkspaceStore?
+#endif
+
     /// Per-session Combine subscription for Claude Code → sidebar name sync.
     /// Subscribes directly to `surface.$title` (see `subscribeNameSync`) —
     /// `@Published` only ever emits a settled value (`SurfaceView_AppKit`'s
@@ -1304,7 +1312,17 @@ final class SessionCoordinator: ObservableObject {
             if isLikelyPromptingForInput(sessionId: sessionId) {
                 return .needsAttention
             }
-            // Silent but no strong signal of a prompt — generic waiting.
+            // Silent, not at a shell prompt, no prompt-shaped title. For plain
+            // shell sessions `isAtPrompt` is a trustworthy signal (driven by
+            // real OSC 133 markers), so silence-without-it genuinely means
+            // "waiting on something". Agent-kind sessions (Claude Code, custom
+            // agent CLIs) are full-screen TUIs that never emit OSC 133 — for
+            // those, `isAtPrompt` is permanently false and silence alone is not
+            // evidence the user is needed. Absence of evidence must fall back
+            // to the low-salience state, not an attention-seeking one.
+            if isAgentKindSession(sessionId) {
+                return .idle
+            }
             return .waiting
 
         case .completed, .exited, .killed:
@@ -1313,6 +1331,29 @@ final class SessionCoordinator: ObservableObject {
         case .error:
             return .error
         }
+    }
+
+    /// Whether a session's template is an agent CLI (Claude Code, custom) rather
+    /// than a plain shell.
+    ///
+    /// Plain shell sessions emit real OSC 133 prompt markers, so `isAtPrompt`
+    /// is trustworthy for them. Agent-kind sessions are full-screen TUIs that
+    /// never emit that marker, so `isAtPrompt` never becomes true for their
+    /// entire lifetime — the `.waiting` fallback in `indicatorState(for:)`
+    /// needs to treat their silence differently. Unknown/missing session or
+    /// template (lookup failure) returns `false`, preserving the historic
+    /// shell-like fallback rather than guessing.
+    private func isAgentKindSession(_ sessionId: UUID) -> Bool {
+        #if DEBUG
+        let store = agentKindLookupStoreForTesting ?? WorkspaceStore.shared
+        #else
+        let store = WorkspaceStore.shared
+        #endif
+        guard let session = store.sessions.first(where: { $0.id == sessionId }),
+              let template = store.templates.first(where: { $0.id == session.templateId }) else {
+            return false
+        }
+        return template.kind != .shell
     }
 
     /// Check if a session is likely blocked on user input based on its last output.
@@ -1453,6 +1494,30 @@ final class SessionCoordinator: ObservableObject {
     /// for the real `Timer` to fire. Never used in production.
     func runActivityTickForTesting() {
         performActivityTick()
+    }
+
+    /// Test-only seam for exercising `indicatorState(for:)`'s decision tree
+    /// without live GhosttyKit surfaces. Sets exactly the internal state
+    /// `indicatorState(for:)` reads and nothing else. Never used in production.
+    func seedIndicatorStateForTesting(
+        id: UUID,
+        status: SessionStatus = .running,
+        lastOutputSecondsAgo: Int? = nil,
+        processingStartSecondsAgo: Int? = nil,
+        isAtPrompt: Bool = false,
+        lastSurfaceTitle: String? = nil
+    ) {
+        statuses[id] = status
+        if let lastOutputSecondsAgo {
+            lastOutputTimestamps[id] = ContinuousClock.now - .seconds(lastOutputSecondsAgo)
+        }
+        if let processingStartSecondsAgo {
+            processingStartTimes[id] = ContinuousClock.now - .seconds(processingStartSecondsAgo)
+        }
+        self.isAtPrompt[id] = isAtPrompt
+        if let lastSurfaceTitle {
+            self.lastSurfaceTitle[id] = lastSurfaceTitle
+        }
     }
 #endif
 }

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorStateTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorStateTests.swift
@@ -1,0 +1,111 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+@testable import Ghostty
+
+/// Tests for the fallback branch at the end of the `.running` case in
+/// `SessionCoordinator.indicatorState(for:)`.
+///
+/// Root cause this guards against: `isAtPrompt` is driven exclusively by
+/// `GHOSTTY_ACTION_PROMPT_READY` (OSC 133 shell-prompt marker), which
+/// full-screen agent TUIs like Claude Code never emit. Before this fix, any
+/// silent Claude Code session — silent for as little as 2 seconds
+/// (`activityThreshold`) — permanently fell through to `.waiting`, an
+/// attention-seeking state, even though nothing was actually waiting on the
+/// user. The fix inverts that fallback to `.idle` for agent-kind sessions
+/// only; plain shell sessions (which DO get real OSC 133 markers) keep the
+/// original `.waiting` fallback unchanged.
+@MainActor
+final class SessionCoordinatorIndicatorStateTests: XCTestCase {
+
+    private func makeProject() -> Project {
+        Project(name: "ghostties", rootPath: "/Users/sean/Code/ghostties", isPinned: true)
+    }
+
+    /// Builds an isolated `WorkspaceStore` (never touches the real
+    /// `workspace.json`) seeded with a single session on the given template,
+    /// and a `SessionCoordinator` wired to look up that store instead of
+    /// `WorkspaceStore.shared`.
+    private func makeCoordinator(templateId: UUID) -> (SessionCoordinator, UUID) {
+        let project = makeProject()
+        let session = AgentSession(name: "Session 1", templateId: templateId, projectId: project.id)
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: [session])
+        let coordinator = SessionCoordinator()
+        coordinator.agentKindLookupStoreForTesting = store
+        return (coordinator, session.id)
+    }
+
+    // MARK: - The fix
+
+    func testAgentSessionSilentNotAtPromptNoPromptTitleIsIdle() {
+        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        coordinator.seedIndicatorStateForTesting(id: sessionId, status: .running, isAtPrompt: false)
+
+        XCTAssertEqual(
+            coordinator.indicatorState(for: sessionId),
+            .idle,
+            "a silent Claude Code session with no positive evidence of needing the user must read as idle, not waiting"
+        )
+    }
+
+    // MARK: - Unchanged behavior for agent sessions
+
+    func testAgentSessionRecentOutputIsProcessing() {
+        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        coordinator.seedIndicatorStateForTesting(
+            id: sessionId,
+            status: .running,
+            lastOutputSecondsAgo: 0,
+            processingStartSecondsAgo: 0,
+            isAtPrompt: false
+        )
+
+        XCTAssertEqual(coordinator.indicatorState(for: sessionId), .processing)
+    }
+
+    func testAgentSessionSustainedOutputThirtyPlusMinutesIsLongRunning() {
+        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        coordinator.seedIndicatorStateForTesting(
+            id: sessionId,
+            status: .running,
+            lastOutputSecondsAgo: 0,
+            processingStartSecondsAgo: 1900, // > 1800s longRunningThreshold
+            isAtPrompt: false
+        )
+
+        XCTAssertEqual(coordinator.indicatorState(for: sessionId), .longRunning)
+    }
+
+    func testAgentSessionPromptShapedTitleIsNeedsAttention() {
+        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        coordinator.seedIndicatorStateForTesting(
+            id: sessionId,
+            status: .running,
+            isAtPrompt: false,
+            lastSurfaceTitle: "Overwrite existing file?"
+        )
+
+        XCTAssertEqual(
+            coordinator.indicatorState(for: sessionId),
+            .needsAttention,
+            "a positive prompt-shaped-title signal must still win over the new idle fallback"
+        )
+    }
+
+    // MARK: - Regression guard: plain shell sessions must be untouched
+
+    /// THE regression guard that matters most: `isAtPrompt` is a trustworthy
+    /// signal for plain shell sessions (real OSC 133 markers), so a silent
+    /// shell session with no prompt marker yet must keep reading exactly as
+    /// it did before this fix — `.waiting` — not flip to `.idle`.
+    func testShellSessionSilentNotAtPromptStaysWaitingUnchanged() {
+        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.shell.id)
+        coordinator.seedIndicatorStateForTesting(id: sessionId, status: .running, isAtPrompt: false)
+
+        XCTAssertEqual(
+            coordinator.indicatorState(for: sessionId),
+            .waiting,
+            "plain shell sessions must keep the original .waiting fallback — only agent-kind sessions change"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`SessionCoordinator.indicatorState(for:)`'s fallback branch for a running-but-silent session with no positive prompt-shaped-title evidence returned `.waiting` — an attention-seeking state (blue "your turn" pulse).

`.idle` was only reachable via `isAtPrompt`, which is set exclusively by the OSC 133 shell-prompt marker (`GHOSTTY_ACTION_PROMPT_READY`). Claude Code is a full-screen TUI and never emits that marker. So `isAtPrompt` was permanently `false` for the entire lifetime of every Claude Code session, and `activityThreshold` is only 2 seconds — meaning every Claude session landed on `.waiting` or `.needsAttention` within 2 seconds of going quiet, forever. A Claude session could not reach `.idle`.

Measured against the 11 live Claude sessions on the machine at the time of investigation: Claude's own `~/.claude/sessions/*.json` state reported **7 idle, 4 busy, 0 with `waitingFor` set** — nothing was actually waiting on the user — while the sidebar claimed nearly all of them needed attention.

## Fix

Inverts the polarity of the fallback for **agent-kind sessions only** (any template kind other than `.shell` — Claude Code, custom agent CLIs): absence of positive evidence now returns `.idle` instead of `.waiting`.

- Plain shell sessions are untouched — they genuinely emit OSC 133, so `isAtPrompt` is trustworthy for them and their fallback stays `.waiting`.
- `.needsAttention` (prompt-shaped title heuristic) still wins when it fires — that's positive evidence and takes priority.
- `.processing` / `.longRunning` (recent output) are unaffected — only the last-resort branch changed.
- No changes to `activityThreshold`, `isAtPrompt` plumbing, OSC 133 handling, or the color palette.

`.waiting` is likely now unreachable for agent-kind sessions through this specific branch. Left the enum case and its other call sites in place — not deleted, per scope.

## Test plan

- [x] `xcodebuild ... build` — exit 0
- [x] Full unfiltered suite: **630 total / 628 passed / 1 failed / 1 skipped**. The only failure is the pre-existing `UpdateViewModelTests.testNotFoundText()`; the only skip is `BenchmarkTests.example()` — both unrelated to this change.
- [x] New `SessionCoordinatorIndicatorStateTests.swift` (5 tests, all passing):
  - `testAgentSessionSilentNotAtPromptNoPromptTitleIsIdle` — the fix
  - `testAgentSessionRecentOutputIsProcessing` — unchanged
  - `testAgentSessionSustainedOutputThirtyPlusMinutesIsLongRunning` — unchanged
  - `testAgentSessionPromptShapedTitleIsNeedsAttention` — unchanged
  - `testShellSessionSilentNotAtPromptStaysWaitingUnchanged` — regression guard for plain shell sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56fpyBVGdrYaaMNBJZM9o