### PR TITLE
fix(sidebar): Esc reverts inline rename instead of committing typed value

### DIFF
--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -503,6 +503,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
     }
 
     private func cancelRename() {
+        editingName = ""
         editingSessionId = nil
     }
 }

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -504,14 +504,23 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         if !trimmed.isEmpty, trimmed != session.name {
             store.renameSession(id: session.id, name: trimmed)
         }
-        renameFieldFocused = false
+        // Clear the sentinel before dropping focus: clearing focus itself
+        // triggers the onChange handler that schedules a deferred commit,
+        // so a re-entrant commit only sees the guard fail if the sentinel
+        // is already nil by the time that handler runs.
         editingSessionId = nil
+        renameFieldFocused = false
     }
 
     private func cancelRename() {
-        renameFieldFocused = false
-        editingName = ""
+        // Clear the sentinel before dropping focus: renameFieldFocused =
+        // false is itself a true→false transition that fires the same
+        // onChange handler this cancel is trying to defeat. The guard in
+        // commitRename only works if editingSessionId is already nil when
+        // that deferred handler runs.
         editingSessionId = nil
+        editingName = ""
+        renameFieldFocused = false
     }
 }
 

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -495,14 +495,21 @@ private struct ProjectDisclosureRowContent: View, Equatable {
     }
 
     private func commitRename(session: AgentSession) {
+        // Guards against the Esc blur-commit race: cancelRename() clears
+        // editingSessionId synchronously, so a commit that was scheduled
+        // before the cancel ran (see SessionRow's deferred onChange) finds
+        // a stale/mismatched id here and bails instead of writing.
+        guard editingSessionId == session.id else { return }
         let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty, trimmed != session.name {
             store.renameSession(id: session.id, name: trimmed)
         }
+        renameFieldFocused = false
         editingSessionId = nil
     }
 
     private func cancelRename() {
+        renameFieldFocused = false
         editingName = ""
         editingSessionId = nil
     }

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -256,14 +256,21 @@ struct RecentsListView: View {
     }
 
     private func commitRename(session: AgentSession) {
+        // Guards against the Esc blur-commit race: cancelRename() clears
+        // editingSessionId synchronously, so a commit that was scheduled
+        // before the cancel ran (see RecentsRowView's deferred onChange)
+        // finds a stale/mismatched id here and bails instead of writing.
+        guard editingSessionId == session.id else { return }
         let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty, trimmed != session.name {
             store.renameSession(id: session.id, name: trimmed)
         }
+        renameFieldFocused = false
         editingSessionId = nil
     }
 
     private func cancelRename() {
+        renameFieldFocused = false
         editingName = ""
         editingSessionId = nil
     }

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -264,6 +264,7 @@ struct RecentsListView: View {
     }
 
     private func cancelRename() {
+        editingName = ""
         editingSessionId = nil
     }
 

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -265,14 +265,23 @@ struct RecentsListView: View {
         if !trimmed.isEmpty, trimmed != session.name {
             store.renameSession(id: session.id, name: trimmed)
         }
-        renameFieldFocused = false
+        // Clear the sentinel before dropping focus: clearing focus itself
+        // triggers the onChange handler that schedules a deferred commit,
+        // so a re-entrant commit only sees the guard fail if the sentinel
+        // is already nil by the time that handler runs.
         editingSessionId = nil
+        renameFieldFocused = false
     }
 
     private func cancelRename() {
-        renameFieldFocused = false
-        editingName = ""
+        // Clear the sentinel before dropping focus: renameFieldFocused =
+        // false is itself a true→false transition that fires the same
+        // onChange handler this cancel is trying to defeat. The guard in
+        // commitRename only works if editingSessionId is already nil when
+        // that deferred handler runs.
         editingSessionId = nil
+        editingName = ""
+        renameFieldFocused = false
     }
 
     // MARK: - Relaunch

--- a/macos/Sources/Features/Ghostties/RecentsRowView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsRowView.swift
@@ -38,7 +38,14 @@ struct RecentsRowView: View {
                         .onSubmit { onCommitRename() }
                         .onExitCommand { onCancelRename() }
                         .onChange(of: isRenameFocused.wrappedValue) { focused in
-                            if !focused, isEditing { onCommitRename() }
+                            // Deferred: Esc can drop focus (firing this) before
+                            // SwiftUI's onExitCommand runs cancelRename(). Dispatching
+                            // async lets cancelRename() clear editingSessionId first,
+                            // so the id guard in commitRename(session:) rejects this
+                            // call instead of writing a stale name to the store.
+                            if !focused, isEditing {
+                                DispatchQueue.main.async { onCommitRename() }
+                            }
                         }
                 } else {
                     Text(session.name)

--- a/macos/Sources/Features/Ghostties/SessionDetailView.swift
+++ b/macos/Sources/Features/Ghostties/SessionDetailView.swift
@@ -39,7 +39,14 @@ struct SessionRow: View {
                     .onSubmit { onCommitRename() }
                     .onExitCommand { onCancelRename() }
                     .onChange(of: isRenameFocused.wrappedValue) { focused in
-                        if !focused, isEditing { onCommitRename() }
+                        // Deferred: Esc can drop focus (firing this) before
+                        // SwiftUI's onExitCommand runs cancelRename(). Dispatching
+                        // async lets cancelRename() clear editingSessionId first,
+                        // so the id guard in commitRename(session:) rejects this
+                        // call instead of writing a stale name to the store.
+                        if !focused, isEditing {
+                            DispatchQueue.main.async { onCommitRename() }
+                        }
                     }
             } else {
                 Text(session.name)


### PR DESCRIPTION
## Bug
Right-click a session row → Rename → type a new value → press Esc. The typed value could get committed to the store instead of reverting. Expected: Esc reverts to the original name, exits edit mode, and never writes anything.

## Root cause (corrected — original description was wrong)
The initial diagnosis (missing `editingName = ""` reset) was cosmetic, not the real bug. An independent review found the actual defect:

`.onExitCommand { onCancelRename() }` and `.onChange(of: isRenameFocused.wrappedValue) { ... onCommitRename() }` sit on the same TextField and do **opposite things** — but Esc triggers both, because AppKit's field editor drops focus as part of handling `cancelOperation:`. If the focus-loss `onChange` fires before SwiftUI's `onExitCommand` callback (which the reviewer traced to the field editor's internal ordering), `onCommitRename()` runs first, reads the still-typed `editingName`, and calls `store.renameSession(...)` — which also sets `isNamePinned = true`, permanently severing terminal-title sync for that session, with no undo affordance in Recents mode.

The `editingName = ""` fix only "worked" because it happened to make the commit's `!trimmed.isEmpty` guard reject the write — a coincidental side effect in a different function, not an actual disarm. It did nothing to stop the race itself, and a non-empty accidental value could still slip through depending on event order.

## Fix
Two changes, applied identically to both sidebar implementations (`RecentsListView`/`RecentsRowView` for flat/recents mode, `ProjectDisclosureRow`/`SessionRow` in `SessionDetailView.swift` for project-first mode):

1. **Defer the blur-triggered commit** one runloop turn via `DispatchQueue.main.async` in the `onChange(of: isRenameFocused.wrappedValue)` handler, instead of calling `onCommitRename()` synchronously.
2. **Guard `commitRename(session:)`** with `guard editingSessionId == session.id else { return }`. `cancelRename()` clears `editingSessionId` synchronously and unconditionally, regardless of which callback (`onExitCommand` vs the focus `onChange`) fires first.

This makes the invariant hold under **both** possible event orderings:
- If `onExitCommand`/`cancelRename()` runs first: `editingSessionId` is already `nil` before the deferred commit executes → guard rejects it.
- If the focus-loss `onChange` fires first: the commit is *scheduled*, not executed, so `cancelRename()` still gets to run (synchronously, in the same or next runloop turn) and clear `editingSessionId` before the deferred commit actually executes → guard rejects it.

Either way, `store.renameSession` is never reached on an Esc-driven cancel. Legitimate blur-commits (e.g. click-away without Esc) mostly just see the commit delayed one runloop tick (imperceptible) — but two edge cases genuinely change behavior and are called out below rather than left to be discovered.

Also closes a related latent bug as a side effect: neither `cancelRename()` nor `commitRename()` previously reset the shared `@FocusState` binding, so a stale-`true` focus value could prevent a *second* rename from ever taking keyboard focus. Both functions now explicitly set `renameFieldFocused = false`.

**Follow-up hardening (this update):** `cancelRename()` and `commitRename()` both cleared `editingSessionId` *after* `renameFieldFocused = false` — but dropping focus is itself a `true → false` transition that fires the very `onChange` handler this fix defends against. Only the `DispatchQueue.main.async` deferral was absorbing that ordering hazard, which made the deferral and the guard co-dependent: neither was safe in isolation, so a future refactor that simplified either one alone would have silently re-armed the bug. All four sites (`cancelRename`/`commitRename` × two files) now clear `editingSessionId` first, with a comment at each site explaining why the order matters.

## Known behavior changes (disclosed, not discovered)

1. **Rename-to-rename without an intervening blur no longer commits the first field.** If you're editing session A's name and start a rename on session B *without* first clicking away from A (no blur event on A), A's pending deferred commit is discarded rather than committed. Pre-fix, that flow committed A. Finder's convention is that starting a second rename commits the first, so this is a mild regression from that convention. Narrow (requires starting a second rename mid-edit, not just clicking elsewhere), but real.
2. **A rename in flight is lost, not delayed, if the app quits before the deferred commit drains.** Type a new name, then press ⌘Q without first clicking away from the field: the blur happens in the same runloop turn as termination, so the `DispatchQueue.main.async` block never runs and the commit never happens. Pre-fix, that flow committed. Losing an uncommitted rename on quit is a defensible tradeoff, but it's a real change, not a no-op.

- `macos/Sources/Features/Ghostties/RecentsListView.swift` — `commitRename`/`cancelRename`
- `macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift` — `commitRename`/`cancelRename`
- `macos/Sources/Features/Ghostties/RecentsRowView.swift` — deferred `onChange` handler
- `macos/Sources/Features/Ghostties/SessionDetailView.swift` (`SessionRow`) — deferred `onChange` handler

```diff
     private func commitRename(session: AgentSession) {
+        guard editingSessionId == session.id else { return }
         let trimmed = editingName.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty, trimmed != session.name {
             store.renameSession(id: session.id, name: trimmed)
         }
+        // Clear the sentinel before dropping focus — see comment below.
+        editingSessionId = nil
         renameFieldFocused = false
     }

     private func cancelRename() {
+        // Clear the sentinel before dropping focus: dropping focus is
+        // itself a true→false transition that fires the same onChange
+        // handler this cancel is trying to defeat.
+        editingSessionId = nil
         editingName = ""
-        editingSessionId = nil
+        renameFieldFocused = false
     }
```

```diff
     .onChange(of: isRenameFocused.wrappedValue) { focused in
-        if !focused, isEditing { onCommitRename() }
+        if !focused, isEditing {
+            DispatchQueue.main.async { onCommitRename() }
+        }
     }
```

## Build evidence
```
xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties \
  -derivedDataPath macos/build -configuration Debug \
  ONLY_ACTIVE_ARCH=YES ARCHS=arm64 build-for-testing
...
CodeSign .../Ghostties Dev.app
Validate .../Ghostties Dev.app
RegisterWithLaunchServices .../Ghostties Dev.app
** TEST BUILD SUCCEEDED **
```

## Testing
No new tests added — this is a small, self-contained behavioral fix and app-hosted `GhosttyTests` cannot execute headlessly in this environment (known repo constraint).

## Merge gate: this requires a human runtime check

The fix's correctness reduces to whether `.onExitCommand` fires at all in the live app — that can't be verified statically or by a headless build. **Merge is gated on Sean running this checklist in his own GUI session:**

1. Right-click a session row → Rename → type `zzz` → Esc. Row must show the **original** name.
2. Right-click that same row again: **"Sync name automatically" must be ABSENT** from the context menu. It only appears once `isNamePinned` is true, so its presence would prove a store write slipped through and the fix is a no-op.
3. Rename again, type `abc`, then click **another row** (no Esc) — must commit to `abc`.
4. Rename → Esc → immediately Rename again — the field must accept keystrokes (regression check for the stale-focus latent bug this PR also fixes).

