### PR TITLE
fix: shrink hero pyramid ghosts to 72px

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -67,8 +67,8 @@
     }
 
     .ghost {
-      width: 100px;
-      height: 100px;
+      width: 72px;
+      height: 72px;
       opacity: 0;
     }
 


### PR DESCRIPTION
## Summary
- Hero pyramid ghosts (`.ghost`) shrunk from 100px to 72px — reduces visual weight of the 8-ghost stack at the top of the homepage.
- Ambient background ghosts (`.bg-ghost`, 24px/0.10 opacity) are untouched.
- 72px is a first pass and trivially dialable if it needs further adjustment.

## Test plan
- [x] `git diff` confirmed as a 2-line change to a single CSS rule
- [x] Verified `.bg-ghost` untouched at 24px/0.10
- [x] Served locally, captured screenshots at 1440x900 and 375x812 after 9s (past the ~3.8s entrance animation)
- [x] Confirmed all 8 ghosts present in correct 1-2-3-2 pyramid, no clipping/overlap
- [x] Measured `.ghosts` container: 1440px viewport = 1328x336px; 375px viewport = 303x286px (fits within viewport with margin)

Screenshots were captured locally but couldn't be embedded here (image upload tooling unavailable in this session). See session output for local file paths if you want to view them before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)