### PR TITLE
security: drop two hardened-runtime exceptions from shipping entitlements (C2)

### DIFF
--- a/macos/Ghostties.entitlements
+++ b/macos/Ghostties.entitlements
@@ -4,10 +4,6 @@
 <dict>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>


### PR DESCRIPTION
Closes C2 from the 2026-08-01 security review.

Removes `com.apple.security.cs.allow-unsigned-executable-memory` and
`com.apple.security.cs.disable-library-validation` from `macos/Ghostties.entitlements`.

## Why these were there

Both were added in `6244286` ("feat: CEF browser Phase 2"), copied from the **dev-build**
entitlements (`GhosttyDebug` / `GhosttyReleaseLocal`), where they are correct because
`scripts/embed-cef.sh` ad-hoc signs CEF for local builds. Upstream Ghostty's *shipping*
`Ghostty.entitlements` has neither. A dev-build accommodation ended up in the shipping file.

## Evidence (measured against the running beta.20 build, pid 52462, CEF initialized)

**`allow-unsigned-executable-memory` — unused.** Zero memory regions with *current*
protection `rwx`. V8/JIT runs in the renderer and GPU helpers, which carry `allow-jit` in
their own entitlement files and do not inherit from the parent. Chromium's own
`app-entitlements.plist` omits it too.

**`disable-library-validation` — unnecessary.** The only non-system Mach-O images mapped
into the main process are `Sparkle.framework` and `Chromium Embedded Framework.framework`.
Those two and the app itself are all `TeamIdentifier=5P7G79U672`; library validation already
permits same-team code.

## Re-sign verification

A copy of the shipped bundle was re-signed with the trimmed entitlements
(`--options runtime`, **no `--deep`**) using `Developer ID Application: Sean Smith (5P7G79U672)`:

- Both keys confirmed absent from the resulting signature.
- `codesign --verify`: *valid on disk*, *satisfies its Designated Requirement*; CEF and
  Sparkle frameworks both validated.
- Helpers retained `com.apple.security.cs.allow-jit` (verified on Renderer and GPU) —
  `--deep` was avoided precisely because it would have stripped them.

## Blast radius

CEF is `dlopen`'d lazily (`CEFBridge.mm`), reached only from
`SessionCoordinator.createBrowserSession()`. If library validation ever did reject it,
`LoadInMain()` returns false and the browser session refuses to open — terminal, sidebar,
sessions, and Sparkle updates are unaffected. **Launch is never at risk.**

`GhosttyDebug.entitlements`, `GhosttyReleaseLocal.entitlements`, and the per-helper
entitlement files are deliberately untouched. Only the Release build config references
`Ghostties.entitlements`.

## Remaining manual gate

Launch test of the re-signed copy (open a browser session, load a page, second tab, watch
Console for `[CEFBridge] Failed to load CEF framework.` / `Library Validation failed`).
It needs the running Ghostties quit first, since the test copy shares the bundle ID and
CEF profile directory.