### PR TITLE
fix(sidebar): Cmd+Shift+[/] cycles the Sessions tab's own order

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,6 +35,18 @@ Two follow-ups, neither blocking:
 
 - [ ] **Idea-log prune** — 10 of 31 captures in `tease-capture.md` are older than 30 days and unacted-on, which is that file's own documented prune threshold (1 from May, 9 from June). Surfaced at `/wrap` 2026-08-02, nothing deleted. Spans projects, so it is not this thread's objective. | ops | needs-Sean
 
+## 2026-08-03 — stale live indicator in Sessions tab ACTIVE zone
+
+Found during PR #90 review (`fix/sessions-tab-cycle-order`). Exited sessions render
+in the Sessions tab's ACTIVE zone with a stale live indicator until relaunched or
+removed: `handleSurfaceClose` (`SessionCoordinator.swift`) removes the session tree
+and sets `.exited`/`.completed`/`.error` but never calls `removeIndicatorState`, and
+the 1 Hz tick only iterates statuses where `isAlive`, so the stale indicator never
+clears. Pre-existing display bug, not introduced by #90 — but it's what made the
+Cmd+Shift+[/] cycling regression reachable (a dead session sitting in ACTIVE with a
+live-looking indicator). Root-cause fix would clear indicator state on session exit;
+deferred because it touches what lands in Archive. | craft | quick
+
 ## 2026-08-03 — repo branch/PR cleanup ✅ COMPLETE
 
 Objective (locked): clean up ghostties branches and PRs. **Done.** Origin branches

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -247,17 +247,42 @@ struct WorkspaceSidebarView: View {
         expandedProjectIds.insert(targetId)
     }
 
-    /// Cmd+Shift+]/[ in Projects/Sessions tabs. Cycles focus through every
-    /// session with a live surface (`store.sessionsInVisualOrder(coordinator:)`
-    /// — not just `.running` ones, so cycling matches the browser-tab mental
-    /// model and what's actually visible in the sidebar), wrapping at both
-    /// ends. No-ops (no beep, no crash) when there are zero live sessions; is
-    /// a no-op when there is exactly one.
+    /// Cmd+Shift+]/[ in Projects/Sessions tabs. Cycles focus through the
+    /// sessions visible in whichever tab is active, wrapping at both ends.
+    /// No-ops (no beep, no crash) when there are zero live sessions; is a
+    /// no-op when there is exactly one.
+    ///
+    /// - Projects tab: every session with a live surface
+    ///   (`store.sessionsInVisualOrder(coordinator:)` — not just `.running`
+    ///   ones, so cycling matches the browser-tab mental model and what's
+    ///   actually visible in the sidebar).
+    /// - Sessions tab: the ACTIVE zone only, in exactly the order
+    ///   `RecentsListView` renders it (`RecentsListView.activeSessions`) —
+    ///   the same static both use, so render order and cycle order can never
+    ///   drift apart. Archive rows are skipped.
+    ///
+    /// `expandedProjectIds`/`selectedProjectId` are Projects-tab-only
+    /// concepts (disclosure expansion + the Projects list's own selection
+    /// cursor). Writing them from the Sessions tab is not just inert — it's
+    /// actively wrong: `selectedProjectId`'s `onChange` calls
+    /// `coordinator.focusLastSession(forProject:)`, which would immediately
+    /// re-focus that project's *last-active* session and stomp the session
+    /// we just cycled to. Scoped to the Projects-tab branch only.
     private func selectAdjacentLiveSession(offset: Int) {
-        let liveSessions = store.sessionsInVisualOrder(coordinator: coordinator)
+        let liveSessions: [AgentSession]
+        if sidebarTab == .sessions {
+            liveSessions = RecentsListView.activeSessions(
+                from: store.sessions,
+                indicatorStates: store.globalIndicatorStates
+            )
+        } else {
+            liveSessions = store.sessionsInVisualOrder(coordinator: coordinator)
+        }
         guard let target = coordinator.focusAdjacentLiveSession(offset: offset, in: liveSessions) else { return }
-        expandedProjectIds.insert(target.projectId)
-        selectedProjectId = target.projectId
+        if sidebarTab == .projects {
+            expandedProjectIds.insert(target.projectId)
+            selectedProjectId = target.projectId
+        }
     }
 }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -262,18 +262,18 @@ struct WorkspaceSidebarView: View {
     ///   drift apart. Archive rows are skipped.
     ///
     /// `expandedProjectIds`/`selectedProjectId` are Projects-tab-only
-    /// concepts (disclosure expansion + the Projects list's own selection
-    /// cursor). Writing them from the Sessions tab is not just inert — it's
-    /// actively wrong: `selectedProjectId`'s `onChange` calls
-    /// `coordinator.focusLastSession(forProject:)`, which would immediately
-    /// re-focus that project's *last-active* session and stomp the session
-    /// we just cycled to. Scoped to the Projects-tab branch only.
+    /// concepts. On the Sessions tab, writing them would be inert: nothing
+    /// there reads either — `RecentsListView` derives row highlight and
+    /// auto-expand from `coordinator.activeSessionId`. On the Projects tab,
+    /// writing them is redundant with `focusSession`, which already updates
+    /// `lastActiveSessionPerProject`. Scoped to the Projects-tab branch only.
     private func selectAdjacentLiveSession(offset: Int) {
         let liveSessions: [AgentSession]
         if sidebarTab == .sessions {
-            liveSessions = RecentsListView.activeSessions(
-                from: store.sessions,
-                indicatorStates: store.globalIndicatorStates
+            liveSessions = Self.sessionsTabCycleOrder(
+                sessions: store.sessions,
+                indicatorStates: store.globalIndicatorStates,
+                coordinator: coordinator
             )
         } else {
             liveSessions = store.sessionsInVisualOrder(coordinator: coordinator)
@@ -283,6 +283,26 @@ struct WorkspaceSidebarView: View {
             expandedProjectIds.insert(target.projectId)
             selectedProjectId = target.projectId
         }
+    }
+
+    /// The Sessions-tab cycle order: the ACTIVE zone in render order,
+    /// filtered to sessions that still have a live surface. Extracted as a
+    /// static so tests can call the exact composition `selectAdjacentLiveSession`
+    /// uses without instantiating a view inside SwiftUI's environment.
+    ///
+    /// `RecentsListView.activeSessions` guarantees nothing about liveness —
+    /// it filters on indicator state only, so an exited session can sit in
+    /// ACTIVE with a stale indicator (`handleSurfaceClose` doesn't clear it).
+    /// Without the `hasLiveSurface` filter, cycling onto such a session
+    /// bails inside `focusSession`'s live-tree guard while `activeSessionId`
+    /// never moves, permanently dead-ending forward cycling.
+    static func sessionsTabCycleOrder(
+        sessions: [AgentSession],
+        indicatorStates: [UUID: SessionIndicatorState],
+        coordinator: SessionCoordinator
+    ) -> [AgentSession] {
+        RecentsListView.activeSessions(from: sessions, indicatorStates: indicatorStates)
+            .filter { coordinator.hasLiveSurface(id: $0.id) }
     }
 }
 

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -251,6 +251,56 @@ final class RecentsListViewTests: XCTestCase {
         ), "Active must not force-expand for the selected session — only Archive gets that override")
     }
 
+    // MARK: - Sessions-tab Cmd+Shift+[/] cycle order (single shared source)
+
+    /// `WorkspaceSidebarView.selectAdjacentLiveSession(offset:)` feeds the
+    /// Sessions tab's Cmd+Shift+[/] cycle from
+    /// `RecentsListView.activeSessions(from:indicatorStates:)` — the exact
+    /// same static the tab renders the ACTIVE zone from — so cycle order can
+    /// never drift from render order. This exercises that composition end to
+    /// end: build the ACTIVE zone the same way the tab does, then cycle
+    /// through it via `SessionCoordinator.focusAdjacentLiveSession(offset:in:)`,
+    /// asserting both forward and backward wraparound. Archive rows (no live
+    /// indicator state) must be skipped entirely.
+    @MainActor
+    func testSessionsTabCycleOrderMatchesActiveZoneRenderOrderWithWraparound() {
+        let project = Project(name: "p", rootPath: "~/p")
+        let a = AgentSession(name: "a", templateId: UUID(), projectId: project.id)
+        let b = AgentSession(name: "b", templateId: UUID(), projectId: project.id)
+        let c = AgentSession(name: "c", templateId: UUID(), projectId: project.id)
+        let archived = AgentSession(name: "archived", templateId: UUID(), projectId: project.id)
+
+        let indicatorStates: [UUID: SessionIndicatorState] = [
+            a.id: .processing,
+            b.id: .waiting,
+            c.id: .idle,
+            // archived.id intentionally absent -> resolves .inactive -> Archive, not Active.
+        ]
+
+        // Same call the Sessions tab renders from — the single shared source.
+        let activeZone = RecentsListView.activeSessions(
+            from: [a, b, c, archived],
+            indicatorStates: indicatorStates
+        )
+        XCTAssertEqual(activeZone.map(\.name), ["a", "b", "c"], "must match the ACTIVE zone RecentsListView renders")
+
+        let coordinator = SessionCoordinator()
+        for session in activeZone {
+            coordinator.seedEmptySessionTreeForTesting(id: session.id)
+        }
+
+        // No active session yet -> forward cycle starts at the first entry.
+        XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: 1, in: activeZone)?.name, "a")
+        // Forward from a -> b -> c -> wraps back to a.
+        XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: 1, in: activeZone)?.name, "b")
+        XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: 1, in: activeZone)?.name, "c")
+        XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: 1, in: activeZone)?.name, "a", "must wrap forward past the end")
+
+        // Backward from a -> wraps to c.
+        XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: -1, in: activeZone)?.name, "c", "must wrap backward past the start")
+        XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: -1, in: activeZone)?.name, "b")
+    }
+
     // MARK: - Relative Time Labels
 
     func testRelativeLabelJustNow() {

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -257,10 +257,12 @@ final class RecentsListViewTests: XCTestCase {
     /// Sessions tab's Cmd+Shift+[/] cycle from
     /// `RecentsListView.activeSessions(from:indicatorStates:)` — the exact
     /// same static the tab renders the ACTIVE zone from — so cycle order can
-    /// never drift from render order. This exercises that composition end to
-    /// end: build the ACTIVE zone the same way the tab does, then cycle
-    /// through it via `SessionCoordinator.focusAdjacentLiveSession(offset:in:)`,
-    /// asserting both forward and backward wraparound. Archive rows (no live
+    /// never drift from render order. This does NOT exercise that
+    /// composition end to end (the production method is private on a
+    /// SwiftUI view and isn't called here); it builds the ACTIVE zone with
+    /// the same static and cycles it directly via
+    /// `SessionCoordinator.focusAdjacentLiveSession(offset:in:)`, asserting
+    /// both forward and backward wraparound. Archive rows (no live
     /// indicator state) must be skipped entirely.
     @MainActor
     func testSessionsTabCycleOrderMatchesActiveZoneRenderOrderWithWraparound() {
@@ -299,6 +301,56 @@ final class RecentsListViewTests: XCTestCase {
         // Backward from a -> wraps to c.
         XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: -1, in: activeZone)?.name, "c", "must wrap backward past the start")
         XCTAssertEqual(coordinator.focusAdjacentLiveSession(offset: -1, in: activeZone)?.name, "b")
+    }
+
+    /// Regression test for the dead-end-cycling bug: the ACTIVE zone
+    /// guarantees nothing about liveness (`RecentsListView.activeSessions`
+    /// filters only on indicator state, not on whether a session still has
+    /// a live surface), so a session can sit in ACTIVE with a stale
+    /// indicator after its surface has closed. `selectAdjacentLiveSession`
+    /// must filter the ACTIVE zone down to `coordinator.hasLiveSurface`
+    /// before cycling, matching what the Projects-tab branch already does
+    /// via `sessionsInVisualOrder`. Seeds live surfaces for `a` and `c` but
+    /// not `b`, so the production filter must drop `b` from the cycle.
+    ///
+    /// Asserts on `coordinator.activeSessionId`, not on
+    /// `focusAdjacentLiveSession`'s return value: `focusSession` bails via
+    /// `guard let tree = sessionTrees[id] else { return }` when the target
+    /// has no live surface, but the caller still returns the target
+    /// non-nil, so the return value alone can't tell success from a no-op.
+    @MainActor
+    func testSessionsTabCycleSkipsActiveZoneEntriesWithoutLiveSurface() {
+        let project = Project(name: "p", rootPath: "~/p")
+        let a = AgentSession(name: "a", templateId: UUID(), projectId: project.id)
+        let b = AgentSession(name: "b", templateId: UUID(), projectId: project.id)
+        let c = AgentSession(name: "c", templateId: UUID(), projectId: project.id)
+
+        let indicatorStates: [UUID: SessionIndicatorState] = [
+            a.id: .processing,
+            b.id: .waiting,
+            c.id: .idle,
+        ]
+
+        let coordinator = SessionCoordinator()
+        // b never gets a live surface -> stale indicator, exited session.
+        coordinator.seedEmptySessionTreeForTesting(id: a.id)
+        coordinator.seedEmptySessionTreeForTesting(id: c.id)
+
+        // The exact composition `selectAdjacentLiveSession` uses on the
+        // Sessions tab — calls through the production static, not a
+        // reimplementation of it.
+        let liveSessions = WorkspaceSidebarView.sessionsTabCycleOrder(
+            sessions: [a, b, c],
+            indicatorStates: indicatorStates,
+            coordinator: coordinator
+        )
+        XCTAssertEqual(liveSessions.map(\.name), ["a", "c"], "b has no live surface and must be excluded from the cycle")
+
+        _ = coordinator.focusAdjacentLiveSession(offset: 1, in: liveSessions)
+        XCTAssertEqual(coordinator.activeSessionId, a.id, "cycle starts at a")
+
+        _ = coordinator.focusAdjacentLiveSession(offset: 1, in: liveSessions)
+        XCTAssertEqual(coordinator.activeSessionId, c.id, "cycling forward from a must skip b and land on c")
     }
 
     // MARK: - Relative Time Labels


### PR DESCRIPTION
## Summary
- `Cmd+Shift+[`/`]` on the Sessions tab was cycling the Projects-tab order (`store.sessionsInVisualOrder`) instead of the flat ACTIVE-zone order the Sessions tab actually renders, so the keybinding never landed on the visually adjacent session.
- `selectAdjacentLiveSession(offset:)` is now tab-aware: on the Sessions tab it cycles `RecentsListView.activeSessions(from:indicatorStates:)` directly — the same static `RecentsListView` uses to render the ACTIVE zone — so render order and cycle order share one source and can't drift apart again. Archive rows are skipped.
- `expandedProjectIds`/`selectedProjectId` writes are now scoped to the Projects-tab branch only. They're Projects-tab concepts (disclosure state + that tab's selection cursor).
- Projects-tab behavior is unchanged — same call (`store.sessionsInVisualOrder(coordinator:)`), same side effects, just gated behind `sidebarTab == .projects`.

## Review round 2 fixes
- **Liveness filter (the regression):** `RecentsListView.activeSessions` guarantees nothing about whether a session still has a live surface — it filters on indicator state only, and `handleSurfaceClose` never clears indicator state on exit. So an exited session could sit in the ACTIVE zone with a stale live-looking indicator; cycling onto it silently dead-ended forward cycling (`focusSession` bails on a missing live tree, but the caller still returns the target non-nil). `selectAdjacentLiveSession`'s Sessions-tab branch now filters through `coordinator.hasLiveSurface`, matching the guarantee the Projects-tab branch already had via `sessionsInVisualOrder`.
- **Doc comment corrected:** the claim that writing `selectedProjectId` from the Sessions tab was "actively wrong" (would stomp the cycled session via `focusLastSession(forProject:)`) was refuted in review — `focusSession` updates `lastActiveSessionPerProject` *before* `selectedProjectId` is assigned, so the resulting re-focus is idempotent, not a stomp. Comment now states the real reason: inert on the Sessions tab, redundant on the Projects tab.
- **Regression test added:** `testSessionsTabCycleSkipsActiveZoneEntriesWithoutLiveSurface` seeds live surfaces for 2 of 3 ACTIVE-zone sessions and asserts on `coordinator.activeSessionId` (not `focusAdjacentLiveSession`'s return value, which lies here). Extracted the Sessions-tab composition into `WorkspaceSidebarView.sessionsTabCycleOrder` (static) so the test calls the actual production path — `selectAdjacentLiveSession` is a private method on a SwiftUI `View` and isn't reachable from XCTest even with `@testable`. Verified: fails without the liveness filter, passes with it.
- **BACKLOG entry added** for the underlying stale-indicator bug (pre-existing, not introduced by this PR, but what made the cycling regression reachable).

## Test plan
- [x] `testSessionsTabCycleOrderMatchesActiveZoneRenderOrderWithWraparound` — ACTIVE-zone composition + forward/backward wraparound, Archive exclusion.
- [x] `testSessionsTabCycleSkipsActiveZoneEntriesWithoutLiveSurface` — new regression test; confirmed red without the liveness filter, green with it.
- [x] Full unfiltered `xcodebuild test`: 627 unique tests, 0 failed, 1 skipped (`BenchmarkTests/example()`) — 2 more than the 625/0/1 pre-PR baseline (this PR's own new tests), no regressions.
- [x] `swiftlint lint` on both changed files: 0 violations.
- [x] `xcodebuild build` succeeds (`ONLY_ACTIVE_ARCH=YES ARCHS=arm64`, `-derivedDataPath macos/build`).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01BqQb3MidbaFrgmv7hys61E