### PR TITLE
fix(security): lock MCP source discovery to ~/.ghostties, sweep stale launcher scripts

### DIFF
--- a/cli/Sources/GhosttiesMCPClient/MCPSourceStore.swift
+++ b/cli/Sources/GhosttiesMCPClient/MCPSourceStore.swift
@@ -1,9 +1,14 @@
 import Foundation
 import GhosttiesCore
 
-/// Persists the list of configured MCP sources to `.ghostties/mcp-sources.json`.
-/// Discovery walks up from cwd the same way `TasksDirectory.find` does — the
-/// MCP sources config lives alongside `.ghostties/tasks/`.
+/// Persists the list of configured MCP sources to `~/.ghostties/mcp-sources.json`.
+///
+/// This is intentionally the user's home directory ONLY — never a project-relative
+/// path. MCP source definitions name a binary to spawn; if discovery walked up from
+/// cwd, opening any cloned repo containing a committed `.ghostties/mcp-sources.json`
+/// could point Ghostties at an arbitrary binary the repo author chose. Loading only
+/// from `~/.ghostties/` means a source must be something the user configured
+/// themselves, never something a repo can plant.
 ///
 /// Pretty-printed JSON with sorted keys so the file diffs cleanly in git.
 public struct MCPSourceStore {
@@ -18,20 +23,11 @@ public struct MCPSourceStore {
         self.fileURL = fileURL
     }
 
-    /// Discover the `.ghostties/` state directory by walking up from cwd and
-    /// point at `mcp-sources.json`. Falls back to `./.ghostties/mcp-sources.json`
-    /// in the current working directory if no ancestor contains one yet.
-    public static func discover(
-        startingAt cwd: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-    ) -> MCPSourceStore {
-        // Reuse TasksDirectory's walk-up: if a tasks dir exists, its parent is
-        // our state dir. Otherwise default to ./.ghostties/ in cwd so a first
-        // `save()` bootstraps the structure without scanning siblings.
-        if let tasksDir = TasksDirectory.find(startingAt: cwd) {
-            let stateDir = TasksDirectory.stateDirectory(from: tasksDir)
-            return MCPSourceStore(fileURL: stateDir.appendingPathComponent(filename))
-        }
-        let state = cwd.appendingPathComponent(".ghostties", isDirectory: true)
+    /// Point at `~/.ghostties/mcp-sources.json`. Never walks the project tree —
+    /// MCP sources are user-level configuration, not project-level.
+    public static func discover() -> MCPSourceStore {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let state = home.appendingPathComponent(".ghostties", isDirectory: true)
         return MCPSourceStore(fileURL: state.appendingPathComponent(filename))
     }
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -258,6 +258,13 @@ class AppDelegate: NSObject,
         // Store our start time
         applicationLaunchTime = ProcessInfo.processInfo.systemUptime
 
+        // Sweep stale per-session launcher scripts (>24h old) left behind by
+        // crashes or force-quits that skipped normal session teardown. Each
+        // script can carry session context, so they shouldn't accumulate.
+        DispatchQueue.global(qos: .utility).async {
+            SessionCoordinator.sweepStaleLauncherScripts()
+        }
+
         // Check if secure input was enabled when we last quit.
         if UserDefaults.ghostty.bool(forKey: "SecureInput") != SecureInput.shared.enabled {
             toggleSecureInput(self)

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -206,7 +206,7 @@ final class SessionCoordinator: ObservableObject {
             guard let cmd = resolvedCommand else { return nil }
             guard let banner = template.launchBanner else { return cmd }
 
-            let scriptDir = ("~/.ghostties/cache/launchers" as NSString).expandingTildeInPath
+            let scriptDir = Self.launcherScriptDir
             let fm = FileManager.default
             if !fm.fileExists(atPath: scriptDir) {
                 try? fm.createDirectory(atPath: scriptDir, withIntermediateDirectories: true, attributes: [
@@ -623,6 +623,7 @@ final class SessionCoordinator: ObservableObject {
         nameSyncSubscriptions.removeValue(forKey: id)
         setStatus(.killed, for: id)
         gcDraftIfPresent(for: id)
+        Self.removeLauncherScript(for: id)
 
         // If this was the active session, switch to another running session.
         if activeSessionId == id {
@@ -896,6 +897,48 @@ final class SessionCoordinator: ObservableObject {
         }
 
         return command
+    }
+
+    // MARK: - Launcher Script Lifecycle
+
+    /// `~/.ghostties/cache/launchers` — per-session wrapper scripts written by
+    /// `createSession`. Each one leaks its session's task context (banner text,
+    /// command line) to anything that can read the directory, so scripts must
+    /// not accumulate indefinitely.
+    nonisolated static var launcherScriptDir: String {
+        ("~/.ghostties/cache/launchers" as NSString).expandingTildeInPath
+    }
+
+    /// Delete a single session's launcher script at teardown. A no-op if the
+    /// session never got one (e.g. templates without a `launchBanner`).
+    nonisolated static func removeLauncherScript(for sessionId: UUID) {
+        let path = (launcherScriptDir as NSString).appendingPathComponent("\(sessionId.uuidString).sh")
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    /// Sweep `~/.ghostties/cache/launchers` on app launch for `*.sh` scripts
+    /// older than 24h, catching any left behind by a crash or force-quit that
+    /// skipped `closeSession`'s per-session cleanup. Scoped to exactly this
+    /// directory and this extension; does not follow symlinks out of it.
+    nonisolated static func sweepStaleLauncherScripts() {
+        let fm = FileManager.default
+        let dir = launcherScriptDir
+        guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { return }
+
+        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+        for name in entries {
+            guard name.hasSuffix(".sh") else { continue }
+            let path = (dir as NSString).appendingPathComponent(name)
+
+            // Use a symlink-aware stat so a planted symlink can't redirect the
+            // deletion (or the age check) outside this directory.
+            guard let attrs = try? fm.attributesOfItem(atPath: path),
+                  attrs[.type] as? FileAttributeType == .typeRegular,
+                  let modified = attrs[.modificationDate] as? Date,
+                  modified < cutoff else { continue }
+
+            try? fm.removeItem(atPath: path)
+        }
     }
 
     /// Find which session owns a given surface by searching all stored trees.


### PR DESCRIPTION
## C3 — MCP source discovery hijack

`MCPSourceStore.discover()` walked up from the current working directory the
same way `TasksDirectory.find` does, looking for a `.ghostties/` state dir.
That meant a **hostile repo scenario**: clone any public repo that ships a
committed `.ghostties/mcp-sources.json`, and Ghostties would happily load its
MCP source list — including a stdio transport `endpoint` naming an arbitrary
binary — and spawn it. Opening someone's project should never be able to run
their code.

Discovery now points at `~/.ghostties/mcp-sources.json` unconditionally, no
walk-up. A source can only come from something the user configured in their
own home directory.

**Deliberately not built:** the plan also calls for a trust-confirmation
dialog on first spawn, showing the binary path. That's a UI/UX decision Sean
wants to make himself — this PR is scoped to closing the discovery hole only.

## C4 — Launcher script lifecycle

Ghostties writes a per-session wrapper script to
`~/.ghostties/cache/launchers/<sessionUUID>.sh` on spawn (agent banner +
exec). Nothing ever deleted them, so they piled up indefinitely, each one
leaking that session's task banner/command line to anything able to read the
directory.

- `closeSession(id:)` now deletes that session's script at teardown.
- App launch sweeps `~/.ghostties/cache/launchers/*.sh` for files older than
  24h (catches scripts orphaned by a crash/force-quit that skipped normal
  teardown). Scoped to exactly that directory + glob; uses `attributesOfItem`
  (lstat-style, doesn't traverse symlinks) so a planted symlink can't redirect
  the sweep outside the directory.

## Build / test evidence

- `bash scripts/download-cef.sh` was needed (no `vendor/cef/` in this
  worktree) — SHA-256 checksum verification passed against the pinned value.
- `xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties
  -configuration Release -derivedDataPath macos/build ONLY_ACTIVE_ARCH=YES
  ARCHS=arm64 build` → `** BUILD SUCCEEDED **`
- `cd cli && swift test` → 110 tests, 0 failures (unfiltered)
- App-hosted `GhosttyTests`/`GhosttyUITests` were **not executed** (known
  hang under CLI test execution in this environment — Cmd+U in Xcode only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)