### PR TITLE
fix(web): ghostties.org accessibility, responsive, and hardening audit remediation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -73,6 +73,8 @@ were squash-merged; PR state is the only reliable signal.
 
 Full design/technical audit of the live site. Scores: **Design 15/40 Nielsen, Technical 5/20 — "Critical" band.** Six mechanical bugs found in this same audit (changelog 404, missing custom 404 page, dead X link, robots/sitemap, 1.5 MB orphaned assets, asset cache policy) already shipped in PR #77 and are deliberately absent below.
 
+**Most of this section is addressed in PR #86 (`fix/web-audit-remediation`, open, not yet merged — do not read "fixed" below as "on main").** Verified against `git diff origin/main -- web/`. New findings the remediation work surfaced are logged in a subsection at the end.
+
 ### Structural — SHIPPED to main 2026-08-02 (PR #81, `cff9bc345`)
 - ~~**`web/` has no design system.**~~ **Shipped.** `web/style.css` (tokens +
   reset + base elements + shared components + footer) and `web/DESIGN.md` (the
@@ -101,57 +103,65 @@ Full design/technical audit of the live site. Scores: **Design 15/40 Nielsen, Te
   gotcha that `var()` is silently ignored for `animation-timing-function`
   inside `@keyframes`. | web | project
 
-### Accessibility — scored 1/4
-- **`prefers-reduced-motion` is ~19% honored.** Only rule is `.bg-ghost { animation: none }` at `index.html:410`. Measured under `reduce`: 26 animations on the page, **17 still running, 8 still infinite** (`float-g0`…`float-g7`), plus the full ~10s entrance and typewriter sequence.
-- **Contrast failures, all computed and all failing WCAG AA:** 2.27:1 `rgba(255,255,255,0.25)` footer text and links on **every page** (worst value on the site); 2.70:1 changelog `<h4>` section labels; 3.03:1 `#666` on flows lane names; 3.21:1 `.back` link; 3.22:1 homepage `.line-3`; 3.78:1 `.download-meta` / `.all-releases`; 4.27–4.43:1 download/changelog body note. Raising the white-alpha floor to `0.55` yields 5.96:1. Note `#C97350` captions **pass** at 4.92:1 — not a finding.
-- No `<h1>` on `index.html`; no `<main>` landmark on any of the 7 pages; no skip link.
-- `changelog.html` skips heading levels H1 → H3, six times.
-- The ghost-scatter interaction is mouse-only — `<div class="ghosts">` with a click listener at `index.html:637`, no `tabindex`, `role`, or key handler. Not reachable in a tab sweep.
-- 8 foreground ghost SVGs have no `aria-hidden`, `role="img"`, or `<title>`.
-- `/flows` has 0 focusable elements and 6 mermaid SVGs with no accessible name.
-- No focus styling authored anywhere (`:focus`/`outline` = zero hits across all 7 pages). The Chromium UA default is intact, so this is a gap, not a removal.
-- All six terminal lines are in the DOM from load, only clipped by `width: 0` — a screen reader announces `- ghostties % install soon` as fact. The joke is visual-only. | web | project
+### Accessibility — was 1/4, mostly fixed in PR #86 (open)
+- ~~`prefers-reduced-motion` is ~19% honored.~~ Not part of this pass — carried below unchanged where still open (see Small/polish and 07-29 items); the fixes below did not touch the entrance/typewriter animation set.
+- ~~**Contrast failures, all computed and all failing WCAG AA:** 2.27:1 footer text and links on every page (worst on the site); 2.70:1 changelog labels; 3.21:1 `.back` link; 3.22:1 homepage `.line-3`; 3.78:1 `.download-meta`/`.all-releases`; 4.27–4.43:1 body note.~~ **Fixed.** All six raised past AA (`--text-faint` 0.25→0.55 alpha = 5.96:1, the rest similarly), per-token contrast numbers now in `web/DESIGN.md` §3. **Not fixed:** 3.03:1 `#666` on flows lane names — lives in `task-flows.html`, which stayed out of the design-system migration pending the `/flows` decision below.
+- ~~No `<h1>` on `index.html`; no `<main>` landmark on any of the 7 pages; no skip link.~~ **Fixed** on all 7 pages: visually-hidden `<h1>` on the homepage, `<main id="main">` wrapping content, a skip link before it. `task-flows.html` still has none — see the `/flows` decision below.
+- ~~`changelog.html` skips heading levels H1 → H3, six times.~~ **Fixed** — release headings are now H2, section labels H3.
+- ~~The ghost-scatter interaction is mouse-only, not reachable in a tab sweep.~~ **Resolved as decorative, not by adding a control.** The scatter `<div class="ghosts">` and its 8 SVGs are now `aria-hidden="true"`; the click handler is unchanged (still mouse-only) but the element is out of the accessibility tree, so there's no longer an unreachable interactive element for AT users to miss.
+- ~~8 foreground ghost SVGs have no `aria-hidden`.~~ **Fixed**, same change as above.
+- `/flows` still has 0 focusable elements and 6 unlabeled mermaid SVGs — untouched, tracked under the `/flows` decision below.
+- ~~No focus styling authored anywhere.~~ **Fixed** — site-wide `:focus-visible` ring (`--accent`, 2px, keyboard-only), plus a `:focus` reveal on the new skip link.
+- ~~All six terminal lines are in the DOM from load... a screen reader announces `- ghostties % install soon` as fact.~~ **Fixed.** `.line-3` (the joke line) is now `aria-hidden="true"`; every line that states something real stays in the tree. `.line-6`'s `+ [` / `]` decoration is also now `aria-hidden`, so the link's accessible name is "download now," not "plus bracket download now bracket" (this was originally filed under Small/polish, fixed by the same change). | web | project
 
-### Responsive — scored 1/4
-- **Horizontal overflow at 10 of 14 tested widths, from two independent causes.** (1) 320–560px: `.terminal` is clamped by `max-width: calc(100vw - 48px)` but its `.line` children are `white-space: nowrap` and animate to hard-coded `ch` widths, so they escape the parent; only visible after ~7s because the typewriter delays run to 9.7s. (2) 700–900px: `.product-window::before { inset: -10%; filter: blur(40px) }` escapes because `.product` has no `overflow: hidden` — arithmetic confirmed at 768/820/900px. **Cause 2 shipped in PR #72 and is live.**
-- `/support` overflows +11px and `/privacy` +22px at 320px (`CODE` elements don't wrap).
-- **All 48 interactive elements are under 44×44 at 375px; zero pass in both dimensions.** Footer icons are 14×14 (index) and 16×16 (subpages). The `/download` primary CTA is 280.8×41 — 3px short.
-- Breakpoint coverage is a single `max-width: 480px` query on six of seven pages; nothing addresses 481–719px on index, which is exactly where the overflows live.
-- All font sizes are `px` literals — no `rem`/`em`, so text scaling breaks layouts. | web | project
+### Responsive — was 1/4, mostly fixed in PR #86 (open)
+- ~~**Horizontal overflow at 10 of 14 tested widths, from two independent causes.**~~ **Both fixed.** (1) 320–560px `.terminal` escape: `.terminal` now clips overflow and its `max-width` calc widened to account for body padding. (2) 700–900px `.product-window::before` glow escape: `.product` now has `overflow: hidden`. Cause 2 had already shipped in PR #72; cause 1 is new in #86.
+- ~~`/support` overflows +11px and `/privacy` +22px at 320px.~~ **Fixed** — `<code>` now has `overflow-wrap: anywhere` site-wide so long unbroken tokens (bundle IDs) wrap instead of forcing the container wider.
+- ~~All 48 interactive elements are under 44×44 at 375px.~~ **Fixed** for the CTA and footer icons — `/download`'s primary button gets `min-height: 44px`, and footer icon anchors get 15px padding to grow their tap box to 44×44 without changing the visible 14px icon.
+- **Breakpoint coverage is still a single `max-width: 480px` query on six of seven pages.** Not addressed by adding breakpoints — the overflow fixes above (clip + wrap + wider `calc()`) are width-independent, so the gap in 481–719px coverage no longer has a live overflow bug behind it. The breakpoint sparseness itself is unchanged.
+- ~~All font sizes are `px` literals.~~ **Fixed** — every sized value in `style.css` and the un-tokenised single-use sizes in each page are now `rem`. | web | project
 
-### Conversion and trust
-- **The homepage CTA is gated behind ~10.1s of animation** with no skip. `.line-6` types at 9.7s (`index.html:196-201`); JS locks the caret at 10100ms. Median bounce is well under that. Fix should compress the schedule (the delays are hand-authored) and add a persistent download affordance outside the animated scene — the hero's choreography stays as-is.
-- **`/download` has no trust signals at the highest-risk moment.** A 147MB DMG from an unknown developer, with no mention of Developer ID signing, notarization, Gatekeeper, or a checksum — **even though the build genuinely is notarized**. It names no author, and it is the only page in the funnel with no product image.
-- The homepage has no `<h1>`, no wordmark, and no prose. The product name appears only inside `cd ~/ghostties` and a GitHub URL.
-- The site never says this is a fork of Ghostty until `/licenses`, the last footer link.
-- No Download link in any subpage footer — the funnel dead-ends on every page it can reach.
-- `og:image` is relative (`index.html:26`) and may not resolve for crawlers. No `og:url`, `twitter:card`, or `twitter:image`. **Zero OG tags on all five subpages** — sharing the download link produces a bare URL, which matters for a product distributed by link-sharing. | web | session
+### Conversion and trust — mostly still open
+- **The homepage CTA is still gated behind ~10.1s of animation with no skip.** Untouched by PR #86.
+- **`/download` still has no trust signals at the highest-risk moment.** Untouched.
+- The homepage still has no `<h1>` a sighted user can see (the new `<h1>` added for a11y is `visually-hidden`), no visible wordmark, no prose.
+- The site still never says this is a fork of Ghostty until `/licenses`. Untouched.
+- Still no Download link in any subpage footer. Untouched.
+- ~~`og:image` is relative and may not resolve for crawlers. No `og:url`, `twitter:card`, or `twitter:image`. Zero OG tags on all five subpages.~~ **Partially fixed, one thing made worse on purpose.** `og:title`/`og:description`/`og:type`/`og:url`/`twitter:card` were added to all 7 pages (was zero on 5 of them). `og:image`/`twitter:image` were **removed**, not added — the only candidate image, `assets/poster.png`, is wrong for the job (dead GitHub URL, "install soon" copy, wrong aspect ratio for a Twitter large-image card; see the new item below). Shipping a broken share image was judged worse than shipping none. | web | session
 
-### Content staleness
-- `changelog.html`'s newest entry is **beta.19**; the site ships **beta.21** — two releases undocumented.
-- `/support` says "Last updated April 26, 2026" and its `<meta description>` advertises a known-issues section the page does not contain.
-- The release version is hand-synced across 4+ locations, two of which are character counts (`steps(N)` and `Nch`). Bumping to a longer version string clips or trails the primary CTA. Wants build-time substitution. | web | quick
+### Content staleness — mostly fixed in PR #86 (open)
+- ~~`changelog.html`'s newest entry is beta.19; the site ships beta.21.~~ **Fixed** — beta.20 and beta.21 entries added.
+- ~~`/support`'s `<meta description>` advertises a known-issues section the page does not contain.~~ **Fixed** — meta description corrected to match the page. **Not fixed:** the visible "Last updated April 26, 2026" text on the page itself is still stale; only the meta tag was touched.
+- **The release version is still hand-synced across 4+ locations**, two of which are character counts (`steps(N)` and `Nch`). Untouched — still wants build-time substitution. | web | quick
 
-### Footer consistency
-- **Four distinct footer variants across seven pages**; `task-flows.html` has none. Same link labeled `aria-label="X / Twitter"` on index vs `"Twitter"` on subpages.
-- Footers are `position: fixed` with no background, so on any page taller than the viewport they render on top of body text. Confirmed on `/support` mobile colliding with a code span. | web | quick
+### Footer consistency — fixed in PR #86 (open)
+- ~~**Four distinct footer variants across seven pages**; `task-flows.html` has none.~~ **Fixed for the six document pages** — one shared `.footer-links` markup/CSS block. The homepage keeps its own icon-row variant deliberately (see `web/DESIGN.md`). `task-flows.html` still has none — tracked under the `/flows` decision below.
+- ~~Same link labeled `aria-label="X / Twitter"` on index vs `"Twitter"` on subpages.~~ **Was already stale before this pass** — there is no Twitter/X link anywhere on the live site (removed earlier, per PR #77's dead-link fix). Nothing to do here.
+- ~~Footers are `position: fixed` with no background, so on any page taller than the viewport they render on top of body text.~~ **Fixed for the six document pages** — footer is now `position: static`, pushed to the bottom of a flex column via `main { flex: 1 }`. The homepage re-pins its footer to `fixed` deliberately (it's a single exactly-viewport-height hero designed around a footer glued to the bottom edge, not a scrolling document). | web | quick
 
-### `/flows` — needs a decision
-- `task-flows.html` is an internal spec, publicly routed at `vercel.json`, linked from nowhere. Its subtitle is "Review before building further" and its bottom third is a grid of red `GAP` cards enumerating unbuilt features. It also loads `mermaid@11` from jsdelivr as a **render-blocking, unpinned, no-SRI** third-party script on the same origin that serves the Sparkle appcast. Decide: pull it from `web/`, or give it the site's design language and rewrite the GAP grid as a roadmap. | web | needs-Sean
+### `/flows` — still needs a decision
+- `task-flows.html` is untouched by PR #86, deliberately — an internal spec, publicly routed, linked from nowhere, unpinned `mermaid@11` from jsdelivr, no design-system migration, no `<main>`/skip-link/`<h1>`/footer. Still needs Sean's call: pull it from `web/`, or bring it into the design system and rewrite the GAP grid as a roadmap. | web | needs-Sean
 
-### Security headers
-- `vercel.json` sets HSTS and `nosniff`. Missing: `Content-Security-Policy` (relevant given the unpinned CDN script above), `X-Frame-Options` / `frame-ancestors`, `Referrer-Policy`, `Permissions-Policy`. | security | quick
+### Security headers — fixed in PR #86 (open)
+- ~~`vercel.json` sets HSTS and `nosniff`. Missing: `Content-Security-Policy`, `X-Frame-Options`/`frame-ancestors`, `Referrer-Policy`, `Permissions-Policy`.~~ **Fixed** — all four added. | security | quick
 
-### Performance
-- No `preload` attribute on any `<video>`; the full file is fetched even when playback never starts. Media dropped 582KB → 262KB in PR #72, so this is now smaller but still eager.
-- Zero lazy loading site-wide — no `loading=`, `decoding=`, or `preload` anywhere. | web | quick
+### Performance — investigated, no change warranted
+- **No `preload` attribute on any `<video>`.** Investigated in PR #86 and deliberately left alone: both product videos are `autoplay`, so eager fetch is the correct behavior — `preload="none"`/`"metadata"` would just delay playback for no benefit. The finding was moot, not fixed.
+- **Zero lazy loading site-wide.** Investigated: there are zero `<img>` tags anywhere on the site (all imagery is inline SVG or CSS), so `loading=`/`decoding=` have nothing to attach to. Also moot. | web | quick
 
 ### Small / polish
-- The favicon randomizes color on every load, so a pinned tab is never recognizable. Deliberate call needed. | web | needs-Sean
-- `<link rel="icon" href="">` on all pages fires a request against the current document URL before the JS runs.
-- `.product-window::before` uses `rgba(201,115,80,0.3)` — terracotta, explicitly dropped as a brand color. It's the only chromatic accent below the hero while the actual 8-ghost palette sits unused.
-- `.line-6` anchor text is `+ [download now]` — the diff marker is inside the link, so screen readers announce "plus bracket download now bracket".
-- The mobile `.ghost` override is still `64px` while the base is now `72px` (shipped in PR #78) — only an 8px step down. Probably wants revisiting or removing. | web | quick
+- The favicon still randomizes color on every load. Untouched — still needs Sean's call. | web | needs-Sean
+- ~~`<link rel="icon" href="">` on all pages fires a request against the current document URL.~~ **Fixed** — the empty `href` attribute was removed entirely on all 7 pages.
+- **`.product-window::before` still uses terracotta** (`rgba(201,115,80,0.3)`), the only chromatic accent below the hero. Untouched. (Separately, terracotta is now also the site's focus-ring color — see the new item below.)
+- ~~`.line-6` anchor text is `+ [download now]` — the diff marker is inside the link.~~ **Fixed**, same change that resolved the terminal-announced-as-fact accessibility item above — the `+ [` / `]` decoration is now `aria-hidden`, so the accessible name is "download now."
+- **The mobile `.ghost` override is still `64px`** against a `72px` base. An agent changed it during this work; the change was deliberately reverted before merge. Still open. | web | quick
+
+### New findings from PR #86 (needs Sean)
+- **The site has no correct social-share image.** `web/assets/poster.png` contains the dead `SeanSmithDesign` GitHub URL and the text "install soon," and is 1080×1080 so a `summary_large_image` Twitter card crops all the text off. `og:image`/`twitter:image` were removed rather than ship it (see Conversion and trust above). Needs a real 1200×630 image. | web | needs-Sean
+- **`web/assets/poster.png` is unreferenced but still contains dead content.** It's not actually used as any `<video>`'s `poster` attribute (both product videos have their own `-poster.jpg` files) — it was only ever linked via the now-removed `og:image` tag. It's a dead asset with a dead GitHub URL sitting in the repo; low priority since nothing serves it, but worth deleting once the real 1200×630 replacement exists. | web | quick
+- **Terracotta `--accent` now doubles as the site's focus-ring color** (4.92:1, passes AA) on a site where terracotta was explicitly dropped as a brand color. Introduced by the new `:focus-visible` rule in PR #86. Deliberate or not, terracotta is now an interaction color, not just a caption accent. | web | needs-Sean
+- **The hero terminal clips the GitHub URL below 768px.** A fluid `clamp()` type scale fixes it but retunes the hero's type across the whole 320–767px range and reaches 10px monospace at 320px — a real design tradeoff, not a defect fix. Built and deliberately reverted before PR #86 merged. | web | needs-Sean
+- **The mobile footer is now ~2.5× its former height** (112px document / 106px homepage at ≤480px) because the 44×44 touch-target fix makes the tap boxes real. Reads fine, but on the homepage — which pins its footer `position: fixed` — it's now a permanently fixed ~13% of an 800px viewport. | web | needs-Sean
 
 ## 2026-08-01 — ghostties.org docs section (parked)
 

--- a/web/404.html
+++ b/web/404.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page not found — ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];

--- a/web/404.html
+++ b/web/404.html
@@ -151,7 +151,7 @@
     }
 
     @media (max-width: 480px) {
-      h1 { font-size: 18px; }
+      h1 { font-size: 1.125rem; } /* 18px */
     }
   </style>
 </head>

--- a/web/404.html
+++ b/web/404.html
@@ -25,11 +25,18 @@
   <style>
     /* 404 page only. Shared base: /style.css */
 
-    /* min-height:100% never resolves here (html has no definite height), so the
-       column had no free space and justify-content:center did nothing. */
-    body {
-      min-height: 100dvh;
+    /* Centering lives on <main>, not <body>: main is the flex:1 item that
+       claims the column's free space (style.css), and footer's own
+       margin-top:auto has nothing left to consume — so centering main's
+       content also leaves the footer sitting right after it, at the
+       bottom of the viewport on short pages and right below content on
+       tall ones. Centering on body instead would work today but breaks the
+       moment footer stops being the last flex child. */
+    main {
       justify-content: center;
+    }
+
+    body {
       text-align: center;
     }
 
@@ -170,7 +177,13 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/licenses">Licenses</a>
+    </span>
   </footer>
 </body>
 </html>

--- a/web/404.html
+++ b/web/404.html
@@ -156,6 +156,8 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <main id="main">
   <div class="not-found-ghost" aria-hidden="true">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF4136" shape-rendering="crispEdges">
       <rect x="12" y="0" width="24" height="4"/><rect x="8" y="4" width="32" height="4"/><rect x="4" y="8" width="40" height="4"/><rect x="4" y="12" width="8" height="8"/><rect x="20" y="12" width="8" height="8"/><rect x="36" y="12" width="8" height="8"/><rect x="0" y="20" width="48" height="20"/><rect x="0" y="40" width="8" height="4"/><rect x="12" y="40" width="8" height="4"/><rect x="28" y="40" width="8" height="4"/><rect x="40" y="40" width="8" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="16" y="44" width="4" height="4"/><rect x="28" y="44" width="4" height="4"/><rect x="44" y="44" width="4" height="4"/>
@@ -165,6 +167,7 @@
   <h1>404 — page not found</h1>
   <p>That page doesn't exist.</p>
   <a class="home-link" href="/">&larr; Back to ghostties.org</a>
+  </main>
 
   <footer>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -164,9 +164,9 @@ runs on — they resolve identically to what shipped before.
 
 Line height: `--leading-snug` 1.6, `--leading-body` 1.65.
 
-Un-tokenised sizes, all single-use inside one page block: 11px (changelog
-`h4`, homepage footer), 18px (licenses `h2`, hero terminal), 20px (changelog
-`h3`), 30px (product heading).
+Un-tokenised sizes, all single-use inside one page block: 0.6875rem/11px
+(changelog `h3`, homepage footer), 18px (licenses `h2`, hero terminal),
+1.25rem/20px (changelog `h2`), 30px (product heading).
 
 **Every size is a `px` literal.** Text scaling therefore breaks layouts —
 queued in `BACKLOG.md` under Responsive. Because the sizes are tokens now,
@@ -271,4 +271,3 @@ concludes from this document that the system is finished.
 - Four footer variants across seven pages. `style.css` now holds the document
   footer; the homepage keeps a mono override. Collapsing them to one is a
   taste call, and deleting the override is all it takes.
-- No `<main>` landmark or skip link on any page; no `<h1>` on the homepage.

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -73,9 +73,10 @@ alpha, plus a single accent.
 
 ### Text ramp
 
-Densest to faintest. **The contrast column is from the 2026-08-02 audit,
-measured against `--bg`.** Everything from `--text-note` down fails WCAG AA
-for body-size text.
+Grouped by role (prose ramp, then footer/timestamp ramp), not strictly by
+value — see the ordering note on the token block in `style.css`. **The
+contrast column is from the 2026-08-03 fix pass, measured against `--bg`.**
+Everything below passes WCAG AA for body-size text.
 
 | Token | Alpha | Contrast | Use |
 | --- | --- | --- | --- |
@@ -83,17 +84,17 @@ for body-size text.
 | `--text-heading-soft` | 0.90 | — | Licenses section titles |
 | `--text-primary` | 0.85 | — | `body` default |
 | `--text-body` | 0.65 | pass | Prose, links, list items |
-| `--text-note` | 0.45 | 4.27–4.43 | Callout copy |
-| `--text-meta` | 0.40 | 3.78 | File size, "all releases" |
-| `--text-label` | 0.35 | 3.21 | Eyebrow `h2`, back link, dates |
-| `--text-label-quiet` | 0.30 | 2.70 | Changelog subsection labels |
-| `--text-faint` | 0.25 | **2.27** | Footer text and links, timestamps, bullets |
+| `--text-note` | 0.52 | 5.468 | Callout copy |
+| `--text-meta` | 0.50 | 5.156 | File size, "all releases" |
+| `--text-label` | 0.48 | 4.857 | Eyebrow `h2`, back link, dates |
+| `--text-label-quiet` | 0.46 | 4.570 | Changelog subsection labels |
+| `--text-faint` | 0.55 | 5.959 | Footer text and links, timestamps, bullets |
 
-`--text-faint` at 2.27:1 is the worst value on the site and it is the footer,
-which appears on all seven pages. The audit's note: raising the floor to 0.55
-yields 5.96:1. **That fix is now a single token edit** — it was the point of
-building this file. It is queued in `BACKLOG.md` under Accessibility and has
-not been applied here, because this pass was a refactor.
+`--text-faint` used to be the worst value on the site at 2.27:1 (0.25 alpha)
+— it was the footer, which appears on all seven pages. Raising the floor to
+0.55 fixed it in a single token edit, shipped 2026-08-03. `--diff-del-fg`
+(the hero terminal's red diff line) is 4.720:1 against its own
+`--diff-del-bg` composite. `--accent` is 4.916:1.
 
 Hover pairs: `--text-body-hover` (0.9), `--text-meta-hover` (0.65),
 `--text-label-hover` (0.6), `--text-faint-hover` (0.5).
@@ -168,9 +169,12 @@ Un-tokenised sizes, all single-use inside one page block: 0.6875rem/11px
 (changelog `h3`, homepage footer), 18px (licenses `h2`, hero terminal),
 1.25rem/20px (changelog `h2`), 30px (product heading).
 
-**Every size is a `px` literal.** Text scaling therefore breaks layouts —
-queued in `BACKLOG.md` under Responsive. Because the sizes are tokens now,
-converting the scale to `rem` is one block in `style.css`.
+**The tokenised sizes above are now all `rem`**, converted in the
+2026-08-03 fix pass so they scale with the user's font-size setting instead
+of ignoring it. The un-tokenised sizes right above this are a mix: some
+converted with them (0.6875rem, 1.25rem), some are still raw `px` literals
+(18px, 30px) because each is single-use inside one page block and wasn't
+part of the shared token sweep.
 
 ### Headings
 
@@ -263,8 +267,11 @@ section goes with it.
 These are real and tracked in `BACKLOG.md`; they are listed here so nobody
 concludes from this document that the system is finished.
 
-- No focus styling is authored anywhere. The browser default is intact, so
-  this is a gap rather than a removal — but a design system should own it.
+- `task-flows.html` (routed at `/flows`, listed in `sitemap.xml`) still has
+  no `<main>` landmark, no skip link, no shared stylesheet, and no footer.
+  The `<main>`/skip-link/`<h1>` gap is fixed on the other six pages, not on
+  this one — it's out of system entirely per §7, and whether it stays on
+  the site at all is an open decision in `BACKLOG.md`.
 - `prefers-reduced-motion` is honoured on `/404` (the ghost fades in already
   fallen — gentler, not zero) and by exactly one rule on the homepage
   (`.bg-ghost`). Seventeen homepage animations still run under `reduce`.

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -97,9 +97,17 @@ Everything below passes WCAG AA for body-size text.
 `--diff-del-bg` composite. `--accent` is 4.916:1.
 
 Hover pairs: `--text-body-hover` (0.9), `--text-meta-hover` (0.65),
-`--text-label-hover` (0.6), `--text-faint-hover` (0.5).
+`--text-label-hover` (0.6), `--text-faint-hover` (0.65).
 
 Hairlines: `--line` (0.08), `--line-strong` (0.12), `--line-faint` (0.07).
+
+### Focus
+
+`:focus-visible` in `style.css` is the only focus styling on the site: a
+`2px solid var(--accent)` ring with a 2px offset and `--radius-sm` corners,
+applied globally rather than per-component. `:focus-visible` (not `:focus`)
+means it shows for keyboard navigation and never for a mouse or touch tap.
+`--accent` measures 4.916:1 against `--bg` here too.
 
 ### Accent
 

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -103,11 +103,14 @@ Hairlines: `--line` (0.08), `--line-strong` (0.12), `--line-faint` (0.07).
 
 ### Focus
 
-`:focus-visible` in `style.css` is the only focus styling on the site: a
+`:focus-visible` in `style.css` is the main focus styling on the site: a
 `2px solid var(--accent)` ring with a 2px offset and `--radius-sm` corners,
 applied globally rather than per-component. `:focus-visible` (not `:focus`)
 means it shows for keyboard navigation and never for a mouse or touch tap.
-`--accent` measures 4.916:1 against `--bg` here too.
+`--accent` measures 4.916:1 against `--bg` here too. The one exception is
+`.skip-link:focus`, which reveals the skip link itself on focus (a `:focus`,
+not `:focus-visible`, since the link is otherwise off-screen and needs to
+appear for any focus method that lands on it).
 
 ### Accent
 
@@ -179,10 +182,10 @@ Un-tokenised sizes, all single-use inside one page block: 0.6875rem/11px
 
 **The tokenised sizes above are now all `rem`**, converted in the
 2026-08-03 fix pass so they scale with the user's font-size setting instead
-of ignoring it. The un-tokenised sizes right above this are a mix: some
-converted with them (0.6875rem, 1.25rem), some are still raw `px` literals
-(18px, 30px) because each is single-use inside one page block and wasn't
-part of the shared token sweep.
+of ignoring it. The un-tokenised sizes right above this were converted too —
+all four are `rem` (0.6875rem, 1.25rem, 1.125rem, 1.875rem) — they just
+stayed out of the shared token sweep because each is single-use inside one
+page block.
 
 ### Headings
 
@@ -283,6 +286,8 @@ concludes from this document that the system is finished.
 - `prefers-reduced-motion` is honoured on `/404` (the ghost fades in already
   fallen — gentler, not zero) and by exactly one rule on the homepage
   (`.bg-ghost`). Seventeen homepage animations still run under `reduce`.
-- Four footer variants across seven pages. `style.css` now holds the document
-  footer; the homepage keeps a mono override. Collapsing them to one is a
-  taste call, and deleting the override is all it takes.
+- Two footer variants across seven pages. `style.css` now holds one identical
+  `.footer-links` block shared by the six document pages; the homepage keeps
+  its own variant (an icons span plus a three-link row, no Licenses link).
+  Collapsing them to one is a taste call, and deleting the homepage override
+  is all it takes.

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -378,7 +378,13 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/licenses">Licenses</a>
+    </span>
   </footer>
 </body>
 </html>

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -23,11 +23,9 @@
   <meta name="description" content="Changelog — what's new in each Ghostties release.">
   <meta property="og:title" content="Changelog — ghostties">
   <meta property="og:description" content="Changelog — what's new in each Ghostties release.">
-  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ghostties.org/changelog">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Changelog page only. Shared base: /style.css */
@@ -56,6 +54,7 @@
       color: var(--text-heading);
       text-transform: none;
       margin-top: 0;
+      margin-bottom: 0;
     }
 
     .release-heading .date {
@@ -168,7 +167,7 @@
     <div class="release">
       <div class="release-heading">
         <h2>v0.1.0-beta.20</h2>
-        <span class="date">July 21, 2026</span>
+        <span class="date">July 20, 2026</span>
       </div>
       <p class="release-summary">Quality-of-life improvements to the workspace sidebar &mdash; resize it, rename sessions in place, and jump between live agents from the keyboard.</p>
 

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Changelog — ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];
@@ -21,6 +21,13 @@
     })();
   </script>
   <meta name="description" content="Changelog — what's new in each Ghostties release.">
+  <meta property="og:title" content="Changelog — ghostties">
+  <meta property="og:description" content="Changelog — what's new in each Ghostties release.">
+  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ghostties.org/changelog">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Changelog page only. Shared base: /style.css */
@@ -111,6 +118,75 @@
 
     <div class="note">
       <p><strong style="color:rgba(255,255,255,0.6)">Beta.15 and earlier:</strong> Auto-updates aren't reliable yet in early betas. Download the latest release manually from the <a href="/download">download page</a>.</p>
+    </div>
+
+    <!-- beta.21 -->
+    <div class="release">
+      <div class="release-heading">
+        <h2>v0.1.0-beta.21</h2>
+        <span class="date">August 1, 2026</span>
+      </div>
+      <p class="release-summary">The Sessions tab gets its own character, names that keep themselves current, and a round of security hardening.</p>
+
+      <div class="release-section">
+        <h3>Added</h3>
+        <ul>
+          <li>Session names that keep themselves current &mdash; a session&rsquo;s name in the sidebar now follows the title Claude Code sets, so a row shows what that agent is actually working on instead of a generic label. Rename a session yourself and your name wins; right-click and choose &ldquo;Sync name automatically&rdquo; to hand it back.</li>
+          <li>A ghost for every session &mdash; each session in the Sessions tab now has its own ghost character, tinted by status, in place of the plain dot. A session keeps its ghost across relaunches.</li>
+          <li>Collapsible Active and Archive sections &mdash; the Sessions tab splits into Active and Archive, and each one folds away. Ghostties remembers which you left open.</li>
+        </ul>
+      </div>
+
+      <div class="release-section">
+        <h3>Changed</h3>
+        <ul>
+          <li>The Sessions list holds still &mdash; rows used to reshuffle by most recent activity, rearranging the list while you were reading it. Order is now stable.</li>
+          <li>Status colors across the sidebar &mdash; green means working, blue means your turn, gold means a decision is waiting, orange means long-running, red means something went wrong.</li>
+        </ul>
+      </div>
+
+      <div class="release-section">
+        <h3>Fixed</h3>
+        <ul>
+          <li><code>Cmd+Shift+[</code> and <code>Cmd+Shift+]</code> cycle sessions again &mdash; the shortcut only worked when focus was outside the terminal, which is almost never in practice; the terminal was claiming the key combination for its own tab switching before the menu ever saw it.</li>
+        </ul>
+      </div>
+
+      <div class="release-section">
+        <h3>Security</h3>
+        <ul>
+          <li>Updated Sparkle to 2.9.4, fixing two vulnerabilities in the update framework (CVE-2026-47121 and CVE-2026-47122).</li>
+          <li>MCP server discovery now reads only your own configuration &mdash; Ghostties used to also look inside the project folder you opened, so opening someone else&rsquo;s repository could offer to launch a program that repository shipped. It now reads from <code>~/.ghostties/</code> only.</li>
+          <li>Narrowed what the app is permitted to do &mdash; the shipping build no longer requests two hardened-runtime exceptions it never needed.</li>
+          <li>Session launcher scripts are cleaned up when a session ends, and anything left behind for more than a day is swept away at launch.</li>
+          <li>Fixed a path-handling flaw in <code>gt done</code> that let a crafted task name reach files outside the task directory.</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- beta.20 -->
+    <div class="release">
+      <div class="release-heading">
+        <h2>v0.1.0-beta.20</h2>
+        <span class="date">July 21, 2026</span>
+      </div>
+      <p class="release-summary">Quality-of-life improvements to the workspace sidebar &mdash; resize it, rename sessions in place, and jump between live agents from the keyboard.</p>
+
+      <div class="release-section">
+        <h3>Added</h3>
+        <ul>
+          <li>Drag to resize the sidebar &mdash; grab the sidebar&rsquo;s trailing edge and drag to make it wider or narrower. Ghostties remembers your width separately for the Sessions and Tasks views, so each stays how you left it.</li>
+          <li>Rename, stop, and relaunch sessions from the Sessions tab &mdash; right-click any row for a menu matching the project view: Rename, Stop, Relaunch, Remove. Renaming happens inline, right on the row.</li>
+          <li>Cycle through live agents from the keyboard &mdash; <code>Cmd+Shift+]</code> / <code>Cmd+Shift+[</code> now step through your running sessions in sidebar order (or through task zones in Tasks view). Project cycling moved to <code>Cmd+Ctrl+]</code> / <code>Cmd+Ctrl+[</code>.</li>
+        </ul>
+      </div>
+
+      <div class="release-section">
+        <h3>Changed</h3>
+        <ul>
+          <li>The Sessions list trims itself at launch &mdash; it used to keep every agent session you ever started. It now keeps everything from the last 30 days plus each project&rsquo;s 15 most recent, so the list stays tidy without touching any of your actual work.</li>
+        </ul>
+      </div>
     </div>
 
     <!-- beta.19 -->

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -42,11 +42,13 @@
       margin-bottom: 8px;
     }
 
-    .release-heading h3 {
+    .release-heading h2 {
       font-size: 20px;
       font-weight: 700;
       letter-spacing: -0.02em;
       color: var(--text-heading);
+      text-transform: none;
+      margin-top: 0;
     }
 
     .release-heading .date {
@@ -65,7 +67,7 @@
       margin-top: 16px;
     }
 
-    .release-section h4 {
+    .release-section h3 {
       font-size: 11px;
       font-weight: 600;
       text-transform: uppercase;
@@ -99,6 +101,8 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <main id="main">
   <div class="content">
     <a class="back" href="/">&larr; ghostties</a>
 
@@ -112,20 +116,20 @@
     <!-- beta.19 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.19</h3>
+        <h2>v0.1.0-beta.19</h2>
         <span class="date">July 5, 2026</span>
       </div>
       <p class="release-summary">The workspace stays responsive when several agents are running at once.</p>
 
       <div class="release-section">
-        <h4>Fixed</h4>
+        <h3>Fixed</h3>
         <ul>
           <li>Running multiple agents no longer pins the CPU &mdash; the sidebar was rebuilding itself on every terminal-title change and redoing that work for every project row whether or not anything had changed, which could peg a core and beachball the app until you force-quit it. Activity updates are now throttled and the sidebar only redraws the rows that changed.</li>
         </ul>
       </div>
 
       <div class="release-section">
-        <h4>Performance</h4>
+        <h3>Performance</h3>
         <ul>
           <li>Task list reloads incrementally &mdash; only the task files that changed are re-read, instead of re-parsing every task on any file-system event.</li>
         </ul>
@@ -135,7 +139,7 @@
     <!-- beta.18 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.18</h3>
+        <h2>v0.1.0-beta.18</h2>
         <span class="date">June 19, 2026</span>
       </div>
       <p class="release-summary">The first build delivered to existing users over the air &mdash; it confirms auto-updates work end to end.</p>
@@ -144,13 +148,13 @@
     <!-- beta.17 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.17</h3>
+        <h2>v0.1.0-beta.17</h2>
         <span class="date">June 19, 2026</span>
       </div>
       <p class="release-summary">Auto-updates work now, and the workspace sidebar no longer freezes the app.</p>
 
       <div class="release-section">
-        <h4>Fixed</h4>
+        <h3>Fixed</h3>
         <ul>
           <li>Auto-updates now work &mdash; &ldquo;Check for Updates&rdquo; was silently doing nothing in beta.16, and the in-app update notification never rendered in the workspace window. Ghostties now checks for updates in the background and shows a notification pill when a new version is ready.</li>
           <li>Sidebar no longer freezes the app &mdash; opening the project sidebar could peg the CPU and beachball the window.</li>
@@ -161,13 +165,13 @@
     <!-- beta.16 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.16</h3>
+        <h2>v0.1.0-beta.16</h2>
         <span class="date">May 18, 2026</span>
       </div>
       <p class="release-summary">The tasks sidebar is now fully wired up, with six status zones, Linear preset support, and a complete <code>gt</code> CLI.</p>
 
       <div class="release-section">
-        <h4>Added</h4>
+        <h3>Added</h3>
         <ul>
           <li>Six-zone task sidebar &mdash; Inbox, Backlog, Running, Needs You, Review, and Graveyard lanes are all live. Done tasks no longer appear in Inbox.</li>
           <li>Linear Sync preset &mdash; a template in the New Session picker pre-configures the MCP server with your Linear workspace. Source dots show indigo for Linear-sourced tasks, sage for shell tasks.</li>
@@ -183,7 +187,7 @@
       </div>
 
       <div class="release-section">
-        <h4>Fixed</h4>
+        <h3>Fixed</h3>
         <ul>
           <li>&ldquo;Check for Updates&rdquo; visibility &mdash; progress and result messages now appear correctly in hidden-titlebar and tabbed windows.</li>
           <li>Auto-update channel &mdash; channel is now user-controllable via <code>defaults write</code>. Previously hardcoded.</li>
@@ -192,7 +196,7 @@
       </div>
 
       <div class="release-section">
-        <h4>Performance</h4>
+        <h3>Performance</h3>
         <ul>
           <li>Suppressed 1Hz sidebar re-render when session states haven&rsquo;t changed &mdash; reduces CPU overhead while Claude is running.</li>
         </ul>
@@ -202,13 +206,13 @@
     <!-- beta.15 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.15</h3>
+        <h2>v0.1.0-beta.15</h2>
         <span class="date">May 5, 2026</span>
       </div>
       <p class="release-summary">Polish and stability fixes following the beta.14 smoke test.</p>
 
       <div class="release-section">
-        <h4>Fixed</h4>
+        <h3>Fixed</h3>
         <ul>
           <li>Dark mode titlebar now matches the canvas background color (previously showed a mismatched gray).</li>
           <li>Fullscreen icon position in the toolbar corrected.</li>
@@ -219,7 +223,7 @@
       </div>
 
       <div class="release-section">
-        <h4>Quality</h4>
+        <h3>Quality</h3>
         <ul>
           <li>All upstream Ghostty tests pass &mdash; full test suite is green.</li>
         </ul>
@@ -229,13 +233,13 @@
     <!-- beta.14 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.14</h3>
+        <h2>v0.1.0-beta.14</h2>
         <span class="date">April 30, 2026</span>
       </div>
       <p class="release-summary">First beta with a production-quality icon and an onboarding experience on first launch.</p>
 
       <div class="release-section">
-        <h4>Added</h4>
+        <h3>Added</h3>
         <ul>
           <li>New production app icon.</li>
           <li>Debug builds use a distinct blueprint-style icon so it&rsquo;s easy to tell Dev from Release at a glance.</li>
@@ -246,7 +250,7 @@
       </div>
 
       <div class="release-section">
-        <h4>Changed</h4>
+        <h3>Changed</h3>
         <ul>
           <li>Fresh installs now default to showing the project sidebar first (previously opened to an empty state).</li>
         </ul>
@@ -256,20 +260,20 @@
     <!-- beta.13 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.13</h3>
+        <h2>v0.1.0-beta.13</h2>
         <span class="date">April 30, 2026</span>
       </div>
       <p class="release-summary">Window controls alignment and the first version of task row interaction.</p>
 
       <div class="release-section">
-        <h4>Fixed</h4>
+        <h3>Fixed</h3>
         <ul>
           <li>Traffic light buttons (close / minimize / zoom) are now correctly centered in the titlebar &mdash; previously they floated slightly off.</li>
         </ul>
       </div>
 
       <div class="release-section">
-        <h4>Added</h4>
+        <h3>Added</h3>
         <ul>
           <li>Sidebar row-click v0 &mdash; clicking a task row now lets you interact with it.</li>
         </ul>
@@ -279,13 +283,13 @@
     <!-- beta.12 -->
     <div class="release">
       <div class="release-heading">
-        <h3>v0.1.0-beta.12</h3>
+        <h2>v0.1.0-beta.12</h2>
         <span class="date">April 28, 2026</span>
       </div>
       <p class="release-summary">First distributable build. Ghostties can now be installed and kept up to date automatically.</p>
 
       <div class="release-section">
-        <h4>Added</h4>
+        <h3>Added</h3>
         <ul>
           <li>First full DMG bundle with notarization &mdash; Ghostties is now installable like any other Mac app.</li>
           <li>Sparkle auto-update wired to ghostties.org &mdash; the app will notify you when a new beta is available.</li>
@@ -296,6 +300,7 @@
     </div>
 
   </div>
+  </main>
 
   <footer>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -43,7 +43,7 @@
     }
 
     .release-heading h2 {
-      font-size: 20px;
+      font-size: 1.25rem; /* 20px */
       font-weight: 700;
       letter-spacing: -0.02em;
       color: var(--text-heading);
@@ -68,7 +68,7 @@
     }
 
     .release-section h3 {
-      font-size: 11px;
+      font-size: 0.6875rem; /* 11px */
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.1em;

--- a/web/download.html
+++ b/web/download.html
@@ -23,11 +23,9 @@
   <meta name="description" content="Download Ghostties — a multi-agent workspace terminal for macOS.">
   <meta property="og:title" content="Download — ghostties">
   <meta property="og:description" content="Download Ghostties — a multi-agent workspace terminal for macOS.">
-  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ghostties.org/download">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Download page only. Shared base: /style.css */
@@ -117,7 +115,7 @@
         Download v0.1.0-beta.21 for macOS
       </a>
       <div class="download-meta">
-        v0.1.0-beta.21 &middot; August 2, 2026 &middot; 147 MB<br>
+        v0.1.0-beta.21 &middot; August 1, 2026 &middot; 147 MB<br>
         macOS 13 (Ventura) or later &middot; Apple Silicon
       </div>
     </div>

--- a/web/download.html
+++ b/web/download.html
@@ -73,7 +73,25 @@
     }
 
     @media (max-width: 480px) {
-      .download-btn { font-size: var(--size-meta); padding: 12px 22px; }
+      .download-btn {
+        font-size: var(--size-meta);
+        padding: 12px 22px;
+        /* 12px padding + ~14px line-height measured 41px tall, 3px short
+           of the 44px touch-target minimum. min-height guarantees 44px
+           regardless of font metrics without changing the padding that
+           sets the button's horizontal proportions. */
+        min-height: 44px;
+        display: inline-flex;
+        align-items: center;
+      }
+
+      /* padding grows the tap target; the offsetting margin (base
+         margin-top 24px minus the new 15px padding-top = 9px, etc.) keeps
+         the visible link in the exact position it was in before. */
+      .all-releases {
+        padding: 15px 4px;
+        margin: 9px -4px -15px -4px;
+      }
     }
   </style>
 </head>

--- a/web/download.html
+++ b/web/download.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Download — ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];
@@ -21,6 +21,13 @@
     })();
   </script>
   <meta name="description" content="Download Ghostties — a multi-agent workspace terminal for macOS.">
+  <meta property="og:title" content="Download — ghostties">
+  <meta property="og:description" content="Download Ghostties — a multi-agent workspace terminal for macOS.">
+  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ghostties.org/download">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Download page only. Shared base: /style.css */

--- a/web/download.html
+++ b/web/download.html
@@ -78,6 +78,8 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <main id="main">
   <div class="content">
     <a class="back" href="/">&larr; ghostties</a>
 
@@ -107,6 +109,7 @@
 
     <p class="updated">Last updated August 2, 2026</p>
   </div>
+  </main>
 
   <footer>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>

--- a/web/download.html
+++ b/web/download.html
@@ -135,7 +135,13 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/licenses">Licenses</a>
+    </span>
   </footer>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -111,7 +111,7 @@
       line-height: 2;
       color: var(--terminal-fg);
       width: 46ch;
-      max-width: calc(100vw - 48px);
+      max-width: calc(100vw - 112px);
       margin: 0 auto;
       text-align: left;
       /* .line children animate to hard-coded ch widths (e.g. 43ch for the

--- a/web/index.html
+++ b/web/index.html
@@ -105,7 +105,7 @@
     /* --- Terminal text --- */
     .terminal {
       font-family: var(--font-mono);
-      font-size: 18px;
+      font-size: 1.125rem; /* 18px */
       font-weight: 600;
       line-height: 2;
       color: var(--terminal-fg);
@@ -113,6 +113,14 @@
       max-width: calc(100vw - 48px);
       margin: 0 auto;
       text-align: left;
+      /* .line children animate to hard-coded ch widths (e.g. 43ch for the
+         GitHub URL) that exceed this container below ~560px, since it's
+         already clamped narrower than 46ch there. Without this, the widest
+         .line escapes .terminal's own (correctly clamped) box and forces a
+         horizontal scrollbar on the whole page. This only clips content
+         that's already wider than the container — at desktop widths every
+         line fits inside 46ch, so nothing here changes what's rendered. */
+      overflow: hidden;
     }
 
     .line {
@@ -259,12 +267,18 @@
       margin: 0 auto;
       padding: 24px 32px 96px;
       text-align: center;
+      /* .product-window::before (the glow) uses inset:-10%, which escapes
+         past .product's own edge once the window is wide enough — confirmed
+         at 768/820/900px. .product's own width never exceeds its container
+         (100%, capped at 900px), so clipping overflow here can only remove
+         the escaping glow; it can never clip real content. */
+      overflow: hidden;
     }
 
     /* Display heading — opts out of the shared uppercase eyebrow h2. */
     .product h2 {
       font-family: var(--font-ui);
-      font-size: 30px;
+      font-size: 1.875rem; /* 30px */
       font-weight: 700;
       color: var(--terminal-fg);
       text-transform: none;
@@ -326,16 +340,25 @@
 
     .product-caption {
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: 0.75rem; /* 12px */
       color: var(--accent);
       margin-top: 12px;
     }
 
-    /* --- Footer (homepage variant: mono, smaller) --- */
+    /* --- Footer (homepage variant: mono, smaller, pinned to the hero) ---
+       style.css made footer position:static for the document pages (a
+       fixed footer rendered on top of body text once a page ran past one
+       viewport). The homepage is a single, exactly-viewport-height hero
+       and is designed around the footer glued to its bottom edge, so it
+       re-pins here. */
     footer {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
       padding: 14px 24px;
       font-family: var(--font-mono);
-      font-size: 11px;
+      font-size: 0.6875rem; /* 11px */
     }
 
     .footer-icons {
@@ -402,18 +425,33 @@
     @media (max-width: 480px) {
       body { padding: 16px; }
       .scene { padding: 32px 20px 28px; }
-      .ghost { width: 64px; height: 64px; }
+      /* PR #78 bumped the base ghost from 100px to 72px but left this
+         override at 64px — an 8px step that reads as almost no reduction
+         (89% of base) when the original override was 64px against a
+         100px base (a 64% step). Restoring that ~2/3 ratio against the
+         new 72px base lands on 48px, which is also on the site's 4px
+         spacing scale. */
+      .ghost { width: 48px; height: 48px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      .terminal { font-size: 16px; }
-      footer { padding: 12px 16px; font-size: 10px; }
+      .terminal { font-size: 1rem; } /* 16px */
+      footer { padding: 12px 16px; font-size: 0.625rem; } /* 10px */
       .product { padding: 16px 20px 72px; }
-      .product h2 { font-size: 22px; margin-bottom: 28px; }
+      .product h2 { font-size: 1.375rem; margin-bottom: 28px; } /* 22px */
       .product-window { margin-bottom: 28px; }
       .product-window--sessions .product-card,
       .product-window--flow .product-card { transform: none; }
-      .product-caption { font-size: 11px; margin-top: 8px; }
+      .product-caption { font-size: 0.6875rem; margin-top: 8px; } /* 11px */
       .bg-ghost { width: 22px; height: 22px; }
+
+      /* Touch target: the icon stays 14px, the anchor's clickable box
+         grows to 44x44 via padding around it. */
+      .footer-icons a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 15px;
+      }
     }
   </style>
 </head>

--- a/web/index.html
+++ b/web/index.html
@@ -23,11 +23,9 @@
   <meta name="description" content="Ghostties — a multi-agent workspace terminal. Now in beta.">
   <meta property="og:title" content="ghostties">
   <meta property="og:description" content="A multi-agent workspace terminal. Now in beta.">
-  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ghostties.org/">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Homepage only. Shared tokens, reset, and footer base: /style.css */
@@ -108,7 +106,13 @@
     /* --- Terminal text --- */
     .terminal {
       font-family: var(--font-mono);
-      font-size: 1.125rem; /* 18px */
+      /* Fluid between 320px and 768px viewports; clamp()'s max caps it at
+         exactly 1.125rem for every viewport >= 768px, so desktop rendering
+         is byte-for-byte what it was before this was a clamp(). Below 768
+         the type shrinks enough that the 43ch GitHub-URL line (the widest
+         .line) fits inside .terminal's own clamped width without hitting
+         the overflow:hidden clip below, down to 320px. */
+      font-size: clamp(0.625rem, calc(0.625rem + (1.125rem - 0.625rem) * (100vw - 320px) / (768px - 320px)), 1.125rem);
       font-weight: 600;
       line-height: 2;
       color: var(--terminal-fg);
@@ -117,12 +121,13 @@
       margin: 0 auto;
       text-align: left;
       /* .line children animate to hard-coded ch widths (e.g. 43ch for the
-         GitHub URL) that exceed this container below ~560px, since it's
-         already clamped narrower than 46ch there. Without this, the widest
-         .line escapes .terminal's own (correctly clamped) box and forces a
-         horizontal scrollbar on the whole page. This only clips content
-         that's already wider than the container — at desktop widths every
-         line fits inside 46ch, so nothing here changes what's rendered. */
+         GitHub URL). The fluid font-size above keeps that line inside
+         .terminal's own (correctly clamped) box at every width this site
+         supports; this stays as a hard backstop in case a future edit
+         reintroduces a line wider than the container, so it can only ever
+         clip content that's already wider than the container — at desktop
+         widths every line fits inside 46ch, so nothing here changes what's
+         rendered. */
       overflow: hidden;
     }
 
@@ -351,9 +356,11 @@
     /* --- Footer (homepage variant: mono, smaller, pinned to the hero) ---
        style.css made footer position:static for the document pages (a
        fixed footer rendered on top of body text once a page ran past one
-       viewport). The homepage is a single, exactly-viewport-height hero
-       and is designed around the footer glued to its bottom edge, so it
-       re-pins here. */
+       viewport). The homepage is a scrolling page (2132px tall at
+       1280x900, well past one screen) but is designed around the footer
+       glued to the *viewport's* bottom edge regardless of scroll
+       position, so it re-pins to fixed here rather than following
+       style.css's in-flow footer. */
     footer {
       position: fixed;
       bottom: 0;
@@ -428,16 +435,12 @@
     @media (max-width: 480px) {
       body { padding: 16px; }
       .scene { padding: 32px 20px 28px; }
-      /* PR #78 bumped the base ghost from 100px to 72px but left this
-         override at 64px — an 8px step that reads as almost no reduction
-         (89% of base) when the original override was 64px against a
-         100px base (a 64% step). Restoring that ~2/3 ratio against the
-         new 72px base lands on 48px, which is also on the site's 4px
-         spacing scale. */
-      .ghost { width: 48px; height: 48px; }
+      .ghost { width: 64px; height: 64px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      .terminal { font-size: 1rem; } /* 16px */
+      /* .terminal font-size is fluid (see its rule above) — no fixed
+         override here, or it would clobber the clamp() and reintroduce the
+         clipped GitHub URL this media query used to cause. */
       footer { padding: 12px 16px; font-size: 0.625rem; } /* 10px */
       .product { padding: 16px 20px 72px; }
       .product h2 { font-size: 1.375rem; margin-bottom: 28px; } /* 22px */
@@ -552,13 +555,17 @@
       </div>
       </div>
 
-      <div class="terminal" aria-hidden="true">
+      <div class="terminal">
       <!-- line-1: 14 chars: cd ~/ghostties -->
       <div class="line line-1">cd ~/ghostties</div>
       <!-- line-2: 43 chars: https://github.com/SeanSmithWorks/ghostties -->
-      <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener" tabindex="-1">https://github.com/SeanSmithWorks/ghostties</a></div>
+      <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithWorks/ghostties</a></div>
       <!-- line-3: 26 chars: - ghostties % install soon -->
-      <div class="line line-3">- ghostties % install soon</div>
+      <!-- Joke line, not a fact about the product — the only line hidden from
+           assistive tech. Every other line in this terminal states something
+           real (repo URL, version, requirements, download link) and must stay
+           in the accessibility tree. -->
+      <div class="line line-3" aria-hidden="true">- ghostties % install soon</div>
       <!-- line-4: 28 chars: + ghostties % v0.1.0-beta.21 -->
       <div class="line line-4">+ ghostties % v0.1.0-beta.21</div>
       <!-- line-5: 39 chars: + 02Aug2026 · macOS 13+ · Apple Silicon -->
@@ -568,7 +575,7 @@
            ("+ [" / "]") sits outside the link so the accessible name is just
            "download now"; both spans render normally, so the visible text and
            the 16ch typing width are unchanged. -->
-      <div class="line line-6"><span aria-hidden="true">+ [</span><a href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.21/Ghostties.dmg" download tabindex="-1">download now</a><span aria-hidden="true">]</span></div>
+      <div class="line line-6"><span aria-hidden="true">+ [</span><a href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.21/Ghostties.dmg" download>download now</a><span aria-hidden="true">]</span></div>
       </div>
     </div>
 
@@ -576,14 +583,14 @@
       <h2><span>Multiple agents.</span><span>One window.</span></h2>
       <div class="product-window product-window--sessions">
         <div class="product-card">
-          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" preload="auto" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
+          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
         </div>
       </div>
       <div class="product-caption">four sessions, one window</div>
 
       <div class="product-window product-window--flow">
         <div class="product-card">
-          <video src="/assets/product-flow.mp4" poster="/assets/product-flow-poster.jpg" preload="auto" autoplay muted loop playsinline aria-label="gt list showing every task across projects organized into status lanes like needs-you and running"></video>
+          <video src="/assets/product-flow.mp4" poster="/assets/product-flow-poster.jpg" autoplay muted loop playsinline aria-label="gt list showing every task across projects organized into status lanes like needs-you and running"></video>
         </div>
       </div>
       <div class="product-caption">gt list &mdash; every task, one lane</div>

--- a/web/index.html
+++ b/web/index.html
@@ -418,6 +418,7 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
   <div class="ghost-backdrop" aria-hidden="true">
     <div class="bg-ghost bg-ghost-1">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF4136" shape-rendering="crispEdges">
@@ -451,12 +452,15 @@
     </div>
   </div>
 
-  <div class="scene animate">
-    <div class="ghosts">
+  <main id="main">
+    <h1 class="visually-hidden">Ghostties — a multi-agent workspace terminal for macOS</h1>
+
+    <div class="scene animate">
+      <div class="ghosts" aria-hidden="true">
       <!-- Row 1: blinky (red) -->
       <div class="ghost-row">
         <div class="ghost g0">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF4136" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF4136" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="12" y="0" width="24" height="4"/><rect x="8" y="4" width="32" height="4"/><rect x="4" y="8" width="40" height="4"/><rect x="4" y="12" width="8" height="8"/><rect x="20" y="12" width="8" height="8"/><rect x="36" y="12" width="8" height="8"/><rect x="0" y="20" width="48" height="20"/><rect x="0" y="40" width="8" height="4"/><rect x="12" y="40" width="8" height="4"/><rect x="28" y="40" width="8" height="4"/><rect x="40" y="40" width="8" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="16" y="44" width="4" height="4"/><rect x="28" y="44" width="4" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
@@ -464,12 +468,12 @@
       <!-- Row 2: specter (purple), inky (cyan) -->
       <div class="ghost-row">
         <div class="ghost g1">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#7C4DFF" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#7C4DFF" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="12" y="0" width="24" height="4"/><rect x="4" y="4" width="40" height="4"/><rect x="0" y="8" width="48" height="4"/><rect x="0" y="12" width="8" height="4"/><rect x="16" y="12" width="16" height="4"/><rect x="40" y="12" width="8" height="4"/><rect x="0" y="16" width="4" height="4"/><rect x="16" y="16" width="16" height="4"/><rect x="44" y="16" width="4" height="4"/><rect x="0" y="20" width="48" height="20"/><rect x="0" y="40" width="8" height="4"/><rect x="16" y="40" width="16" height="4"/><rect x="40" y="40" width="8" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="20" y="44" width="8" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
         <div class="ghost g2">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#00BCD4" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#00BCD4" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="12" y="0" width="24" height="4"/><rect x="8" y="4" width="32" height="4"/><rect x="4" y="8" width="40" height="4"/><rect x="4" y="12" width="12" height="8"/><rect x="32" y="12" width="12" height="8"/><rect x="0" y="20" width="48" height="20"/><rect x="0" y="40" width="4" height="4"/><rect x="8" y="40" width="8" height="4"/><rect x="20" y="40" width="8" height="4"/><rect x="32" y="40" width="8" height="4"/><rect x="44" y="40" width="4" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="12" y="44" width="4" height="4"/><rect x="32" y="44" width="4" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
@@ -477,17 +481,17 @@
       <!-- Row 3: pinky (pink), clyde (orange), banshee (yellow) -->
       <div class="ghost-row">
         <div class="ghost g3">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF80AB" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF80AB" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="16" y="0" width="16" height="4"/><rect x="8" y="4" width="32" height="4"/><rect x="4" y="8" width="40" height="4"/><rect x="4" y="12" width="4" height="8"/><rect x="16" y="12" width="16" height="8"/><rect x="40" y="12" width="4" height="8"/><rect x="0" y="20" width="48" height="20"/><rect x="0" y="40" width="12" height="4"/><rect x="20" y="40" width="8" height="4"/><rect x="36" y="40" width="12" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
         <div class="ghost g4">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF9800" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FF9800" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="8" y="0" width="32" height="4"/><rect x="4" y="4" width="40" height="4"/><rect x="0" y="8" width="48" height="4"/><rect x="0" y="12" width="8" height="8"/><rect x="16" y="12" width="16" height="8"/><rect x="40" y="12" width="8" height="8"/><rect x="0" y="20" width="48" height="20"/><rect x="0" y="40" width="12" height="4"/><rect x="16" y="40" width="16" height="4"/><rect x="36" y="40" width="12" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="20" y="44" width="8" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
         <div class="ghost g5">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FFEB3B" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#FFEB3B" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="8" y="0" width="32" height="4"/><rect x="4" y="4" width="40" height="4"/><rect x="0" y="8" width="48" height="4"/><rect x="0" y="12" width="4" height="8"/><rect x="16" y="12" width="16" height="8"/><rect x="44" y="12" width="4" height="8"/><rect x="0" y="20" width="48" height="4"/><rect x="0" y="24" width="12" height="4"/><rect x="36" y="24" width="12" height="4"/><rect x="0" y="28" width="48" height="12"/><rect x="0" y="40" width="8" height="4"/><rect x="16" y="40" width="16" height="4"/><rect x="40" y="40" width="8" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="20" y="44" width="8" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
@@ -495,23 +499,23 @@
       <!-- Row 4: chill (light blue, round), dusk (muted purple) -->
       <div class="ghost-row">
         <div class="ghost g6">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#81D4FA" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#81D4FA" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="16" y="0" width="16" height="4"/><rect x="8" y="4" width="32" height="4"/><rect x="4" y="8" width="40" height="4"/><rect x="0" y="12" width="48" height="4"/><rect x="0" y="16" width="12" height="8"/><rect x="20" y="16" width="8" height="8"/><rect x="36" y="16" width="12" height="8"/><rect x="0" y="24" width="48" height="12"/><rect x="4" y="36" width="40" height="4"/><rect x="8" y="40" width="32" height="4"/><rect x="16" y="44" width="16" height="4"/>
           </svg>
         </div>
         <div class="ghost g7">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#7986CB" shape-rendering="crispEdges">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#7986CB" shape-rendering="crispEdges" aria-hidden="true">
             <rect x="8" y="0" width="32" height="4"/><rect x="4" y="4" width="40" height="4"/><rect x="0" y="8" width="48" height="4"/><rect x="0" y="12" width="12" height="4"/><rect x="20" y="12" width="28" height="4"/><rect x="0" y="16" width="8" height="4"/><rect x="20" y="16" width="28" height="4"/><rect x="0" y="20" width="12" height="4"/><rect x="20" y="20" width="28" height="4"/><rect x="0" y="24" width="48" height="16"/><rect x="0" y="40" width="8" height="4"/><rect x="16" y="40" width="16" height="4"/><rect x="40" y="40" width="8" height="4"/><rect x="0" y="44" width="4" height="4"/><rect x="20" y="44" width="8" height="4"/><rect x="44" y="44" width="4" height="4"/>
           </svg>
         </div>
       </div>
-    </div>
+      </div>
 
-    <div class="terminal">
+      <div class="terminal" aria-hidden="true">
       <!-- line-1: 14 chars: cd ~/ghostties -->
       <div class="line line-1">cd ~/ghostties</div>
       <!-- line-2: 43 chars: https://github.com/SeanSmithWorks/ghostties -->
-      <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithWorks/ghostties</a></div>
+      <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener" tabindex="-1">https://github.com/SeanSmithWorks/ghostties</a></div>
       <!-- line-3: 26 chars: - ghostties % install soon -->
       <div class="line line-3">- ghostties % install soon</div>
       <!-- line-4: 28 chars: + ghostties % v0.1.0-beta.21 -->
@@ -519,27 +523,31 @@
       <!-- line-5: 39 chars: + 02Aug2026 · macOS 13+ · Apple Silicon -->
       <div class="line line-5">+ 02Aug2026 &middot; macOS 13+ &middot; Apple Silicon</div>
       <!-- line-6: 16 chars: + [download now] (clickable) -->
-      <!-- Hardcoded DMG URL — bump the version tag with each release -->
-      <div class="line line-6"><a href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.21/Ghostties.dmg" download>+ [download now]</a></div>
-    </div>
-  </div>
-
-  <section class="product">
-    <h2><span>Multiple agents.</span><span>One window.</span></h2>
-    <div class="product-window product-window--sessions">
-      <div class="product-card">
-        <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
+      <!-- Hardcoded DMG URL — bump the version tag with each release. Decoration
+           ("+ [" / "]") sits outside the link so the accessible name is just
+           "download now"; both spans render normally, so the visible text and
+           the 16ch typing width are unchanged. -->
+      <div class="line line-6"><span aria-hidden="true">+ [</span><a href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.21/Ghostties.dmg" download tabindex="-1">download now</a><span aria-hidden="true">]</span></div>
       </div>
     </div>
-    <div class="product-caption">four sessions, one window</div>
 
-    <div class="product-window product-window--flow">
-      <div class="product-card">
-        <video src="/assets/product-flow.mp4" poster="/assets/product-flow-poster.jpg" autoplay muted loop playsinline aria-label="gt list showing every task across projects organized into status lanes like needs-you and running"></video>
+    <section class="product">
+      <h2><span>Multiple agents.</span><span>One window.</span></h2>
+      <div class="product-window product-window--sessions">
+        <div class="product-card">
+          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
+        </div>
       </div>
-    </div>
-    <div class="product-caption">gt list &mdash; every task, one lane</div>
-  </section>
+      <div class="product-caption">four sessions, one window</div>
+
+      <div class="product-window product-window--flow">
+        <div class="product-card">
+          <video src="/assets/product-flow.mp4" poster="/assets/product-flow-poster.jpg" autoplay muted loop playsinline aria-label="gt list showing every task across projects organized into status lanes like needs-you and running"></video>
+        </div>
+      </div>
+      <div class="product-caption">gt list &mdash; every task, one lane</div>
+    </section>
+  </main>
 
   <footer>
     <span class="footer-icons">

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#FF4136','#7C4DFF','#00BCD4','#FF80AB','#FF9800','#FFEB3B','#81D4FA','#7986CB'];
@@ -23,8 +23,11 @@
   <meta name="description" content="Ghostties — a multi-agent workspace terminal. Now in beta.">
   <meta property="og:title" content="ghostties">
   <meta property="og:description" content="A multi-agent workspace terminal. Now in beta.">
-  <meta property="og:image" content="/assets/poster.png">
+  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ghostties.org/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Homepage only. Shared tokens, reset, and footer base: /style.css */
@@ -573,14 +576,14 @@
       <h2><span>Multiple agents.</span><span>One window.</span></h2>
       <div class="product-window product-window--sessions">
         <div class="product-card">
-          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
+          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" preload="auto" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
         </div>
       </div>
       <div class="product-caption">four sessions, one window</div>
 
       <div class="product-window product-window--flow">
         <div class="product-card">
-          <video src="/assets/product-flow.mp4" poster="/assets/product-flow-poster.jpg" autoplay muted loop playsinline aria-label="gt list showing every task across projects organized into status lanes like needs-you and running"></video>
+          <video src="/assets/product-flow.mp4" poster="/assets/product-flow-poster.jpg" preload="auto" autoplay muted loop playsinline aria-label="gt list showing every task across projects organized into status lanes like needs-you and running"></video>
         </div>
       </div>
       <div class="product-caption">gt list &mdash; every task, one lane</div>

--- a/web/index.html
+++ b/web/index.html
@@ -106,13 +106,7 @@
     /* --- Terminal text --- */
     .terminal {
       font-family: var(--font-mono);
-      /* Fluid between 320px and 768px viewports; clamp()'s max caps it at
-         exactly 1.125rem for every viewport >= 768px, so desktop rendering
-         is byte-for-byte what it was before this was a clamp(). Below 768
-         the type shrinks enough that the 43ch GitHub-URL line (the widest
-         .line) fits inside .terminal's own clamped width without hitting
-         the overflow:hidden clip below, down to 320px. */
-      font-size: clamp(0.625rem, calc(0.625rem + (1.125rem - 0.625rem) * (100vw - 320px) / (768px - 320px)), 1.125rem);
+      font-size: 1.125rem; /* 18px */
       font-weight: 600;
       line-height: 2;
       color: var(--terminal-fg);
@@ -121,13 +115,8 @@
       margin: 0 auto;
       text-align: left;
       /* .line children animate to hard-coded ch widths (e.g. 43ch for the
-         GitHub URL). The fluid font-size above keeps that line inside
-         .terminal's own (correctly clamped) box at every width this site
-         supports; this stays as a hard backstop in case a future edit
-         reintroduces a line wider than the container, so it can only ever
-         clip content that's already wider than the container — at desktop
-         widths every line fits inside 46ch, so nothing here changes what's
-         rendered. */
+         GitHub URL). At narrow widths that line can exceed .terminal's own
+         width; clipping it beats letting it force horizontal page scroll. */
       overflow: hidden;
     }
 
@@ -438,9 +427,7 @@
       .ghost { width: 64px; height: 64px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      /* .terminal font-size is fluid (see its rule above) — no fixed
-         override here, or it would clobber the clamp() and reintroduce the
-         clipped GitHub URL this media query used to cause. */
+      .terminal { font-size: 1rem; } /* 16px */
       footer { padding: 12px 16px; font-size: 0.625rem; } /* 10px */
       .product { padding: 16px 20px 72px; }
       .product h2 { font-size: 1.375rem; margin-bottom: 28px; } /* 22px */
@@ -606,7 +593,12 @@
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 16l-5-5h3V4h4v7h3l-5 5zm-7 2h14v2H5v-2z"/></svg>
       </a>
     </span>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+    </span>
   </footer>
 
   <script>

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -23,11 +23,9 @@
   <meta name="description" content="Open-source licenses for Ghostties and its dependencies.">
   <meta property="og:title" content="Licenses — ghostties">
   <meta property="og:description" content="Open-source licenses for Ghostties and its dependencies.">
-  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ghostties.org/licenses">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Licenses page only. Shared base: /style.css */

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -27,7 +27,7 @@
 
     /* Section title — opts out of the shared uppercase eyebrow h2. */
     h2 {
-      font-size: 18px;
+      font-size: 1.125rem; /* 18px */
       font-weight: 600;
       letter-spacing: -0.01em;
       color: var(--text-heading-soft);
@@ -67,7 +67,7 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
   </footer>
 </body>
 </html>

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -42,6 +42,8 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <main id="main">
   <div class="content">
     <a class="back" href="/">&larr; ghostties</a>
 
@@ -62,6 +64,7 @@
 
     <p class="updated">Last updated April 27, 2026</p>
   </div>
+  </main>
 
   <footer>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Licenses — ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];
@@ -21,6 +21,13 @@
     })();
   </script>
   <meta name="description" content="Open-source licenses for Ghostties and its dependencies.">
+  <meta property="og:title" content="Licenses — ghostties">
+  <meta property="og:description" content="Open-source licenses for Ghostties and its dependencies.">
+  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ghostties.org/licenses">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Licenses page only. Shared base: /style.css */

--- a/web/licenses.html
+++ b/web/licenses.html
@@ -72,7 +72,13 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/licenses">Licenses</a>
+    </span>
   </footer>
 </body>
 </html>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -62,7 +62,7 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
   </footer>
 </body>
 </html>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -67,7 +67,13 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/licenses">Licenses</a>
+    </span>
   </footer>
 </body>
 </html>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy — ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];
@@ -21,6 +21,13 @@
     })();
   </script>
   <meta name="description" content="Ghostties privacy policy — what the app collects (nothing) and what network calls it makes.">
+  <meta property="og:title" content="Privacy — ghostties">
+  <meta property="og:description" content="Ghostties privacy policy — what the app collects (nothing) and what network calls it makes.">
+  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ghostties.org/privacy">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -24,6 +24,8 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <main id="main">
   <div class="content">
     <a class="back" href="/">&larr; ghostties</a>
 
@@ -57,6 +59,7 @@
 
     <p class="updated">Last updated April 26, 2026</p>
   </div>
+  </main>
 
   <footer>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -23,11 +23,9 @@
   <meta name="description" content="Ghostties privacy policy — what the app collects (nothing) and what network calls it makes.">
   <meta property="og:title" content="Privacy — ghostties">
   <meta property="og:description" content="Ghostties privacy policy — what the app collects (nothing) and what network calls it makes.">
-  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ghostties.org/privacy">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>

--- a/web/style.css
+++ b/web/style.css
@@ -386,7 +386,7 @@ footer svg {
    an item and its separator, never leave a dangling "·" at the end of a
    row. */
 .footer-links > * + *::before {
-  content: "\00B7";
+  content: "\00B7" / "";
   margin: 0 8px;
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -267,9 +267,13 @@ pre {
 
 /* Flex item in the body column. Explicit width keeps percentage-sized
    children (e.g. .scene, .content) resolving against a real containing
-   block instead of main's shrink-to-fit default. */
+   block instead of main's shrink-to-fit default. flex:1 makes main (not
+   footer's margin-top:auto) the thing that claims the column's free space
+   on short pages — that's what lets a page center its own content inside
+   <main> (see 404.html) while the footer still lands at the bottom. */
 main {
   width: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -332,11 +336,11 @@ footer {
      in the middle of the page instead of spanning edge to edge the way the
      old fixed/inset:0 footer did. Same reasoning as main's width:100% above. */
   width: 100%;
-  /* Pushes the footer to the bottom of the flex column: on short pages body's
-     min-height:100dvh gives the column room to grow into, and this margin
-     consumes it instead of leaving it as dead space below the footer. On
-     tall pages there's no free space to consume, so this is a no-op and the
-     footer sits right after the content, same as before. */
+  /* Pushes the footer to the bottom of the flex column on short pages. Now a
+     backstop, not the primary mechanism: main's flex:1 above is what claims
+     the column's free space, so this margin is normally a no-op. It stays
+     so the footer is still bottom-anchored if a page ever has content
+     outside <main> in the flex column. */
   margin-top: auto;
   display: flex;
   align-items: center;
@@ -363,6 +367,29 @@ footer svg {
   display: block;
 }
 
+/* Wrapping link row (copyright + Changelog/Privacy/Support[/Licenses], and
+   the same markup reused for index.html's footer). Real flex layout, not a
+   line-height trick: each link is a flex item, so padding on it is counted
+   in its own box and reserved by the row — unlike padding on a plain inline
+   element, which paints outside the line box without pushing anything
+   apart. That's what let two wrapped rows overlap before. row-gap adds
+   guaranteed clearance between wrapped rows on top of that. */
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 0;
+}
+
+/* Middot separators travel with the link that follows them (as ::before,
+   inside that link's own flex item) so a wrap can only ever break between
+   an item and its separator, never leave a dangling "·" at the end of a
+   row. */
+.footer-links > * + *::before {
+  content: "\00B7";
+  margin: 0 8px;
+}
+
 /* 7. Responsive ============================================================ */
 
 @media (max-width: 480px) {
@@ -377,22 +404,17 @@ footer svg {
   footer {
     padding: 12px 16px;
     font-size: var(--size-caption);
-    /* The link row wraps to two lines at this width. Padding on footer a
-       below grows each link's tap target to ~44px tall without changing the
-       line's own layout height, so with the browser's default line-height
-       the two wrapped lines sat only ~14px apart — nowhere near enough to
-       keep two 44px-tall boxes from overlapping. This is the row gap: it
-       has to grow, not the padding, or bigger targets just collide harder. */
-    line-height: 3.8;
   }
 
-  /* Touch targets: vertical padding on an inline element grows its
-     clickable box without adding to the line's layout height, so the tap
-     target grows while the visible text stays the same size and position.
-     Horizontal padding does add real space between links — an acceptable,
-     visible trade for hitting the 44px minimum. */
-  footer a {
-    padding: 15px 6px;
+  /* Touch targets: because .footer-links is a real flex row (see above),
+     padding here grows each link's box the same way it grows any block
+     box — reserved space, not just paint — so rows can't collide. 13px top
+     and bottom lands the box at ~40px tall against this caption-size text;
+     44px would need either a third row or padding large enough to make the
+     dot-separated row wrap earlier and orphan more links, so this trades
+     down to ~40px rather than risk overlap. */
+  .footer-links a {
+    padding: 13px 6px;
   }
 
   .back {

--- a/web/style.css
+++ b/web/style.css
@@ -23,15 +23,17 @@
   --surface-inline: rgba(255, 255, 255, 0.07); /* inline <code> */
 
   /* --- Text ramp (white on --bg) ---
-     Roles, densest to faintest. Several fail WCAG AA today; see DESIGN.md §3. */
+     Roles, densest to faintest. Alphas raised 2026-08-03 to clear WCAG AA
+     (4.5:1 body text) against --bg; see DESIGN.md §3 for the audit numbers
+     and web/DESIGN.md history for the pre-fix values. */
   --text-heading: #fff;
   --text-primary: rgba(255, 255, 255, 0.85); /* body default */
   --text-body: rgba(255, 255, 255, 0.65); /* prose, links */
-  --text-note: rgba(255, 255, 255, 0.45); /* callout copy */
-  --text-meta: rgba(255, 255, 255, 0.4); /* file size, release links */
-  --text-label: rgba(255, 255, 255, 0.35); /* eyebrows, back link, dates */
-  --text-label-quiet: rgba(255, 255, 255, 0.3); /* changelog subsections */
-  --text-faint: rgba(255, 255, 255, 0.25); /* footer, timestamps, bullets */
+  --text-note: rgba(255, 255, 255, 0.52); /* callout copy */
+  --text-meta: rgba(255, 255, 255, 0.5); /* file size, release links */
+  --text-label: rgba(255, 255, 255, 0.48); /* eyebrows, back link, dates */
+  --text-label-quiet: rgba(255, 255, 255, 0.46); /* changelog subsections */
+  --text-faint: rgba(255, 255, 255, 0.55); /* footer, timestamps, bullets */
   --text-heading-soft: rgba(255, 255, 255, 0.9); /* licenses section titles */
 
   /* --- Text hover pairs --- */
@@ -58,7 +60,7 @@
   --terminal-fg: #e0e0e0;
   --diff-add-fg: rgba(100, 220, 120, 0.9);
   --diff-add-bg: rgba(80, 210, 100, 0.13);
-  --diff-del-fg: rgba(255, 100, 100, 0.7);
+  --diff-del-fg: rgba(255, 100, 100, 0.95); /* 4.72:1 against its own diff-del-bg composite; see DESIGN.md §3 */
   --diff-del-bg: rgba(255, 80, 80, 0.13);
 
   /* --- Type --- */
@@ -114,6 +116,44 @@ body {
   padding: 64px 24px 96px;
   font-family: var(--font-ui);
   color: var(--text-primary);
+}
+
+/* Keyboard focus. Replaces the browser default with a visible ring that
+   reads against --bg; :focus-visible means it never shows on mouse/touch. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Visually hidden until focused — skip link, and reused for the homepage h1 */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 8px;
+  z-index: 100;
+  padding: 8px 16px;
+  background: var(--bg);
+  color: var(--text-primary);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 8px;
 }
 
 /* 3. Typography ============================================================ */
@@ -207,6 +247,16 @@ pre {
 }
 
 /* 4. Layout ================================================================ */
+
+/* Flex item in the body column. Explicit width keeps percentage-sized
+   children (e.g. .scene, .content) resolving against a real containing
+   block instead of main's shrink-to-fit default. */
+main {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 
 .content {
   width: 100%;

--- a/web/style.css
+++ b/web/style.css
@@ -60,7 +60,12 @@
   --terminal-fg: #e0e0e0;
   --diff-add-fg: rgba(100, 220, 120, 0.9);
   --diff-add-bg: rgba(80, 210, 100, 0.13);
-  --diff-del-fg: rgba(255, 100, 100, 0.95); /* 4.72:1 against its own diff-del-bg composite; see DESIGN.md §3 */
+  --diff-del-fg: rgba(
+    255,
+    100,
+    100,
+    0.95
+  ); /* 4.72:1 against its own diff-del-bg composite; see DESIGN.md §3 */
   --diff-del-bg: rgba(255, 80, 80, 0.13);
 
   /* --- Type --- */
@@ -69,13 +74,16 @@
     "SFMono-Regular", "SF Mono", "Fira Code", "Cascadia Code", "JetBrains Mono",
     monospace;
 
-  --size-caption: 12px;
-  --size-small: 13px;
-  --size-meta: 14px;
-  --size-body: 15px;
-  --size-lead: 16px;
-  --size-title-sm: 22px; /* h1 under 480px */
-  --size-title: 28px;
+  /* Sizes are rem against the unmodified 16px browser default — no page sets
+     a root font-size, so 1rem = 16px and every value below renders at the
+     same pixel size as its old px literal. */
+  --size-caption: 0.75rem; /* 12px */
+  --size-small: 0.8125rem; /* 13px */
+  --size-meta: 0.875rem; /* 14px */
+  --size-body: 0.9375rem; /* 15px */
+  --size-lead: 1rem; /* 16px */
+  --size-title-sm: 1.375rem; /* 22px, h1 under 480px */
+  --size-title: 1.75rem; /* 28px */
 
   --leading-snug: 1.6;
   --leading-body: 1.65;
@@ -229,6 +237,11 @@ code {
   padding: 1px 5px;
   border-radius: var(--radius-sm);
   color: rgba(255, 255, 255, 0.75);
+  /* Long unbroken paths (e.g. bundle IDs) have no natural break point;
+     without this the <code> run forces its container wider than the
+     viewport at narrow widths. Letting it break mid-token beats letting it
+     push the page into horizontal scroll. */
+  overflow-wrap: anywhere;
 }
 
 pre {
@@ -303,11 +316,18 @@ main {
 
 /* 6. Footer ================================================================ */
 
+/* Static, not fixed: a viewport-pinned footer renders on top of body text
+   on any page taller than one screen (confirmed colliding with a code span
+   on /support at mobile width). index.html re-pins its own footer to fixed
+   in its page <style> block — the homepage is a single, exactly-viewport-
+   height hero and is designed around a footer glued to its bottom edge. */
 footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  position: static;
+  /* body centers flex items by default (align-items:center), so without an
+     explicit width footer would shrink-wrap its content and float centered
+     in the middle of the page instead of spanning edge to edge the way the
+     old fixed/inset:0 footer did. Same reasoning as main's width:100% above. */
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -347,5 +367,19 @@ footer svg {
   footer {
     padding: 12px 16px;
     font-size: var(--size-caption);
+  }
+
+  /* Touch targets: vertical padding on an inline element grows its
+     clickable box without adding to the line's layout height, so the tap
+     target grows while the visible text stays the same size and position.
+     Horizontal padding does add real space between links — an acceptable,
+     visible trade for hitting the 44px minimum. */
+  footer a {
+    padding: 15px 6px;
+  }
+
+  .back {
+    padding: 14px 4px;
+    margin: -14px -4px 26px;
   }
 }

--- a/web/style.css
+++ b/web/style.css
@@ -23,9 +23,13 @@
   --surface-inline: rgba(255, 255, 255, 0.07); /* inline <code> */
 
   /* --- Text ramp (white on --bg) ---
-     Roles, densest to faintest. Alphas raised 2026-08-03 to clear WCAG AA
-     (4.5:1 body text) against --bg; see DESIGN.md §3 for the audit numbers
-     and web/DESIGN.md history for the pre-fix values. */
+     Alphas raised 2026-08-03 to clear WCAG AA (4.5:1 body text) against
+     --bg; see DESIGN.md §3 for the audit numbers and web/DESIGN.md history
+     for the pre-fix values. No longer densest-to-faintest in this order —
+     --text-faint (0.55) ended up brighter than --text-note/--text-meta/
+     --text-label/--text-label-quiet below it once each was raised only as
+     far as its own AA requirement demanded. All still pass AA; this list is
+     grouped by role (prose ramp, then footer/timestamp ramp), not by value. */
   --text-heading: #fff;
   --text-primary: rgba(255, 255, 255, 0.85); /* body default */
   --text-body: rgba(255, 255, 255, 0.65); /* prose, links */
@@ -40,7 +44,7 @@
   --text-body-hover: rgba(255, 255, 255, 0.9);
   --text-meta-hover: rgba(255, 255, 255, 0.65);
   --text-label-hover: rgba(255, 255, 255, 0.6);
-  --text-faint-hover: rgba(255, 255, 255, 0.5);
+  --text-faint-hover: rgba(255, 255, 255, 0.65);
 
   /* --- Lines --- */
   --line: rgba(255, 255, 255, 0.08);
@@ -113,7 +117,7 @@
 
 html,
 body {
-  min-height: 100%;
+  min-height: 100dvh;
   background: var(--bg);
 }
 
@@ -121,7 +125,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 64px 24px 96px;
+  padding: 64px 24px 64px;
   font-family: var(--font-ui);
   color: var(--text-primary);
 }
@@ -328,6 +332,12 @@ footer {
      in the middle of the page instead of spanning edge to edge the way the
      old fixed/inset:0 footer did. Same reasoning as main's width:100% above. */
   width: 100%;
+  /* Pushes the footer to the bottom of the flex column: on short pages body's
+     min-height:100dvh gives the column room to grow into, and this margin
+     consumes it instead of leaving it as dead space below the footer. On
+     tall pages there's no free space to consume, so this is a no-op and the
+     footer sits right after the content, same as before. */
+  margin-top: auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -357,7 +367,7 @@ footer svg {
 
 @media (max-width: 480px) {
   body {
-    padding: 48px 16px 88px;
+    padding: 48px 16px 48px;
   }
 
   h1 {
@@ -367,6 +377,13 @@ footer svg {
   footer {
     padding: 12px 16px;
     font-size: var(--size-caption);
+    /* The link row wraps to two lines at this width. Padding on footer a
+       below grows each link's tap target to ~44px tall without changing the
+       line's own layout height, so with the browser's default line-height
+       the two wrapped lines sat only ~14px apart — nowhere near enough to
+       keep two 44px-tall boxes from overlapping. This is the row gap: it
+       has to grow, not the padding, or bigger targets just collide harder. */
+    line-height: 3.8;
   }
 
   /* Touch targets: vertical padding on an inline element grows its

--- a/web/style.css
+++ b/web/style.css
@@ -417,6 +417,19 @@ footer svg {
     padding: 13px 6px;
   }
 
+  /* No middot at mobile widths: a wrap can land at any point depending on
+     link count and viewport, so any separator scheme risks a dangling
+     leading or trailing "·" on some row. Dropping it removes the
+     possibility entirely; the flex gap above already separates items. */
+  .footer-links {
+    gap: 6px 12px;
+  }
+
+  .footer-links > * + *::before {
+    content: none;
+    margin: 0;
+  }
+
   .back {
     padding: 14px 4px;
     margin: -14px -4px 26px;

--- a/web/support.html
+++ b/web/support.html
@@ -23,11 +23,9 @@
   <meta name="description" content="Support for Ghostties — system requirements, updates, and how to report bugs.">
   <meta property="og:title" content="Support — ghostties">
   <meta property="og:description" content="Support for Ghostties — system requirements, updates, and how to report bugs.">
-  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ghostties.org/support">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
+  <meta name="twitter:card" content="summary">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Support page only. Shared base: /style.css */

--- a/web/support.html
+++ b/web/support.html
@@ -71,7 +71,7 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
   </footer>
 </body>
 </html>

--- a/web/support.html
+++ b/web/support.html
@@ -40,6 +40,8 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <main id="main">
   <div class="content">
     <a class="back" href="/">&larr; ghostties</a>
 
@@ -66,6 +68,7 @@
 
     <p class="updated">Last updated April 26, 2026</p>
   </div>
+  </main>
 
   <footer>
     <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>

--- a/web/support.html
+++ b/web/support.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Support — ghostties</title>
-  <link rel="icon" type="image/svg+xml" href="">
+  <link rel="icon" type="image/svg+xml">
   <script>
     (function() {
       var colors = ['#e84855','#8b5cf6','#22d3ee','#f472b6','#f59e0b','#eab308','#38bdf8','#7c6f9c'];
@@ -20,7 +20,14 @@
       link.href = 'data:image/svg+xml;base64,' + btoa(svg);
     })();
   </script>
-  <meta name="description" content="Support for Ghostties — system requirements, known issues, and how to report bugs.">
+  <meta name="description" content="Support for Ghostties — system requirements, updates, and how to report bugs.">
+  <meta property="og:title" content="Support — ghostties">
+  <meta property="og:description" content="Support for Ghostties — system requirements, updates, and how to report bugs.">
+  <meta property="og:image" content="https://ghostties.org/assets/poster.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ghostties.org/support">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://ghostties.org/assets/poster.png">
   <link rel="stylesheet" href="/style.css">
   <style>
     /* Support page only. Shared base: /style.css */

--- a/web/support.html
+++ b/web/support.html
@@ -76,7 +76,13 @@
   </main>
 
   <footer>
-    <span>&copy; 2026 &nbsp;&middot;&nbsp; <a href="/changelog">Changelog</a> &nbsp;&middot;&nbsp; <a href="/privacy">Privacy</a> &nbsp;&middot;&nbsp; <a href="/support">Support</a> &nbsp;&middot;&nbsp; <a href="/licenses">Licenses</a></span>
+    <span class="footer-links">
+      <span>&copy; 2026</span>
+      <a href="/changelog">Changelog</a>
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/licenses">Licenses</a>
+    </span>
   </footer>
 </body>
 </html>

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -18,7 +18,20 @@
           "key": "Strict-Transport-Security",
           "value": "max-age=31536000; includeSubDomains"
         },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; media-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+        }
       ]
     },
     {


### PR DESCRIPTION
Remediates the parked items from the 2026-08-02 `impeccable` audit (Accessibility 1/4, Responsive 1/4, plus headers, perf, content staleness and footer consistency). Six commits, all inside `web/`.

Built by three implementer agents in sequence on one branch — every finding touched `style.css` and the same seven pages, so parallel branches would only have conflicted. Reviewed across **three adversarial rounds** by a separate agent running Chromium against baseline-vs-branch local servers at 320 / 375 / 414 / 480 / 768 / 900 / 1280.

## What shipped

**Accessibility**
- `<main>` landmark + skip link on all 7 pages; visually-hidden `<h1>` on index (there was none)
- `changelog.html` heading hierarchy fixed — it skipped H1 → H3 six times
- `:focus-visible` ring authored — `:focus`/`outline` previously returned **zero hits site-wide**
- Six contrast tokens raised to WCAG AA. Worst was the footer at **2.27:1 → 5.96:1**. Independently recomputed by the reviewer: `--text-note` 5.468 · `--text-meta` 5.156 · `--text-label` 4.857 · `--text-label-quiet` 4.570 · `--text-faint` 5.959 · `--diff-del-fg` 4.720
- Decorative ghost SVGs marked `aria-hidden`; only the *joke* terminal line is hidden from AT, so the version string, system requirements and repo URL stay in the accessibility tree

**Responsive**
- Horizontal overflow eliminated at every tested width. Baseline scrolled at 320/375/414/480/700/768/1280; branch is clean at all of them
- `<code>` now wraps — `/privacy` and `/support` overflowed 320px viewports
- Footers rebuilt as a real flex row with a `gap`. Previously four variants across seven pages, `position: fixed` with no background so they painted over body text on any page taller than the viewport
- Tap targets: zero overlapping hit boxes on all 7 pages at 320/375/414/480. Min target 73×41 (document pages), 44×38 (homepage), up from 13–16px
- All font sizes converted to `rem` — rendering verified pixel-identical at default settings

**Hardening / content**
- CSP, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy` added to `vercel.json`. Verified against the real jsdelivr-loaded `/flows` page: 6/6 mermaid diagrams render, zero CSP violations. The `/assets/*` cache scoping is untouched, so Sparkle still gets `appcast-*.xml` fresh
- `changelog.html` was two releases stale — beta.20 and beta.21 added, prose diffed line-by-line against `gh release view` and `CHANGELOG.md`, dates aligned to `CHANGELOG.md`
- OG/Twitter metadata added to all pages (five subpages had none)

## Open calls — yours, not made here

1. **The site has no correct social image.** `assets/poster.png` contains the dead `SeanSmithDesign` GitHub URL and the words "install soon", and at 1080×1080 X crops every line of text off it. Rather than ship that as the canonical share card, `og:image`/`twitter:image` were **removed** and `twitter:card` set to `summary`. A real 1200×630 image would let them go back in.
2. **With `og:image` removed, `poster.png` is now an unreferenced dead file.** Worth deleting. (An earlier draft of this description claimed it was also the homepage `<video>` poster and therefore visible in production — that was wrong. The two product videos have their own `product-sessions-poster.jpg` / `product-flow-poster.jpg`; `poster.png` was only ever the `og:image`.)
3. **Terracotta `--accent` now doubles as the focus-ring colour** (4.92:1, passes) on a site where terracotta was dropped as a brand colour.
4. **The hero terminal clips the GitHub URL on phones.** A fluid `clamp()` type scale fixes it, but it retunes the hero across 320–767px and drops to 10px monospace at 320. Built, then **deliberately reverted** — that's a design decision for you, not an agent. The containment fix that kills the actual scroll bug stayed.
5. **Mobile ghost size** stays on the backlog. An agent changed it 64px → 48px unprompted; reverted.

## Deliberately untouched

`task-flows.html` (pending the `/flows` keep-or-pull decision), `appcast-*.xml`, favicon randomisation, the hero animation timing, and the four app PRs waiting on runtime gates.

## Honest caveats

- **No screenshots in this description** — `gh` can't upload images to a PR body; that needs the web UI. Every layout claim above is `getBoundingClientRect()` / computed-style / AX-tree measurement rather than visual reading.
- Firefox is not installed on this machine, so the one novel CSS feature used (`content: "·" / ""` alt text) is verified in Chromium and WebKit only.
- Three review rounds each found real regressions **introduced by the previous round's fixes** — the a11y pass made the hero CTA keyboard-unreachable, the footer fix broke `/404` centring and left overlapping tap targets, and the footer rebuild put a middot on the front of every link's accessible name. All fixed and re-measured, but that hit rate is the reason this got three rounds instead of one.

Not merged — merging `main` auto-deploys Vercel production.
