### PR TITLE
docs: record the information architecture and how it was arrived at

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ shipped, or tested here.
 See [TESTING.md](TESTING.md) for what each suite covers and the two xcodebuild
 flags you need from the command line.
 
+Editing docs? [docs/INFORMATION-ARCHITECTURE.md](docs/INFORMATION-ARCHITECTURE.md)
+says who each file is for and how each one is meant to stay true. Do not add a new
+document without answering the questions in it.
+
 ## Directory structure
 
 - `src/` — shared Zig core (upstream's terminal)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,18 @@ Parked items that survive context resets. Prune at `/wrap`.
 
 > Reconciled 2026-07-29: the tracked `main` copy (07-17→07-22) and the untracked working-tree copy (07-26→07-28) had diverged. This file is the union. Only closed items were dropped (PR #48 merged as `3d2cefc57`).
 
+## 2026-08-02 — documentation IA + case study
+
+Objective (locked): repo documentation + correct Ghostty-vs-Ghostties calibration. All five refresh waves are merged to `main`; this wave adds the design layer that was missing.
+
+- [ ] **PR #80 — `docs/INFORMATION-ARCHITECTURE.md` + `docs/case-study-documentation-refresh.md`.** Open, MERGEABLE, CI green 4/4. Records the IA the refresh produced (audience model, the disambiguation-not-topic-tree principle, decay model per file, five questions before adding a doc) and the narrative of how it was arrived at, including that it was emergent rather than designed up front. Entry points added in `CONTRIBUTING.md` for humans and `AGENTS.md` for agents. | docs | ready-to-merge
+- [ ] **Should the case-study visuals live in the repo? — STRAWMAN: no, kill it.** GitHub markdown cannot render the CSS/SVG figures, so putting them in the repo means exporting PNGs. Images cannot be diffed, so they would go stale silently and break the decay-model rule the IA doc itself sets. Recommendation: repo docs stay textual; the visual version stays an Artifact for job and portfolio use. Only revisit if the repo docs are meant to carry imagery. | docs | decide-or-kill
+- [ ] **Visual case study lives only as an Artifact.** `https://claude.ai/code/artifact/8bda1349-3010-4780-bee8-88ffe72e5c0c` — six figures (inherited-scale receipt, the auto-close trap, the routing fork, six entry points, the 3.8:1 deletion bar, CONTRIBUTING before/after) plus the inlined demo GIF. Private to Sean's account; it is not backed up in the repo and would need rebuilding from `docs/case-study-documentation-refresh.md` if lost. | docs | reference
+
+**Off-objective, parked deliberately:**
+
+- [ ] **Idea-log prune** — 10 of 31 captures in `tease-capture.md` are older than 30 days and unacted-on, which is that file's own documented prune threshold (1 from May, 9 from June). Surfaced at `/wrap` 2026-08-02, nothing deleted. Spans projects, so it is not this thread's objective. | ops | needs-Sean
+
 ## 2026-08-01 — ghostties.org docs section (parked)
 
 - [ ] **ghostties.org — high-level docs section (P3).** Add a docs overview page to the marketing site with high-level concepts, linking to the GitHub repo for depth. Blocked on the repo-documentation work happening in a separate thread — needs the real doc URLs to land first so the links aren't dead. | web | needs-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ issue and I'll credit you when it ships.
 Documentation corrections are the exception — if something here is wrong or out of
 date, a small PR is welcome.
 
+If you're adding a document rather than fixing one,
+[docs/INFORMATION-ARCHITECTURE.md](docs/INFORMATION-ARCHITECTURE.md) explains how
+these files are organized and the questions to answer before adding another.
+
 ## Filing a good issue
 
 - Which version you're on (About Ghostties in the menu bar, or `gt --version`) and

--- a/docs/INFORMATION-ARCHITECTURE.md
+++ b/docs/INFORMATION-ARCHITECTURE.md
@@ -1,0 +1,99 @@
+# Information architecture
+
+How the documentation in this repository is organized, who each piece is for, and the rules for adding to it.
+
+This is written for anyone maintaining these docs, including future me and any coding agent working in this repo. It exists because the last set of docs rotted silently: they were inherited from upstream and stayed wrong for months, because nothing recorded what they were supposed to do.
+
+A note on honesty: this architecture was not designed up front. It emerged from an audit, and this document was written afterward to make it explicit and therefore maintainable. Writing it down is what turns a set of choices into something that can be checked.
+
+## The problem this structure solves
+
+Ghostties is a fork of [Ghostty](https://github.com/ghostty-org/ghostty). Nearly all of the source is upstream's work. The sidebar, the `gt` CLI, and the MCP server are the fork's.
+
+That means almost every visitor arrives with a question that has to be routed before it can be answered: **is this a Ghostty thing or a Ghostties thing?** Get it wrong and a bug report lands with maintainers who never shipped the software, or a fix that would help every Ghostty user gets buried in a fork.
+
+So the organizing principle here is not a topic tree. It is a disambiguation.
+
+## Who arrives, and what they need
+
+| Reader | Arrives at | Needs to know | Served by |
+|---|---|---|---|
+| Someone deciding whether to care | README | What it is, what it looks like, whether it runs on their machine | `README.md` |
+| Someone with a problem | Issues, README | Whether this is the right repo, and how to describe it usefully | Issue forms, `CONTRIBUTING.md` |
+| Someone who wants to help | CONTRIBUTING | Whether code contributions are wanted, and what to do instead | `CONTRIBUTING.md` |
+| Someone building from source | HACKING | How to get it compiling | `HACKING.md`, `TESTING.md` |
+| A security researcher | SECURITY | Where to send it privately, and what is in scope | `SECURITY.md` |
+| Someone checking licensing | LICENSE | Who owns what, and what is bundled | `LICENSE`, `THIRD-PARTY-NOTICES.md` |
+| A coding agent | AGENTS.md | The commands that work here, and the rules it must not break | `AGENTS.md` |
+
+One document per reader, not one document per topic. A document that serves two readers well is rare. A document that claims to serve two readers usually serves neither.
+
+The last row is the one people miss. `AGENTS.md` has a non-human audience, and it is read as instructions rather than as reference. That makes accuracy in it more load-bearing than in prose a person would skim: an agent will act on a stale command without noticing it is stale.
+
+## Wayfinding is repeated, not centralized
+
+The Ghostty-or-Ghostties question is answered at **six** entry points:
+
+1. `README.md`, in its own section
+2. `CONTRIBUTING.md`, as the first heading after the intro
+3. `SECURITY.md`, as an explicit in-scope and out-of-scope split
+4. The bug report form, before the first field
+5. The feature request form, before the first field
+6. `.github/ISSUE_TEMPLATE/config.yml`, as a link out to upstream
+
+That repetition is deliberate. People do not arrive at the front door and walk inward. They arrive from a search result, a link, or the New Issue button. A single canonical page explaining the boundary would be correct and unread.
+
+The tradeoff is real: six copies of an idea is six places to update when it changes. The rule that keeps it manageable is that only the *boundary* is repeated, never the detail. Each copy is one or two sentences and a link.
+
+## Disclosure is keyed to commitment, not to complexity
+
+The ladder runs: README, then CONTRIBUTING, then TESTING and HACKING.
+
+The ordering is by how much of their time the reader is about to spend, not by how advanced the material is. This is why "code pull requests are not being accepted" appears in CONTRIBUTING rather than lower down in HACKING. Someone deciding whether to write a patch needs it before they build, not after.
+
+Put the discouraging thing early. A reader who bounces at the top of the funnel lost a minute. A reader who finds out at the bottom lost a weekend.
+
+## Every document declares how it decays
+
+Documentation goes wrong when nobody knows which parts are supposed to be true. Each file here has one of three decay models.
+
+**Generated.** `THIRD-PARTY-NOTICES.md` is assembled from the licence files on disk and diffed against them, never retyped. When a dependency version changes, the file is regenerated, not edited. Legal text is the clearest case where hand-copying is a defect.
+
+**Measured.** `TESTING.md` states test counts and timings from actual runs. Those numbers go stale by design, which is why the file says to read the count from the run rather than trusting the number printed in it.
+
+**Inherited and frozen.** `HACKING.md` is upstream's build documentation and stays that way, because Ghostties does not modify the build system, the Zig core, or the renderer. Rewriting it would mean maintaining a worse copy of a correct document. Only its header is ours, and that header's job is to mark which sections describe platforms this fork does not ship.
+
+If you cannot say which of the three a new document is, it is not ready to add.
+
+## Deletion is most of the work
+
+The refresh that produced this structure changed 39 files: **1,340 lines added, 5,028 removed.** Close to four lines deleted for every one written, and a fifth of what was added was the plan describing the deletions.
+
+The failure mode was not missing documentation. It was confidently wrong documentation: a `CODEOWNERS` file assigning review of this fork's source to 39 upstream teams, a vouching system that auto-closed issues from anyone not on a 233-person list belonging to another project, and contributor guides written in another maintainer's voice about another maintainer's rules.
+
+Wrong signposts are worse than no signposts. Someone lost will ask. Someone confidently misdirected will not.
+
+When auditing these docs, the first question is which files are lying, not which files are missing.
+
+## Adding a document
+
+Before adding one, answer these. If any answer is weak, the content probably belongs in an existing file.
+
+1. **Which reader?** Name one from the table above, or add a row and justify it.
+2. **What question does it answer** that no current document answers?
+3. **Which decay model?** Generated, measured, or inherited.
+4. **Where is it linked from?** An unlinked document does not exist. It needs an entry point on the path its reader is already walking.
+5. **What does it say about the upstream boundary,** if a reader could plausibly be in the wrong repo?
+
+## What this repository deliberately does not have
+
+- **User-facing product documentation.** Terminal configuration lives at [ghostty.org/docs](https://ghostty.org/docs) and applies unchanged. Restating it here would create a second source of truth that drifts.
+- **API or architecture reference.** The fork's internals change too fast for prose to keep up, and the code is the reference. `AGENTS.md` carries the map, not the detail.
+- **A changelog per document.** Git carries that.
+- **Tutorials.** There is no getting-started path beyond install, because the product is a terminal and the audience already has one.
+
+## Keeping this file true
+
+This document describes the other documents. That makes it the fastest one to rot, and the least likely to be noticed when it does.
+
+It should be revisited whenever a document is added or removed, whenever the upstream boundary shifts, or whenever a reader turns out to arrive somewhere the table above does not predict. That last one is the strongest signal available and the easiest to ignore: if people keep filing terminal bugs here, the wayfinding is not working, regardless of how correct it looks on the page.

--- a/docs/case-study-documentation-refresh.md
+++ b/docs/case-study-documentation-refresh.md
@@ -1,0 +1,93 @@
+# Case study: rebuilding this repo's documentation
+
+A record of how the documentation in this repository was audited, redesigned, and shipped, and what it got wrong along the way.
+
+The structure it produced is described in [INFORMATION-ARCHITECTURE.md](INFORMATION-ARCHITECTURE.md). The original plan, written before any of it shipped, is at [plans/repo-documentation-refresh.html](plans/repo-documentation-refresh.html). This document is the narrative: what the problem turned out to be, which calls were made, and which are still unproven.
+
+## The situation
+
+Ghostties is a fork of [Ghostty](https://github.com/ghostty-org/ghostty), a well-known terminal emulator. The fork adds a workspace sidebar for running several AI agents at once. Nearly all of the source is upstream's.
+
+By August 2026 it had 38 stars and was getting inbound attention. Issues were still switched off, because turning them on felt premature. The brief was simple: make the repository presentable, and get the Ghostty-versus-Ghostties relationship stated correctly, without over- or under-claiming.
+
+The expectation was a README rewrite and a few missing files.
+
+## What the audit actually found
+
+The docs were the smaller half of the problem.
+
+A fork inherits everything, including the parts that describe the original project's community rather than its code. Those parts had never been pruned. They were not stale in the ordinary sense. They were **actively wrong and still running**:
+
+- **`CODEOWNERS`** assigned 67 review rules over this fork's source to **39 `@ghostty-org` teams**. None of them could review anything here. It generated review requests that could never be satisfied.
+- **`.github/VOUCHED.td`** published the names of **233 individuals** from the upstream project, in a repository they had no involvement with.
+- **Five vouching workflows**, two of which **auto-close issues and pull requests** from anyone not on that 233-person list, posting a message linking to another project's contributor guide.
+- **`CONTRIBUTING.md`, `PACKAGING.md`, `AI_POLICY.md`** were upstream verbatim: another maintainer's voice, another project's rules, routing people to a discussion category that does not exist here.
+- **Eight dead pipelines** building artifacts for distribution channels this fork does not ship to.
+
+The affiliation problem everyone worries about in a fork is usually a README wording question. Here it was structural repository data. The repo was not overclaiming in prose. It was overclaiming in configuration, which is worse, because configuration executes.
+
+The sharpest instance: **enabling Issues would have fired the auto-close workflow on the first issue anyone filed.** `issues`-triggered workflows run from the default branch, so the workflow was armed on `main` regardless of what any branch said. The single most important finding of a documentation audit turned out to be a sequencing constraint: purge the governance apparatus, *then* open the front door.
+
+## The design calls
+
+**Route on the boundary, everywhere.** The organizing principle is a disambiguation, not a topic tree: is this a Ghostty problem or a Ghostties problem? That question is answered at six entry points rather than one canonical page, because people arrive from search results and the New Issue button, not the front door. The cost is six places to update. The rule that keeps it cheap is that only the boundary is repeated, never the detail.
+
+**One reader per document.** README for someone deciding whether to care. CONTRIBUTING for someone about to spend time. TESTING and HACKING for someone building. SECURITY for a researcher. `AGENTS.md` for a coding agent, which is a non-human reader that acts on instructions rather than skimming them.
+
+**Disclose by commitment, not complexity.** "Code pull requests are not being accepted" belongs in CONTRIBUTING, not deep in HACKING. Someone deciding whether to write a patch needs that before they build. A reader who bounces early loses a minute. A reader who finds out late loses a weekend.
+
+**Say no clearly.** This is a personal project with no capacity to review outside code. The choice was between an honest posture and a polite one that leaves pull requests rotting for months. CONTRIBUTING states it in the second section, gives the actual reason, exempts documentation fixes, and asks for issues instead.
+
+**Give every document a decay model.** Generated (third-party notices, assembled from licence files on disk by script and diffed against them), measured (test counts, from real runs, with an instruction to re-measure rather than trust the printed number), or inherited and frozen (HACKING, which is upstream's and correct, so rewriting it would mean maintaining a worse copy).
+
+**Delete first.** 39 files changed: 1,340 lines added, 5,028 removed. Wrong signposts are worse than missing ones, because someone lost will ask and someone confidently misdirected will not.
+
+## What shipped
+
+Five pull requests, merged in a required order.
+
+| PR | What | Why the order mattered |
+|---|---|---|
+| #71 | Governance purge, 19 files, 4,524 deletions | Had to precede enabling Issues |
+| #74 | CONTRIBUTING rewrite, SECURITY, CODE_OF_CONDUCT, TESTING, YAML issue forms | Had to precede #76 |
+| #76 | Deleted PACKAGING and AI_POLICY, rewrote AGENTS.md, fixed HACKING header | Depended on #74 removing links to AI_POLICY |
+| #73 | LICENSE stacked copyright, THIRD-PARTY-NOTICES, notice shipped in the app | Independent |
+| #75 | README rewrite | Independent |
+
+CONTRIBUTING went from 195 lines to 60. The README went to 68 lines with a product shot and an inline demo.
+
+## Three things the plan had wrong
+
+Worth recording, because they are the kind of error a plan produces and only contact with the files catches.
+
+**The licence list was wrong in three places.** The plan said nerd-fonts was OFL; what is actually vendored is a source file that nerd-fonts explicitly licenses MIT, and no fonts are vendored at all. swift-argument-parser, which is Apache-2.0, was missing from the plan entirely. And Sparkle's licence file bundles four further licences inside it that a line reading "Sparkle, MIT" would silently drop.
+
+**A notice in the repository is not a notice in the product.** The plan treated the licensing gap as a file to write. The actual obligation, under CEF's BSD-3 clause 2, is that the notice reaches a binary redistribution. The shipped `.app` contained no licence file anywhere, and the DMG is assembled from the `.app` alone, so the app bundle was the only route to a person who installs it. Fixing this meant an Xcode resource change, not a documentation change.
+
+**The README needed a second pass for voice.** The first draft was accurate and structurally right, and read like documentation written by committee. It contained 19 em dashes, which the voice standard bans outright. Splitting those clauses into sentences was most of the fix. Same length, same structure, different register.
+
+## How it was checked
+
+Claims in documentation are worth what the verification behind them is worth.
+
+- Licence bodies were assembled by script from the files on disk, then diffed byte for byte against those sources. Legal text is the clearest case where retyping is a defect.
+- The in-app notice was confirmed by building the app and inspecting the bundle, not by reasoning that the build phase should work.
+- Test counts in TESTING.md came from running both suites: 110 in the Swift package, 673 across 52 suites in the app. The previously recorded figure was 625, so the number had drifted.
+- The six-entry-point claim in the architecture doc was checked by grepping all six files.
+- Every deletion was checked for inbound references before it was made.
+
+## What is still unproven
+
+**The wayfinding has never met a real user.** Issues is still switched off. Every routing decision here is a hypothesis: that people will read the boundary statement, that the dropdown will catch misfiled bugs, that the upstream link will be taken. The first month of real issues is the test, and the honest measure of success is how many terminal bugs still land in this repo.
+
+**Six copies of the boundary is a maintenance bet.** It is correct today. Whether it survives the next change to the fork's scope is unknown.
+
+**`blank_issues_enabled` was left `true`, against the plan.** The plan called for forcing everyone through a form. Leaving the blank option open trades some structure for not turning away someone who fits neither template. If untemplated issues become noise, that flips.
+
+**The hardest problem was not solved, only stated.** A fork's documentation has to explain a relationship, not just a product. Every reader has to be told what is not ours before they can be helped. No amount of structure makes that free.
+
+## The honest note
+
+This architecture was not designed up front from an audience model. It came out of an audit, decision by decision, and the architecture document was written afterward to make the implicit structure explicit and therefore checkable.
+
+That order is worth admitting, because the alternative reading, that a clean structure was derived from first principles, would be a nicer story and a false one. The useful part is the writing-down. A set of choices nobody recorded is what produced the inherited mess in the first place.


### PR DESCRIPTION
The documentation refresh (#71, #73, #74, #75, #76) shipped a structure but never wrote down what that structure *is*, who each file is for, or how it's supposed to stay true.

That gap is exactly what produced the mess it replaced. The inherited upstream docs were wrong for months because nothing recorded what they were meant to do, so nobody could tell they had stopped doing it.

## `docs/INFORMATION-ARCHITECTURE.md`

Makes the structure explicit and checkable.

- **The organizing principle is a disambiguation, not a topic tree.** Almost every visitor arrives needing to know whether their problem is Ghostty's or Ghostties' before it can be answered at all. That question, not a subject hierarchy, is what the docs are arranged around.
- **One reader per document.** Including `AGENTS.md`, whose reader is non-human and *acts* on instructions rather than skimming them, which makes staleness there more dangerous than in prose.
- **Wayfinding is repeated at six entry points**, not centralized on one canonical page, because people arrive from search results and the New Issue button rather than the front door. The tradeoff is stated rather than hidden: six copies is six things to update, so only the *boundary* repeats, never the detail.
- **Disclosure keyed to commitment, not complexity.** This is why "code PRs aren't being accepted" is in CONTRIBUTING and not deeper in HACKING. Bounce early and you lose a minute; find out late and you lose a weekend.
- **Every file declares a decay model** — generated, measured, or inherited-and-frozen. If you can't say which one a new document is, it isn't ready to add.
- **Five questions to answer before adding a document at all.**

## `docs/case-study-documentation-refresh.md`

The narrative: what the audit found, which calls were made and why, three things the plan had wrong, how claims were verified, and what's still unproven.

Two things it says that are worth flagging because they're unflattering:

**The architecture was not designed up front.** It emerged from the audit, decision by decision, and was written down afterward. The alternative telling, that a clean structure was derived from an audience model, would be a nicer story and a false one. The useful part is the writing-down, since a set of choices nobody recorded is what created the inherited mess to begin with.

**None of the routing has met a real user.** Issues is still switched off. Every wayfinding decision in here is a hypothesis, and the honest measure of success is how many terminal bugs still land in this repo once the door opens.

## Numbers were recomputed, not reused

The plan's figures were Wave 1's. The real totals across all five waves are **39 files, 1,340 insertions, 5,028 deletions** — close to four lines deleted per line written. CONTRIBUTING went 195 → 60. The six-entry-point claim was verified by grepping all six files rather than asserted.

## Both documents get an entry point

Per their own rule that an unlinked document does not exist:

- `CONTRIBUTING.md` points contributors at the architecture before they add a file
- `AGENTS.md` points coding agents at it before they do

No content changes to any existing doc beyond those two links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01538wgu5rLs9C1XmP186do6
