### PR TITLE
fix(test): update stale UpdateViewModel notFound assertion

### DIFF
--- a/macos/Tests/Update/UpdateViewModelTests.swift
+++ b/macos/Tests/Update/UpdateViewModelTests.swift
@@ -60,8 +60,21 @@ struct UpdateViewModelTests {
 
     @Test func testNotFoundText() {
         let viewModel = UpdateViewModel()
-        viewModel.state = .notFound(.init(acknowledgement: {}))
-        #expect(viewModel.text == "No Updates Available")
+
+        viewModel.state = .notFound(.init(acknowledgement: {}, channelIsStable: true))
+        #expect(viewModel.text == "No stable releases yet")
+
+        viewModel.state = .notFound(.init(
+            acknowledgement: {},
+            channelIsStable: false,
+            displayVersion: "1.2.3"))
+        #expect(viewModel.text == "You're on the latest (v1.2.3)")
+
+        viewModel.state = .notFound(.init(
+            acknowledgement: {},
+            channelIsStable: false,
+            displayVersion: ""))
+        #expect(viewModel.text == "You're on the latest")
     }
 
     @Test func testErrorText() {


### PR DESCRIPTION
Unblocks the "full test suite green" gate before tagging beta.21.

## What was wrong

`UpdateViewModelTests.testNotFoundText()` asserts `viewModel.text == "No Updates Available"`.
That string no longer exists in the implementation. PR #34 (2026-06-19, "restore working
Sparkle auto-updates") replaced it with a two-branch string in `UpdateViewModel.text`:

```swift
case .notFound(let v):
    if v.channelIsStable {
        return "No stable releases yet"
    } else {
        let ver = v.displayVersion.isEmpty ? "" : " (v\(v.displayVersion))"
        return "You're on the latest\(ver)"
    }
```

The test was never updated. `git log` on the two files:

| File | Last changed |
| --- | --- |
| `UpdateViewModel.swift` (impl) | 2026-06-19 — #34 |
| `UpdateViewModelTests.swift` (test) | 2026-02-19 — a whitespace lint pass |

**It has been red through beta.18, beta.19, and beta.20.** This is not a beta.21 regression,
and it is unrelated to the Sparkle 2.9.4 bump in #63 — those strings are fork code, not Sparkle.

## What this changes

**The test only.** The shipped copy is untouched — that's a design decision, not a test's call.

The old assertion was also non-deterministic: `NotFound.displayVersion` defaults to the host
bundle's `CFBundleShortVersionString`, so any assertion reaching the beta branch would drift
with every release. All three cases now pass `displayVersion` explicitly, including the
empty-string case that drops the parenthetical.

## Evidence

Full app-hosted `GhosttyTests` suite, run locally against `origin/main` + this fix:

```
totalTestCount: 625
passedTests:    624
failedTests:    0
skippedTests:   1     (BenchmarkTests/example(), a deliberate placeholder)
```

Before the fix, same tree, same command: `Failing tests: UpdateViewModelTests.testNotFoundText()` → `** TEST FAILED **`.

## Worth a separate look

CI cannot catch this class of failure. The macOS job runs `build-for-testing`, not `test`
(the host app hangs on headless runners — see #47), so app-hosted *execution* is local-Cmd+U-only.
That gate went unenforced for three releases. Re-enabling execution on CI needs the
host-independent test classes moved into a non-app-hosted logic bundle. Not in scope here.