### PR TITLE
docs: close out the documentation objective in BACKLOG + session notes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,9 +16,20 @@ Investigation only, no code written. Findings in `reference_terminal-images-work
 
 Objective (locked): repo documentation + correct Ghostty-vs-Ghostties calibration. All five refresh waves are merged to `main`; this wave adds the design layer that was missing.
 
-- [ ] **PR #80 — `docs/INFORMATION-ARCHITECTURE.md` + `docs/case-study-documentation-refresh.md`.** Open, MERGEABLE, CI green 4/4. Records the IA the refresh produced (audience model, the disambiguation-not-topic-tree principle, decay model per file, five questions before adding a doc) and the narrative of how it was arrived at, including that it was emergent rather than designed up front. Entry points added in `CONTRIBUTING.md` for humans and `AGENTS.md` for agents. | docs | ready-to-merge
-- [ ] **Should the case-study visuals live in the repo? — STRAWMAN: no, kill it.** GitHub markdown cannot render the CSS/SVG figures, so putting them in the repo means exporting PNGs. Images cannot be diffed, so they would go stale silently and break the decay-model rule the IA doc itself sets. Recommendation: repo docs stay textual; the visual version stays an Artifact for job and portfolio use. Only revisit if the repo docs are meant to carry imagery. | docs | decide-or-kill
+- [x] ~~**PR #80** — `docs/INFORMATION-ARCHITECTURE.md` + `docs/case-study-documentation-refresh.md`.~~ **Merged 2026-08-02 as `1c2ff4e82`.** Records the IA the refresh produced (audience model, the disambiguation-not-topic-tree principle, decay model per file, five questions before adding a doc) and the narrative of how it was arrived at. Entry points in `CONTRIBUTING.md` for humans and `AGENTS.md` for agents.
+- [x] ~~**Should the case-study visuals live in the repo?**~~ **DECIDED 2026-08-03: no, killed.** GitHub markdown cannot render the CSS/SVG figures, so putting them in the repo means exporting PNGs, and images cannot be diffed — they would go stale silently and break the decay-model rule the IA doc itself sets. Repo docs stay textual; the visual version stays an Artifact. Do not re-open as a question.
 - [ ] **Visual case study lives only as an Artifact.** `https://claude.ai/code/artifact/8bda1349-3010-4780-bee8-88ffe72e5c0c` — six figures (inherited-scale receipt, the auto-close trap, the routing fork, six entry points, the 3.8:1 deletion bar, CONTRIBUTING before/after) plus the inlined demo GIF. Private to Sean's account; it is not backed up in the repo and would need rebuilding from `docs/case-study-documentation-refresh.md` if lost. | docs | reference
+
+## 2026-08-03 — Wave 0 repo settings ✅ COMPLETE
+
+Every Wave 0 item is applied and verified live. Issues, Discussions, private vulnerability reporting, Dependabot **alerts**, 10 topics, and the 1280×640 social preview. The long-standing "needs Sean's login" note was wrong on every count — `gh api` reached the settings, and Claude in Chrome reached the social preview, for which **no REST or GraphQL endpoint exists**.
+
+Two follow-ups, neither blocking:
+
+- [ ] **The social-preview card has no preserved source.** It was rendered from a standalone HTML file in a session scratchpad, which is gone. Rebuilding is required to change the version string, the tagline, or the layout. Decide whether that source belongs in the repo (e.g. `.github/assets/social-preview.html` + a render note) or whether the Paper artboard below becomes the canonical one instead. | docs | decide-or-kill
+- [ ] **Paper promo artboard carries the pre-rename URL.** The Paper file "Ghostties" has three promo artboards (1200×630, 1080×1080, 1000×400). The 1200×630 one reads `github.com/SeanSmithDesign/ghostties` — the org renamed to `SeanSmithWorks` on 2026-07-21. Old URLs still redirect so nothing breaks, but it must be fixed before that artboard is exported for anything public. Also note 1200×630 is the OpenGraph standard; GitHub's optimum is 1280×640. | design | needs-Sean
+
+**Deliberately NOT enabled:** Dependabot *security updates* (the auto-PR feature, `/automated-security-fixes`). `.github/dependabot.yml` is still the inherited upstream config pointing at upstream paths, so auto-PRs would file against the wrong targets until that retarget lands.
 
 **Off-objective, parked deliberately:**
 

--- a/docs/SESSION_NOTES.md
+++ b/docs/SESSION_NOTES.md
@@ -2597,3 +2597,42 @@ Pickup session: full test suite was already green on `main` (`a41d842eb`). Tagge
 ### Commits this session (all via merged PRs)
 
 - `c9ce88fc5` (#47), `ccfa97a4b` (#49), `36ba41b4e` (#51), `fb4d2bec4` (#52)
+
+---
+
+## 2026-08-02/03 — documentation IA merged, Wave 0 closed, README hero fixed
+
+**Focus:** Finish the repo-documentation objective — merge the information-architecture PR, then turn on the repo settings the whole refresh was building toward. Phone-mode for the back half.
+
+### Shipped
+
+- **PR #80 merged** (`1c2ff4e82`) — `docs/INFORMATION-ARCHITECTURE.md` + `docs/case-study-documentation-refresh.md`, with entry points in `CONTRIBUTING.md` (humans) and `AGENTS.md` (agents). It was **not** in the state the pickup claimed: `CONFLICTING`/`DIRTY`, not "MERGEABLE, CI green." `main` had moved and #79's audit section collided with the docs-IA section at the same insertion point. Resolved keeping both, verified the diff against main was purely additive (zero deletions), then squashed.
+- **PR #84 merged** (`a1941d3ac`) — restored the README hero image. See below; this was a live bug, not cleanup.
+- **Wave 0 fully closed.** Issues, Discussions, private vulnerability reporting, Dependabot **alerts**, 10 topics, and the 1280×640 social preview — all applied and verified live.
+
+### The README hero was broken in production
+
+`README.md` line 5 embedded `web/assets/product-hero.png`, which did not exist on `main`. **The repo front page had been rendering a broken image** since PR #77 merged.
+
+Cause: #75 (`d7bdf050e`) landed the README referencing that path; #77 (`3c97d5456`, "clear six live web bugs — orphaned assets") then deleted the file. It was not orphaned. The web audit checked the *site's* HTML for references and correctly found none — nothing checked the README.
+
+Fixed by restoring from history into `.github/assets/`, next to the `demo.gif` the README already used. Restoring it in place would have left the cause intact: `web/assets/` is owned by the website work-stream and is being actively pruned (#77, #81, more queued), so a README-only asset there invites the same deletion again.
+
+Then link-checked every relative link and image target across all 11 fork-owned docs: **1 broken before, 0 after.** `CHANGELOG.md` verified current with beta.21.
+
+### Discovered / learned
+
+- **"Needs Sean's login" was wrong on every Wave 0 item.** The repo settings were all reachable from the `gh` token (`has_issues`, `has_discussions`, `/private-vulnerability-reporting`, `/vulnerability-alerts`, `/topics`).
+- **Social preview: no API exists, but it is still automatable.** Verified against GitHub docs and two open community requests — no REST or GraphQL endpoint sets it. Uploaded it anyway via **Claude in Chrome**. Two gotchas worth keeping: use `file_upload` against the input's ref and **never click the file input** (that opens a native picker automation cannot see); and GitHub commits on file-select with no Save button, so verify by the `og:image` host flipping from `opengraph.githubassets.com` (default card) to `repository-images.githubusercontent.com` (custom upload) — the settings form renders a preview either way.
+- **Ordering that mattered:** `.github/ISSUE_TEMPLATE/config.yml` links to `/security/advisories/new`, which 404s unless private vulnerability reporting is on. Enabling Issues alone would have shipped a broken link on day one.
+- **Left off deliberately:** Dependabot *security updates* (auto-PRs). `.github/dependabot.yml` is still the inherited upstream config, so auto-PRs would target the wrong paths until that retarget lands.
+
+### Carried to BACKLOG (2026-08-03)
+
+- Social-preview card has no preserved source (rendered from a scratchpad HTML file, now gone) — decide whether it belongs in the repo.
+- Paper's 1200×630 promo artboard still carries the pre-rename `SeanSmithDesign` URL; must be fixed before that artboard is exported publicly.
+
+### Commits this session (both via merged PRs)
+
+- `1c2ff4e82` (#80) — docs: record the information architecture and how it was arrived at
+- `a1941d3ac` (#84) — fix(docs): restore the README hero image


### PR DESCRIPTION
Session wrap for the repo-documentation objective. Docs only — no code.

## BACKLOG.md

- **PR #80** marked merged (`1c2ff4e82`) instead of "Open, MERGEABLE | ready-to-merge", which went stale the moment it landed.
- **Case-study visuals** marked decided (killed) instead of `decide-or-kill`. That call was already made; leaving it open reads as an unanswered question to the next session.
- **New section: Wave 0 complete** — Issues, Discussions, private vulnerability reporting, Dependabot alerts, 10 topics, social preview. Plus a note on why Dependabot *security updates* are deliberately still off (`dependabot.yml` still targets upstream paths).
- **Two follow-ups carried forward**, both real:
  - The social-preview card has no preserved source — it was rendered from a scratchpad HTML file that no longer exists.
  - Paper's 1200×630 promo artboard still reads `github.com/SeanSmithDesign/ghostties`, from before the 2026-07-21 org rename.

## docs/SESSION_NOTES.md

Covers the README hero regression (broken on the public front page since #77 deleted the image as an "orphaned asset" — it wasn't, the README embeds it), and the two findings worth reusing:

- Every Wave 0 setting was reachable from the `gh` token. The long-standing "needs Sean's login" note was wrong.
- The social preview has **no** REST or GraphQL endpoint, but browser automation reaches it. Verify by the `og:image` host flipping to `repository-images.githubusercontent.com` — the settings form renders a preview whether or not the upload took.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01538wgu5rLs9C1XmP186do6
