### PR TITLE
fix(macos): re-clamp sidebar width when window shrinks

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -544,12 +544,15 @@ class WorkspaceViewContainer: NSView {
     /// Total horizontal space available to the terminal + browser combined.
     /// Subtracts sidebar (when pinned) and the three inset gaps (leading, gap, trailing).
     ///
-    /// Reads `widthModel.width` — the sidebar's actually-applied width —
+    /// Reads `widthModel.width` — the sidebar's applied width while pinned —
     /// rather than `currentSidebarWidth` (the user's desired width). The two
     /// can diverge once the resize reclamp in `layout()` shrinks the applied
     /// width below the desired one without touching the desired value (see
     /// that reclamp's doc comment); the browser math needs the real width the
     /// sidebar currently occupies on screen, not the user's stored preference.
+    /// Note: `widthModel.width` is stale in closed/overlay mode (it isn't
+    /// written when transitioning to `.closed`), which is fine because both
+    /// consumers here gate on `sidebarMode == .pinned` anyway.
     private var resizableWidth: CGFloat {
         let sidebarWidth = sidebarMode == .pinned ? widthModel.width : 0
         let inset = WorkspaceLayout.terminalInset
@@ -728,6 +731,11 @@ class WorkspaceViewContainer: NSView {
             }
         }, completionHandler: { [weak self] in
             self?.isSidebarTransitionAnimating = false
+            // The resize reclamp in `layout()` was deferred for the duration of
+            // this animation. Force one more layout pass now that the flag is
+            // clear, or a window shrink that happened mid-animation may never
+            // get re-clamped.
+            self?.needsLayout = true
         })
         updateTrackingAreas()
         invalidateIntrinsicContentSize()
@@ -1137,6 +1145,11 @@ class WorkspaceViewContainer: NSView {
             }
         }, completionHandler: { [weak self] in
             self?.isSidebarTransitionAnimating = false
+            // The resize reclamp in `layout()` was deferred for the duration of
+            // this animation. Force one more layout pass now that the flag is
+            // clear, or a window shrink that happened mid-animation may never
+            // get re-clamped.
+            self?.needsLayout = true
         })
 
         // 5. Non-animatable properties.

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -255,6 +255,16 @@ class WorkspaceViewContainer: NSView {
     /// survives macOS version bumps and upstream titlebar refactors.
     private var sidebarToggleCenterYConstraint: NSLayoutConstraint!
 
+    /// True while a sidebar mode-transition animation (`transitionTo` or
+    /// `sidebarViewModeChanged`) is in flight. `layout()`'s resize reclamp
+    /// must not run while this is true: `sidebarWidthConstraint.animator()`
+    /// drives the constraint through intermediate values every frame during
+    /// the animation, and reclamping against those mid-flight values would
+    /// fight (or outright kill) the open/close animation. Set true right
+    /// before `NSAnimationContext.runAnimationGroup` starts, cleared in its
+    /// `completionHandler`.
+    private var isSidebarTransitionAnimating = false
+
     /// Stored constraints for animating sidebar show/hide and terminal insets.
     private var sidebarWidthConstraint: NSLayoutConstraint!
     private var shadowHostTopConstraint: NSLayoutConstraint!
@@ -533,8 +543,15 @@ class WorkspaceViewContainer: NSView {
 
     /// Total horizontal space available to the terminal + browser combined.
     /// Subtracts sidebar (when pinned) and the three inset gaps (leading, gap, trailing).
+    ///
+    /// Reads `widthModel.width` — the sidebar's actually-applied width —
+    /// rather than `currentSidebarWidth` (the user's desired width). The two
+    /// can diverge once the resize reclamp in `layout()` shrinks the applied
+    /// width below the desired one without touching the desired value (see
+    /// that reclamp's doc comment); the browser math needs the real width the
+    /// sidebar currently occupies on screen, not the user's stored preference.
     private var resizableWidth: CGFloat {
-        let sidebarWidth = sidebarMode == .pinned ? currentSidebarWidth : 0
+        let sidebarWidth = sidebarMode == .pinned ? widthModel.width : 0
         let inset = WorkspaceLayout.terminalInset
         // Three inset slots: leading of terminal, gap between panels, trailing of browser.
         return bounds.width - sidebarWidth - inset * 3
@@ -543,6 +560,53 @@ class WorkspaceViewContainer: NSView {
     override func layout() {
         super.layout()
 
+        // Re-clamp the sidebar width when the window shrinks. The sidebar
+        // previously never re-clamped on resize, so a sidebar sitting near
+        // its max could exceed the available space once the window got
+        // small enough. Pinned mode only — closed mode is always width 0,
+        // and overlay floats over the terminal rather than sharing its
+        // space. Runs BEFORE the browser split clamp below: the browser
+        // math reads `resizableWidth`, which reads the sidebar's live
+        // applied width, so the sidebar must be settled first or the
+        // browser gets one frame of stale width.
+        //
+        // `bounds.width > 0` guard: during teardown, tab merge/detach, and
+        // fullscreen intermediates `bounds.width` can transiently be 0,
+        // which would drive `maxByAvailableSpace` deeply negative and
+        // collapse the sidebar to `sidebarMinWidth`.
+        //
+        // `currentSidebarWidth` is the user's DESIRED width (the only
+        // in-memory record of what they dragged to — see its doc comment);
+        // it is never written here, only read. Only the applied
+        // width — `sidebarWidthConstraint.constant` / `widthModel.width` —
+        // is clamped. This mirrors the browser panel's own split: the
+        // desired value (`browserSplitRatio`) is untouched by its resize
+        // clamp below, only the applied `browserWidthConstraint.constant`
+        // is. Without this separation, shrinking the window below the
+        // user's chosen width permanently overwrites their preference —
+        // regrowing the window would never restore it.
+        //
+        // Guard witness is `widthModel.width`, not the animated
+        // `sidebarWidthConstraint.constant`: `transitionTo`/
+        // `sidebarViewModeChanged` drive that constraint through animator()
+        // over ~0.2s, so mid-animation it holds transient intermediate
+        // values every frame. Comparing against those would make this
+        // block "correct" the constraint back to its target on every
+        // frame, fighting (or fully overriding) the open animation. We
+        // also bail outright while a mode-transition animation is in
+        // flight — the animation itself is already driving the constraint
+        // to the right place.
+        if sidebarMode == .pinned && bounds.width > 0 && !isSidebarTransitionAnimating {
+            let inset = WorkspaceLayout.terminalInset
+            let maxByAvailableSpace = bounds.width - WorkspaceLayout.terminalMinWidth - inset * 2
+            let upperBound = min(WorkspaceLayout.sidebarMaxWidth, max(maxByAvailableSpace, WorkspaceLayout.sidebarMinWidth))
+            let reclamped = min(max(currentSidebarWidth, WorkspaceLayout.sidebarMinWidth), upperBound)
+            if reclamped != widthModel.width {
+                sidebarWidthConstraint.constant = reclamped
+                widthModel.width = reclamped
+            }
+        }
+
         // Keep the terminal/browser split proportional when the window resizes.
         if isBrowserVisible {
             let available = resizableWidth
@@ -550,31 +614,6 @@ class WorkspaceViewContainer: NSView {
             let desired = available * browserSplitRatio
             let clamped = min(max(desired, WorkspaceLayout.browserMinWidth), max(maxBrowser, WorkspaceLayout.browserMinWidth))
             browserWidthConstraint.constant = clamped
-        }
-
-        // Re-clamp the sidebar width when the window shrinks, mirroring the
-        // browser panel's resize clamp above. The sidebar previously never
-        // re-clamped on resize, so a sidebar sitting near its max could
-        // exceed the available space once the window got small enough.
-        // Pinned mode only — closed mode is always width 0, and overlay
-        // floats over the terminal rather than sharing its space.
-        if sidebarMode == .pinned {
-            let inset = WorkspaceLayout.terminalInset
-            let maxByAvailableSpace = bounds.width - WorkspaceLayout.terminalMinWidth - inset * 2
-            let upperBound = min(WorkspaceLayout.sidebarMaxWidth, max(maxByAvailableSpace, WorkspaceLayout.sidebarMinWidth))
-            let reclamped = min(max(currentSidebarWidth, WorkspaceLayout.sidebarMinWidth), upperBound)
-            if reclamped != sidebarWidthConstraint.constant {
-                // Update the constraint, the stored per-mode width, and the
-                // SwiftUI frame pin together (same three writes as
-                // `handleSidebarDrag`) so they never diverge. Deliberately
-                // does NOT call `persistSidebarWidth()` — that only fires on
-                // drag mouseUp so an intentional user-chosen width isn't
-                // overwritten by a transient window shrink; growing the
-                // window back out doesn't restore a resize-clamped value.
-                sidebarWidthConstraint.constant = reclamped
-                currentSidebarWidth = reclamped
-                widthModel.width = reclamped
-            }
         }
 
         // Explicit shadow paths eliminate per-frame offscreen rendering.
@@ -676,7 +715,8 @@ class WorkspaceViewContainer: NSView {
         // closed mode the width is 0, in overlay mode the constraint follows
         // the overlay width which is also driven by currentSidebarWidth.
         let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-        NSAnimationContext.runAnimationGroup { context in
+        isSidebarTransitionAnimating = true
+        NSAnimationContext.runAnimationGroup({ context in
             context.duration = reduceMotion ? 0 : 0.2
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             switch sidebarMode {
@@ -686,7 +726,9 @@ class WorkspaceViewContainer: NSView {
             case .closed:
                 break
             }
-        }
+        }, completionHandler: { [weak self] in
+            self?.isSidebarTransitionAnimating = false
+        })
         updateTrackingAreas()
         invalidateIntrinsicContentSize()
     }
@@ -1019,7 +1061,8 @@ class WorkspaceViewContainer: NSView {
 
         // 4. Animate constraints, widths, alphas.
         let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
-        NSAnimationContext.runAnimationGroup { context in
+        isSidebarTransitionAnimating = true
+        NSAnimationContext.runAnimationGroup({ context in
             context.duration = reduceMotion ? 0 : 0.2
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
 
@@ -1092,7 +1135,9 @@ class WorkspaceViewContainer: NSView {
                 browserShadowHostBottomConstraint.animator().constant = 0
                 browserShadowHostTrailingConstraint.animator().constant = 0
             }
-        }
+        }, completionHandler: { [weak self] in
+            self?.isSidebarTransitionAnimating = false
+        })
 
         // 5. Non-animatable properties.
         switch newMode {

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -552,6 +552,31 @@ class WorkspaceViewContainer: NSView {
             browserWidthConstraint.constant = clamped
         }
 
+        // Re-clamp the sidebar width when the window shrinks, mirroring the
+        // browser panel's resize clamp above. The sidebar previously never
+        // re-clamped on resize, so a sidebar sitting near its max could
+        // exceed the available space once the window got small enough.
+        // Pinned mode only — closed mode is always width 0, and overlay
+        // floats over the terminal rather than sharing its space.
+        if sidebarMode == .pinned {
+            let inset = WorkspaceLayout.terminalInset
+            let maxByAvailableSpace = bounds.width - WorkspaceLayout.terminalMinWidth - inset * 2
+            let upperBound = min(WorkspaceLayout.sidebarMaxWidth, max(maxByAvailableSpace, WorkspaceLayout.sidebarMinWidth))
+            let reclamped = min(max(currentSidebarWidth, WorkspaceLayout.sidebarMinWidth), upperBound)
+            if reclamped != sidebarWidthConstraint.constant {
+                // Update the constraint, the stored per-mode width, and the
+                // SwiftUI frame pin together (same three writes as
+                // `handleSidebarDrag`) so they never diverge. Deliberately
+                // does NOT call `persistSidebarWidth()` — that only fires on
+                // drag mouseUp so an intentional user-chosen width isn't
+                // overwritten by a transient window shrink; growing the
+                // window back out doesn't restore a resize-clamped value.
+                sidebarWidthConstraint.constant = reclamped
+                currentSidebarWidth = reclamped
+                widthModel.width = reclamped
+            }
+        }
+
         // Explicit shadow paths eliminate per-frame offscreen rendering.
         // Without these, Core Animation rasterizes the entire layer to compute
         // the shadow shape every frame — expensive for a terminal that redraws at 60fps.


### PR DESCRIPTION
## Summary

Shrinking the window didn't re-clamp the sidebar width. If the sidebar sat near `sidebarMaxWidth` and the window shrank, the sidebar could exceed the available space. The browser panel already re-clamps on the same `layout()` resize path — the sidebar just never got the same treatment.

An independent review of the first version of this fix found two blockers, both now fixed.

## Blocker 1 — the clamp was destroying the user's chosen width

`currentSidebarWidth` is not a cache — it's the DESIRED width, the only in-memory record of what the user dragged to (`persistSidebarWidth()` writes it to UserDefaults on drag `mouseUp`). The original clamp wrote its clamped result back into `currentSidebarWidth`, so: drag to 420pt in a wide window → tile the window small → clamp writes 384 into `currentSidebarWidth` → un-tile back to full size → sidebar stays at 384, 420 is gone forever. It also diverged across windows (UserDefaults still held 420) and the loss wasn't even delayed by skipping persistence — the next drag's `mouseUp` would persist the already-clobbered 384.

**Fix:** the reclamp in `layout()` now only writes the *applied* width (`sidebarWidthConstraint.constant` / `widthModel.width`) and never touches `currentSidebarWidth`. This mirrors the browser panel's own split, where `browserSplitRatio` (desired) is never touched by its resize clamp — only the applied `browserWidthConstraint.constant` is.

## Blocker 2 — the clamp was fighting the sidebar open animation

The clamp's change-guard compared against `sidebarWidthConstraint.constant`, the one variable `transitionTo`/`sidebarViewModeChanged` drive through `animator()` over ~0.2s. Mid-animation that constraint holds a different intermediate value every frame; the clamp saw each one as "wrong" and slammed it back to the target, fighting (or fully killing) the open animation — closing still animated (mode already `.closed`, guard skipped) but opening snapped instantly. Asymmetric toggle.

**Fix:** the guard now compares against `widthModel.width` (only ever set by intentional writes, not the animator), and a new `isSidebarTransitionAnimating` flag makes the clamp bail outright while a mode-transition animation is in flight (set true before `NSAnimationContext.runAnimationGroup` starts, cleared in its `completionHandler`).

## Also fixed

- **Ordering:** the sidebar clamp now runs *before* the browser split clamp in `layout()`. `resizableWidth` (which the browser math reads) now reads the sidebar's actually-applied width via `widthModel.width` instead of the desired `currentSidebarWidth` — necessary once Blocker 1 decoupled the two, otherwise the browser panel would permanently over/under-reserve space for a sidebar that's rendering smaller than the user's stored preference.
- **Degenerate bounds:** added a `bounds.width > 0` guard. At `bounds.width == 0` (teardown, tab merge/detach, fullscreen intermediates) the old formula drove the sidebar to its minimum; Blocker 1's fix already makes that non-destructive, but the guard avoids the pointless flicker.

## Formula-coupling decision (left alone)

`maxByAvailableSpace = bounds.width - terminalMinWidth - inset*2` is copied verbatim between this clamp and `handleSidebarDrag()`, and it ignores the browser panel's own width budget — with the browser open at its minimum, the sidebar's upper bound doesn't account for it. This is a **pre-existing bug**, not introduced by this PR, and the two call sites must stay identical (a live drag and this resize clamp computing different upper bounds would fight each other). I left the formula unchanged in both places rather than fixing it in isolation. Flagging as a follow-up, not fixing here.

## Invariants confirmed

**Finite frame pin still holds.** `SidebarWidthFrame` still does `content.frame(width: model.width)` — `model.width` is only ever set to a value produced by `min(max(...))` against the design tokens, never `nil`/`.infinity`.

**No rootView rebuild per resize tick.** The clamp only mutates `widthModel.width` (`@Published` on `SidebarWidthModel`); `applySidebarView()` is never called from this path.

## Build evidence

```
xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties \
  -derivedDataPath macos/build -configuration Debug \
  ONLY_ACTIVE_ARCH=YES ARCHS=arm64 build-for-testing
...
** TEST BUILD SUCCEEDED **
```

## Testing

No new automated tests — targeted `layout()`/`transitionTo` fix; app-hosted `GhosttyTests` can't execute headlessly in this environment. Compile gate only.

**Runtime verification is still outstanding** — needs a real GUI session:

## Test plan
- [ ] Drag the sidebar to near `sidebarMaxWidth` (e.g. 420pt), tile the window small, un-tile back out — confirm the sidebar returns to the original 420pt (not stuck at the resize-clamped value)
- [ ] With Reduce Motion **off**, toggle the sidebar closed → open — confirm the open animation is smooth and symmetric with the close (no snap-open)
- [ ] Shrink the window with the sidebar near max width — confirm it visually re-clamps, terminal keeps its minimum width, no beachball/CPU spike

## Re-review finding (fixed) — deferred clamp never re-triggered

A second independent re-review confirmed both blockers above are genuinely fixed and found exactly one new defect: `isSidebarTransitionAnimating` defers the resize clamp for the animation's duration, but nothing marked the view as needing layout when the flag cleared in the completion handler. If the animation's final layout pass ran before that completion block fired, the deferred clamp was skipped entirely — reachable by shrinking the window while the sidebar is closed, then opening it (the clamp correctly doesn't run while closed, but nothing re-runs it once the flag clears on open). Self-healing on the next incidental layout (window nudge, fullscreen toggle), but silently defeats the feature in exactly the state it exists for.

**Fix:** `self?.needsLayout = true` alongside each `self?.isSidebarTransitionAnimating = false`, matching the existing idiom in `windowDidEnterOrExitFullScreen`. The clamp's own guard (`reclamped != widthModel.width`) makes the extra layout pass a no-op once settled, so this cannot recurse.

Also corrected a doc comment on `resizableWidth` that claimed `widthModel.width` is always "the sidebar's actually-applied width" — it's only current while pinned; both consumers already gate on `sidebarMode == .pinned`, so this was misleading but harmless.
