### PR TITLE
docs: stack fork copyright, add third-party notices, ship them in the app

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2026 Sean Smith
 Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,314 @@
+# Third-Party Notices
+
+Ghostties is a fork of [Ghostty](https://github.com/ghostty-org/ghostty) and is
+built on software written by other people. This file reproduces the license and
+copyright notices for that software.
+
+Ghostties' own license is in [LICENSE](LICENSE).
+
+**Shipped in the application bundle:** Ghostty, Chromium Embedded Framework,
+Sparkle. **Build and source dependencies only** (not redistributed in the
+`.app`): nerd-fonts `font-patcher`, swift-argument-parser.
+
+---
+
+## Ghostty
+
+Ghostties is a derivative work of Ghostty by Mitchell Hashimoto and the Ghostty
+contributors. The terminal emulator, renderer, font stack, and the great
+majority of this repository's source are Ghostty's work. Ghostties adds a
+multi-agent workspace sidebar on top of it.
+
+- Upstream: https://github.com/ghostty-org/ghostty
+- License: MIT
+
+```
+MIT License
+
+Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## Chromium Embedded Framework (CEF)
+
+Used for the embedded browser panel. Shipped in the application bundle as
+`Contents/Frameworks/Chromium Embedded Framework.framework` and the five
+`Ghostties Helper` executables.
+
+- Project: https://bitbucket.org/chromiumembedded/cef
+- Version: `144.0.32+g5ce7d26+chromium-144.0.7559.258`
+- License: BSD 3-Clause
+
+```
+Copyright (c) 2008-2020 Marshall A. Greenblatt. Portions Copyright (c)
+2006-2009 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the name Chromium Embedded
+Framework nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+CEF embeds Chromium, which carries additional third-party licenses beyond the
+CEF notice above. The complete Chromium credits for a given build are published
+by the Chromium project at <https://chromium.googlesource.com/chromium/src/+/main/LICENSE>
+and, in Chrome, at `chrome://credits`.
+
+---
+
+## Sparkle
+
+Used for application updates. Shipped in the application bundle as
+`Contents/Frameworks/Sparkle.framework`.
+
+- Project: https://github.com/sparkle-project/Sparkle
+- Version: `2.9.4`
+- License: MIT, plus the external licenses reproduced below
+
+```
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions 
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+--
+
+sais.c and sais.h, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:
+
+The sais-lite copyright is as follows:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+--
+
+Portable C implementation of Ed25519, from https://github.com/orlp/ed25519
+
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the
+authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial
+applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the
+   original software. If you use this software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+   being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+--
+
+SUSignatureVerifier.m:
+
+Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted providing that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## nerd-fonts (`font-patcher`)
+
+A copy of `font-patcher` lives at `vendor/nerd-fonts/font-patcher.py`. It is
+parsed at build time to generate a lookup table of nerd font scaling rules
+(`src/font/nerd_font_codegen.py`). It is **not** shipped in the application
+bundle, and no nerd-fonts font files are vendored or redistributed.
+
+The nerd-fonts project uses several licenses: its fonts are under the SIL Open
+Font License 1.1, while its source files — including `font-patcher` — are MIT.
+Only the MIT-licensed source file is used here, so only the MIT text applies.
+
+- Project: https://github.com/ryanoasis/nerd-fonts
+- Fetched at commit: `ebc376cbd43f609d8084f47dd348646595ce066e`
+- License: MIT (see `vendor/nerd-fonts/LICENSE` for the project's full
+  multi-license breakdown)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2014 Ryan L McIntyre
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## swift-argument-parser
+
+Used by the `gt` command-line tool in `cli/`. It is not linked into the macOS
+application and is not present in the shipped `.app` bundle.
+
+- Project: https://github.com/apple/swift-argument-parser
+- Version: `1.7.1`
+- License: Apache License 2.0 — full text at
+  <https://github.com/apple/swift-argument-parser/blob/main/LICENSE.txt>
+
+```
+Copyright 2020 Apple Inc. and the Swift project authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/macos/Ghostties.xcodeproj/project.pbxproj
+++ b/macos/Ghostties.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		AA1BFC302B30F1B800E92F16 /* GhosttiesMCPClient in Frameworks */ = {isa = PBXBuildFile; productRef = AA1BFC312B30F1B800E92F16 /* GhosttiesMCPClient */; };
 		AA1BFC322B30F1B800E92F16 /* GhosttiesCore in Frameworks */ = {isa = PBXBuildFile; productRef = AA1BFC332B30F1B800E92F16 /* GhosttiesCore */; };
 		B0A55ABE2F72F4C100018CBF /* debugger.md in Resources */ = {isa = PBXBuildFile; fileRef = B0A55AB92F72F4C100018CBF /* debugger.md */; };
+		B0E55A912F80000000000091 /* THIRD-PARTY-NOTICES.md in Resources */ = {isa = PBXBuildFile; fileRef = B0E55A902F80000000000090 /* THIRD-PARTY-NOTICES.md */; };
 		B0A55ABF2F72F4C100018CBF /* code-reviewer.md in Resources */ = {isa = PBXBuildFile; fileRef = B0A55AB82F72F4C100018CBF /* code-reviewer.md */; };
 		B0A55AC02F72F4C100018CBF /* test-writer.md in Resources */ = {isa = PBXBuildFile; fileRef = B0A55ABC2F72F4C100018CBF /* test-writer.md */; };
 		B0A55AC12F72F4C100018CBF /* architect.md in Resources */ = {isa = PBXBuildFile; fileRef = B0A55AB72F72F4C100018CBF /* architect.md */; };
@@ -101,6 +102,7 @@
 		B0A55AB72F72F4C100018CBF /* architect.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = architect.md; sourceTree = "<group>"; };
 		B0A55AB82F72F4C100018CBF /* code-reviewer.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "code-reviewer.md"; sourceTree = "<group>"; };
 		B0A55AB92F72F4C100018CBF /* debugger.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = debugger.md; sourceTree = "<group>"; };
+		B0E55A902F80000000000090 /* THIRD-PARTY-NOTICES.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "THIRD-PARTY-NOTICES.md"; path = "../THIRD-PARTY-NOTICES.md"; sourceTree = "<group>"; };
 		B0A55ABA2F72F4C100018CBF /* orchestrator.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = orchestrator.md; sourceTree = "<group>"; };
 		B0A55ABB2F72F4C100018CBF /* pair-programmer.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "pair-programmer.md"; sourceTree = "<group>"; };
 		B0A55ABC2F72F4C100018CBF /* test-writer.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "test-writer.md"; sourceTree = "<group>"; };
@@ -337,6 +339,7 @@
 		A5A1F8862A489D7400D1E8BC /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				B0E55A902F80000000000090 /* THIRD-PARTY-NOTICES.md */,
 				B0A55ABD2F72F4C100018CBF /* Presets */,
 				B0E55A012F80000000000001 /* presets */,
 				FC9ABA9B2D0F538D0020D4C8 /* bash-completion */,
@@ -609,6 +612,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B0E55A912F80000000000091 /* THIRD-PARTY-NOTICES.md in Resources */,
 				FC9ABA9C2D0F53F80020D4C8 /* bash-completion in Resources */,
 				29C15B1D2CDC3B2900520DD4 /* bat in Resources */,
 				B0A55ABE2F72F4C100018CBF /* debugger.md in Resources */,


### PR DESCRIPTION
Ghostties ships two pieces of other people's software inside the `.app` — the Chromium Embedded Framework and Sparkle — and carried no third-party notice anywhere: not in the repo, not in the bundle, not in the DMG. CEF's BSD-3 clause 2 requires its copyright notice be reproduced "in the documentation and/or other materials provided with the distribution." That made this the one genuine legal gap in the repo rather than a tidiness item.

## LICENSE

Stacks Sean Smith's copyright above Mitchell Hashimoto's under the same MIT grant — the conventional form for an MIT fork. Previously the file credited only upstream, which implied the fork's own work was Ghostty's.

## THIRD-PARTY-NOTICES.md

Reproduces license and copyright notices for everything Ghostties builds on.

**Shipped in the app bundle:**

| Component | Version | License |
|---|---|---|
| Ghostty (upstream source) | — | MIT |
| Chromium Embedded Framework | `144.0.32+g5ce7d26+chromium-144.0.7559.258` | BSD 3-Clause |
| Sparkle | `2.9.4` | MIT + 4 bundled external licenses |

**Build/source only, not redistributed in the `.app`:** nerd-fonts `font-patcher` (MIT), swift-argument-parser `1.7.1` (Apache-2.0).

Three things turned out differently than planned:

- **nerd-fonts is MIT here, not OFL.** What's vendored is `font-patcher.py` — a source file, which nerd-fonts explicitly licenses MIT. The OFL covers that project's *fonts*, and none are vendored or redistributed.
- **swift-argument-parser was missing from the list entirely.** It's Apache-2.0, reachable through `cli/`. It is not linked into the macOS app and is not in the shipped bundle, so it's documented as a source dependency.
- **Sparkle's LICENSE bundles four more licenses** — bsdiff, sais-lite, ed25519, and SUSignatureVerifier. A bare "Sparkle — MIT" line would have silently dropped all four. The full text is reproduced.

The CEF and Sparkle bodies were assembled directly from the license files on disk and then diffed byte-for-byte against those sources rather than retyped, because transcription errors in license text are the failure mode that matters here.

Where a notice is genuinely incomplete, it says so: CEF embeds Chromium, which carries further third-party licenses beyond CEF's own notice, and the file points at Chromium's credits rather than pretending to be exhaustive.

## Getting it into the shipped app

Adds `THIRD-PARTY-NOTICES.md` to the Ghostties target's Resources build phase, using the same wiring the `macos/Presets/*.md` files already use. The file reference points at the repo-root copy via `../` instead of duplicating it, so there's a single source of truth for the license text.

**Verified by building**, not assumed:

```
** BUILD SUCCEEDED **   (0 errors)

Ghostties Dev.app/Contents/Resources/THIRD-PARTY-NOTICES.md   13.1K, 314 lines
diff vs repo copy: IDENTICAL
```

## Not included

The README still says `Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors` in its License section, which now disagrees with LICENSE. That's a README edit and belongs with the README rewrite rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01538wgu5rLs9C1XmP186do6
