### PR TITLE
security: pin CEF download and fail closed on checksum mismatch

### DIFF
--- a/scripts/download-cef.sh
+++ b/scripts/download-cef.sh
@@ -9,56 +9,17 @@ set -euo pipefail
 CEF_PLATFORM="macosarm64"
 CEF_DIST="standard"
 CEF_DIR="vendor/cef"
-CEF_INDEX_URL="https://cef-builds.spotifycdn.com/index.json"
 CEF_BASE_URL="https://cef-builds.spotifycdn.com"
 
-# ─── Resolve version ────────────────────────────────────────────────
-# Query the CEF builds API for the latest stable macOS ARM64 version.
-# The API returns JSON with platform keys; we need macosx_arm64.
-resolve_latest_stable() {
-  echo "Querying CEF builds API for latest stable macOS ARM64 version..."
-  local json
-  json=$(curl -sfSL "$CEF_INDEX_URL") || {
-    echo "ERROR: Failed to fetch CEF builds index from $CEF_INDEX_URL" >&2
-    exit 1
-  }
-
-  # Extract the first stable version for macosx_arm64
-  # The JSON structure is: { "macosx_arm64": { "versions": [ { "channel": "stable", "cef_version": "...", "chromium_version": "...", "files": [...] }, ... ] } }
-  local version_info
-  version_info=$(echo "$json" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-platform = data.get('macosarm64', data.get('macosx_arm64', {}))
-for v in platform.get('versions', []):
-    if v.get('channel') == 'stable':
-        # Find the standard distribution file
-        sha = ''
-        for f in v.get('files', []):
-            if f.get('type') == 'standard':
-                sha = f.get('sha1', '')  # Some have sha1 only
-                break
-        print(v['cef_version'])
-        print(v.get('chromium_version', ''))
-        print(sha)
-        break
-") || {
-    echo "ERROR: Failed to parse CEF builds index JSON" >&2
-    exit 1
-  }
-
-  CEF_VERSION=$(echo "$version_info" | sed -n '1p')
-  CHROMIUM_VERSION=$(echo "$version_info" | sed -n '2p')
-
-  if [ -z "$CEF_VERSION" ]; then
-    echo "ERROR: Could not find a stable macOS ARM64 CEF version in the builds index" >&2
-    exit 1
-  fi
-
-  echo "Found CEF $CEF_VERSION (Chromium $CHROMIUM_VERSION)"
-}
-
-resolve_latest_stable
+# ─── Pinned version ──────────────────────────────────────────────────
+# The build downloads a fixed CEF release, not "latest stable" — the
+# download server must never be trusted to pick what ships to users.
+#
+# To roll forward: download the new cef_binary_<version>_macosarm64.tar.bz2
+# from https://cef-builds.spotifycdn.com/index.json, run
+# `shasum -a 256` on it, and update both constants below together.
+CEF_VERSION="144.0.32+g5ce7d26+chromium-144.0.7559.258"
+CEF_SHA256="cf923ad835fe7b1ae8cc358af8e97de1fd7ae29a5c328d8173260caf4a77d989"
 
 # ─── Check existing installation ────────────────────────────────────
 if [ -f "$CEF_DIR/.version" ]; then
@@ -97,34 +58,28 @@ curl -fSL --progress-bar -o "$DOWNLOAD_PATH" "$CEF_URL" || {
 
 echo "Download complete. Size: $(du -h "$DOWNLOAD_PATH" | cut -f1)"
 
-# ─── Verify checksum (fetch from API) ───────────────────────────────
-echo "Fetching SHA-1 checksum from CEF builds API..."
-EXPECTED_SHA1=$(curl -sfSL "$CEF_INDEX_URL" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-platform = data.get('macosarm64', data.get('macosx_arm64', {}))
-for v in platform.get('versions', []):
-    if v.get('channel') == 'stable':
-        for f in v.get('files', []):
-            if f.get('type') == 'standard':
-                print(f.get('sha1', ''))
-                break
-        break
-" 2>/dev/null || true)
+# ─── Verify checksum (against pinned SHA-256) ────────────────────────
+# The expected hash is never fetched from the network — it's committed
+# above as CEF_SHA256, alongside the pinned CEF_VERSION.
+echo "Verifying SHA-256 checksum against pinned value..."
+command -v shasum >/dev/null 2>&1 || {
+  echo "ERROR: shasum not found; cannot verify download integrity." >&2
+  exit 1
+}
 
-if [ -n "$EXPECTED_SHA1" ]; then
-  ACTUAL_SHA1=$(shasum -a 1 "$DOWNLOAD_PATH" | awk '{print $1}')
-  if [ "$ACTUAL_SHA1" = "$EXPECTED_SHA1" ]; then
-    echo "SHA-1 checksum verified: $ACTUAL_SHA1"
-  else
-    echo "ERROR: SHA-1 checksum mismatch!" >&2
-    echo "  Expected: $EXPECTED_SHA1" >&2
-    echo "  Actual:   $ACTUAL_SHA1" >&2
-    exit 1
-  fi
-else
-  echo "Warning: No SHA-1 checksum available from API, skipping verification."
+if [ ! -s "$DOWNLOAD_PATH" ]; then
+  echo "ERROR: Downloaded file is missing or empty: $DOWNLOAD_PATH" >&2
+  exit 1
 fi
+
+ACTUAL_SHA256=$(shasum -a 256 "$DOWNLOAD_PATH" | awk '{print $1}')
+if [ "$ACTUAL_SHA256" != "$CEF_SHA256" ]; then
+  echo "ERROR: SHA-256 checksum mismatch!" >&2
+  echo "  Expected: $CEF_SHA256" >&2
+  echo "  Actual:   $ACTUAL_SHA256" >&2
+  exit 1
+fi
+echo "SHA-256 checksum verified: $ACTUAL_SHA256"
 
 # ─── Remove macOS quarantine attribute ───────────────────────────────
 # CEF archives downloaded from the internet get quarantined by macOS
@@ -147,6 +102,5 @@ echo "$CEF_VERSION" > "$CEF_DIR/.version"
 echo ""
 echo "CEF downloaded and extracted successfully."
 echo "  Version:  CEF $CEF_VERSION"
-echo "  Chromium: $CHROMIUM_VERSION"
 echo "  Location: $CEF_DIR/"
 echo "  Contents: $(find "$CEF_DIR" -maxdepth 1 -mindepth 1 | wc -l | tr -d ' ') top-level items"


### PR DESCRIPTION
## Summary

`scripts/download-cef.sh` downloaded a ~300MB Chromium Embedded Framework at build time with two problems:

1. It resolved "latest stable" from `cef-builds.spotifycdn.com` at build time — unpinned, so what got built depended on whatever CEF published that day.
2. It fetched the expected checksum from the *same server* that serves the tarball (and only a SHA-1), then **failed open**: when the checksum lookup came back empty, it printed a warning and extracted anyway (`|| true` on the fetch).

CI code-signs the resulting archive with the Developer ID and Sparkle ships it to every installed user — this was the only place unverified third-party code reached the signing identity.

## What changed

- Replaced the "resolve latest stable" API call with literal pinned constants `CEF_VERSION` / `CEF_SHA256` at the top of the script, with a comment on how to roll them forward.
- The SHA-256 was computed **locally**: downloaded the pinned tarball once, ran `shasum -a 256` on it, committed that value. The script never fetches an expected hash from the network anymore.
- Verification now fails closed: missing `shasum`, an empty/unreadable download, or a checksum mismatch all `exit 1`. The "skipping verification" fallback is gone.

**Pinned version:** `144.0.32+g5ce7d26+chromium-144.0.7559.258`
**SHA-256:** `cf923ad835fe7b1ae8cc358af8e97de1fd7ae29a5c328d8173260caf4a77d989`

As weak corroboration, the CEF index's independently-published SHA-1 for this build (`6e8af55af22631b15c717df301e0ad72b3820680`) matched the SHA-1 of the downloaded tarball.

## Test plan

- [x] **Fail-closed on checksum mismatch** — corrupted the pinned `CEF_SHA256` constant in a throwaway copy, ran the script against the real downloaded tarball: exits 1 with `ERROR: SHA-256 checksum mismatch!` and expected/actual values. Restored before committing.
- [x] **Fail-closed on missing/empty download** — pointed at a version with no matching file: `curl: (37) Couldn't open file` → `ERROR: Download failed...` → exit 1. Also exercised the empty-file branch directly: `ERROR: Downloaded file is missing or empty` → exit 1.
- [x] **Real success run** — ran the committed script end-to-end for real (no shortcuts): downloaded the ~300MB pinned tarball, verified `SHA-256 checksum verified: cf923ad835fe7b1ae8cc358af8e97de1fd7ae29a5c328d8173260caf4a77d989`, extracted to `vendor/cef/`, exit 0.
- [x] `grep -n 'skipping verification\|| true' scripts/download-cef.sh` — only remaining `|| true` is the unrelated quarantine-attribute removal (`xattr -d com.apple.quarantine ... || true`), outside the verification path.
- [x] Confirmed `vendor/cef/` is gitignored (`git check-ignore -v` → `.gitignore:32:vendor/cef/`) — no downloaded artifacts committed.

Scope: only `scripts/download-cef.sh` touched, per the security remediation plan (Wave A / A1). `.github/workflows/ghostties-release.yml` is a separate task.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BePT469FTDafR1BXSSVGtN