### PR TITLE
security: bump Sparkle 2.9.0 -> 2.9.4 (CVE-2026-47121, CVE-2026-47122)

### DIFF
--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -382,8 +382,8 @@ jobs:
       # re-verifying the hash against the new artifact.
       - name: Setup Sparkle CLI
         env:
-          SPARKLE_VERSION: "2.9.0"
-          SPARKLE_SHA256: "44a0d5a00d5bfb6c2ad1755a92b694d948876d61ad44f35a0119eb0e7ace4b65"
+          SPARKLE_VERSION: "2.9.4"
+          SPARKLE_SHA256: "cb6fdbdc8884f15d62a616e79face92b08322410fd2d425edc6596ccbf4ba3b0"
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle

--- a/macos/Ghostties.xcodeproj/project.pbxproj
+++ b/macos/Ghostties.xcodeproj/project.pbxproj
@@ -1568,7 +1568,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.1;
+				minimumVersion = 2.9.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/macos/Ghostties.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Ghostties.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
-        "version" : "2.9.0"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {


### PR DESCRIPTION
## What

Bumps the bundled Sparkle framework from 2.9.0 to 2.9.4 (latest in the 2.9 line).

**CVE-2026-47121 / CVE-2026-47122** affect Sparkle <=2.9.1. 2.9.2 fixes both: a symlink guard on delta-update apply, and connection validation on the privileged installer XPC service. `Package.resolved` pins an exact commit revision, so this repo would never pick up the fix automatically.

## Changes

- `Package.resolved`: revision `21d8df80` -> `b6496a74` (2.9.0 -> 2.9.4). Verified the new revision matches the `2.9.4` tag via `gh api repos/sparkle-project/Sparkle/git/refs/tags/2.9.4`.
- `project.pbxproj`: SPM requirement floor `2.5.1` -> `2.9.4`.
- `.github/workflows/ghostties-release.yml`: `SPARKLE_VERSION` `2.9.0` -> `2.9.4`. Also **recomputed `SPARKLE_SHA256`** for the new release zip (`shasum -a 256` on the downloaded `Sparkle-for-Swift-Package-Manager.zip`) -- an hour-old change on `main` pins and verifies that download against a hash computed for the 2.9.0 artifact, so bumping the version without recomputing the hash would fail the integrity check on every future release.

## Not touched

- Signing key: `SUPublicEDKey` is byte-identical to `main`. No key rotation.
- Appcast generation, channel handling, version auto-bump logic, feed URLs, update interval.
- Everything outside Sparkle (BACKLOG.md, docs, web, scripts).

## Verification

- `xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Release -derivedDataPath macos/build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES` -> `** BUILD SUCCEEDED **`, no Sparkle-related warnings.
- `build-for-testing` on the same scheme/config also succeeded (compile coverage of `GhosttyTests`). **Test execution was not run** -- `xcodebuild test` is known to hang app-hosted `GhosttyTests` in this repo (pre-existing, unrelated issue); do not read this PR as tests-passing.
- App was not launched, installed, or run.