### PR TITLE
fix(sessions): clear cached indicator state when a session's status goes terminal

### DIFF
--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -1277,9 +1277,26 @@ final class SessionCoordinator: ObservableObject {
     }
 
     /// Update a session's status locally and in the global store.
+    ///
+    /// Terminal statuses (`.completed`/`.exited`/`.killed`) also clear the
+    /// cached indicator state: once a session stops being polled by the 1Hz
+    /// tick (which only iterates `statuses where status.isAlive`), nothing
+    /// else would ever recompute its indicator, leaving a stale live value
+    /// behind. Clearing the cache entry makes lookups fall back to
+    /// `.inactive` (the existing `?? .inactive` pattern at read sites), which
+    /// matches what `indicatorState(for:)` would compute for these statuses
+    /// anyway if it were called again. `.error` is intentionally left alone —
+    /// `indicatorState(for:)` returns `.error` for that status to keep failed
+    /// sessions visible.
     private func setStatus(_ status: SessionStatus, for id: UUID) {
         statuses[id] = status
         WorkspaceStore.shared.updateSessionStatus(id: id, status: status)
+        switch status {
+        case .completed, .exited, .killed:
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        case .running, .error:
+            break
+        }
     }
 
     deinit {

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -1286,28 +1286,34 @@ final class SessionCoordinator: ObservableObject {
 
     /// Update a session's status locally and in the global store.
     ///
-    /// Terminal statuses (`.completed`/`.exited`/`.killed`) also clear the
-    /// cached indicator state, in both places it lives: once a session stops
-    /// being polled by the 1Hz tick (which only iterates
-    /// `statuses where status.isAlive`), nothing else would ever recompute
-    /// its indicator, leaving a stale live value behind.
+    /// Both the store's and the coordinator's own indicator caches must be
+    /// kept coherent here, because once a session stops being alive it drops
+    /// out of the 1Hz tick's `statuses where status.isAlive` loop — nothing
+    /// else will ever recompute or self-heal its cached indicator again:
     ///
     /// - `WorkspaceStore.shared`'s `globalIndicatorStates` is what every view
-    ///   reads. Clearing it makes lookups fall back to `.inactive` (the
-    ///   existing `?? .inactive` pattern at read sites).
+    ///   reads.
     /// - `cachedIndicatorStates` here is the change-comparator the 1Hz tick
-    ///   uses to decide whether to publish (`Perf.publishIfChanged`). If this
-    ///   entry isn't cleared too, a relaunch of the same session id computes
-    ///   the same pre-death state on the first post-relaunch tick, the
-    ///   comparator sees no change, and the publish (and the store write) is
-    ///   suppressed — leaving the store empty for a live, running session.
+    ///   uses to decide whether to publish (`Perf.publishIfChanged`), which
+    ///   swaps in `current` (built only from alive sessions) wholesale on
+    ///   every publish. A dead session's key survives in that comparator
+    ///   only until the *next* tick that actually runs a publish — but if
+    ///   this was the last alive session, `hasRunning` goes false and the
+    ///   tick body (including that swap) never runs again, freezing the
+    ///   stale entry indefinitely.
     ///
-    /// `.error` is intentionally left alone for now: `indicatorState(for:)`
-    /// is only ever called for sessions where `status.isAlive`, so once a
-    /// session reaches `.error` (not alive) its cached/stored indicator
-    /// simply keeps whatever value it last held before failing — typically
-    /// its last live state, not a distinct error indicator. Changing that is
-    /// an open design decision, not addressed here.
+    /// Terminal, non-error statuses (`.completed`/`.exited`/`.killed`) clear
+    /// both caches, so lookups fall back to `.inactive` (the existing
+    /// `?? .inactive` pattern at read sites) and the session drops to
+    /// ARCHIVE. `.error` writes `.error` into both caches instead of
+    /// clearing them, so the failed session gets a distinct error indicator
+    /// and stays visible in ACTIVE until relaunched or Removed. Writing
+    /// `cachedIndicatorStates` (not just the store) here matters for the
+    /// same reason the terminal-status clear does: without it, relaunching
+    /// the same session id could recompute a value that coincidentally
+    /// matches the stale pre-error cache entry, suppressing the publish and
+    /// leaving the store stuck on `.error` for a session that is actually
+    /// running again.
     private func setStatus(_ status: SessionStatus, for id: UUID) {
         statuses[id] = status
         WorkspaceStore.shared.updateSessionStatus(id: id, status: status)
@@ -1315,7 +1321,10 @@ final class SessionCoordinator: ObservableObject {
         case .completed, .exited, .killed:
             cachedIndicatorStates?.removeValue(forKey: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
-        case .running, .error:
+        case .error:
+            cachedIndicatorStates?[id] = .error
+            WorkspaceStore.shared.updateIndicatorState(id: id, state: .error)
+        case .running:
             break
         }
     }

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -1152,49 +1152,57 @@ final class SessionCoordinator: ObservableObject {
     private func startActivityTimer() {
         activityTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
-                guard let self else { return }
-                // Only fire objectWillChange if there are running sessions that could transition.
-                let hasRunning = self.statuses.values.contains { $0.isAlive }
-                if hasRunning {
-                    let runningCount = self.statuses.values.lazy.filter { $0.isAlive }.count
-                    let tickState = Perf.signposter.beginInterval("sessionCoordinator.tick", "\(runningCount) running sessions")
-
-                    // Compute current indicator states for all running sessions.
-                    var current: [UUID: SessionIndicatorState] = [:]
-                    for (id, status) in self.statuses where status.isAlive {
-                        current[id] = self.indicatorState(for: id)
-                    }
-
-                    // SEA-214: Only send objectWillChange when state actually changed,
-                    // suppressing the 7-view full-sidebar re-render that fired every second.
-                    //
-                    // Store writes (WorkspaceStore) are moved inside the same changed-branch
-                    // so the @Published dict assignments and updateProjectActivity only run
-                    // when the aggregate state actually shifted. The guards in
-                    // WorkspaceStore.updateIndicatorState / updateSessionStatus are a
-                    // belt-and-suspenders second layer but this avoids even the dict lookup
-                    // churn on no-change ticks.
-                    Perf.publishIfChanged(
-                        "sessionCoordinator.tick",
-                        current: current,
-                        cached: &self.cachedIndicatorStates
-                    ) {
-                        self.objectWillChange.send()
-
-                        // Push each running session's indicator state to the global store
-                        // so the menu bar icon can reflect the aggregate status.
-                        for (id, state) in current {
-                            WorkspaceStore.shared.updateIndicatorState(id: id, state: state)
-                        }
-
-                        // Refresh the per-project grace-period tracker so projects
-                        // whose sessions emit output at <1Hz still keep their
-                        // `.activeNow` slot for the full grace window.
-                        WorkspaceStore.shared.updateProjectActivityFromIndicatorStates()
-                    }
-                    Perf.signposter.endInterval("sessionCoordinator.tick", tickState)
-                }
+                self?.performActivityTick()
             }
+        }
+    }
+
+    /// The 1Hz tick body: recompute indicator states for all live sessions
+    /// and publish to the global store if anything changed. Extracted from
+    /// `startActivityTimer`'s timer closure so it can be invoked directly
+    /// (by the real timer, or synchronously by tests) without waiting on a
+    /// `Timer` fire.
+    private func performActivityTick() {
+        // Only fire objectWillChange if there are running sessions that could transition.
+        let hasRunning = self.statuses.values.contains { $0.isAlive }
+        if hasRunning {
+            let runningCount = self.statuses.values.lazy.filter { $0.isAlive }.count
+            let tickState = Perf.signposter.beginInterval("sessionCoordinator.tick", "\(runningCount) running sessions")
+
+            // Compute current indicator states for all running sessions.
+            var current: [UUID: SessionIndicatorState] = [:]
+            for (id, status) in self.statuses where status.isAlive {
+                current[id] = self.indicatorState(for: id)
+            }
+
+            // SEA-214: Only send objectWillChange when state actually changed,
+            // suppressing the 7-view full-sidebar re-render that fired every second.
+            //
+            // Store writes (WorkspaceStore) are moved inside the same changed-branch
+            // so the @Published dict assignments and updateProjectActivity only run
+            // when the aggregate state actually shifted. The guards in
+            // WorkspaceStore.updateIndicatorState / updateSessionStatus are a
+            // belt-and-suspenders second layer but this avoids even the dict lookup
+            // churn on no-change ticks.
+            Perf.publishIfChanged(
+                "sessionCoordinator.tick",
+                current: current,
+                cached: &self.cachedIndicatorStates
+            ) {
+                self.objectWillChange.send()
+
+                // Push each running session's indicator state to the global store
+                // so the menu bar icon can reflect the aggregate status.
+                for (id, state) in current {
+                    WorkspaceStore.shared.updateIndicatorState(id: id, state: state)
+                }
+
+                // Refresh the per-project grace-period tracker so projects
+                // whose sessions emit output at <1Hz still keep their
+                // `.activeNow` slot for the full grace window.
+                WorkspaceStore.shared.updateProjectActivityFromIndicatorStates()
+            }
+            Perf.signposter.endInterval("sessionCoordinator.tick", tickState)
         }
     }
 
@@ -1279,20 +1287,33 @@ final class SessionCoordinator: ObservableObject {
     /// Update a session's status locally and in the global store.
     ///
     /// Terminal statuses (`.completed`/`.exited`/`.killed`) also clear the
-    /// cached indicator state: once a session stops being polled by the 1Hz
-    /// tick (which only iterates `statuses where status.isAlive`), nothing
-    /// else would ever recompute its indicator, leaving a stale live value
-    /// behind. Clearing the cache entry makes lookups fall back to
-    /// `.inactive` (the existing `?? .inactive` pattern at read sites), which
-    /// matches what `indicatorState(for:)` would compute for these statuses
-    /// anyway if it were called again. `.error` is intentionally left alone —
-    /// `indicatorState(for:)` returns `.error` for that status to keep failed
-    /// sessions visible.
+    /// cached indicator state, in both places it lives: once a session stops
+    /// being polled by the 1Hz tick (which only iterates
+    /// `statuses where status.isAlive`), nothing else would ever recompute
+    /// its indicator, leaving a stale live value behind.
+    ///
+    /// - `WorkspaceStore.shared`'s `globalIndicatorStates` is what every view
+    ///   reads. Clearing it makes lookups fall back to `.inactive` (the
+    ///   existing `?? .inactive` pattern at read sites).
+    /// - `cachedIndicatorStates` here is the change-comparator the 1Hz tick
+    ///   uses to decide whether to publish (`Perf.publishIfChanged`). If this
+    ///   entry isn't cleared too, a relaunch of the same session id computes
+    ///   the same pre-death state on the first post-relaunch tick, the
+    ///   comparator sees no change, and the publish (and the store write) is
+    ///   suppressed — leaving the store empty for a live, running session.
+    ///
+    /// `.error` is intentionally left alone for now: `indicatorState(for:)`
+    /// is only ever called for sessions where `status.isAlive`, so once a
+    /// session reaches `.error` (not alive) its cached/stored indicator
+    /// simply keeps whatever value it last held before failing — typically
+    /// its last live state, not a distinct error indicator. Changing that is
+    /// an open design decision, not addressed here.
     private func setStatus(_ status: SessionStatus, for id: UUID) {
         statuses[id] = status
         WorkspaceStore.shared.updateSessionStatus(id: id, status: status)
         switch status {
         case .completed, .exited, .killed:
+            cachedIndicatorStates?.removeValue(forKey: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
         case .running, .error:
             break
@@ -1343,5 +1364,28 @@ final class SessionCoordinator: ObservableObject {
     /// can assert the dictionary shrinks after teardown without reaching
     /// into a `private` property directly.
     var nameSyncSubscriptionCountForTesting: Int { nameSyncSubscriptions.count }
+
+    /// Test-only seam for driving `setStatus(_:for:)` directly. Exercises the
+    /// same mutation `closeSession`/`handleSurfaceClose` use, including
+    /// `.exited`/`.completed` terminal statuses that `handleSurfaceClose`
+    /// reaches but which have no seam reachable without a live GhosttyKit
+    /// surface. Never used in production.
+    func setStatusForTesting(_ status: SessionStatus, for id: UUID) {
+        setStatus(status, for: id)
+    }
+
+    /// Test-only: seed a "live" session (running + producing recent output)
+    /// so `indicatorState(for:)` resolves `.processing`, without needing a
+    /// real GhosttyKit surface. Never used in production.
+    func seedRunningSessionForTesting(id: UUID) {
+        statuses[id] = .running
+        lastOutputTimestamps[id] = .now
+    }
+
+    /// Test-only: run one 1Hz activity tick synchronously, without waiting
+    /// for the real `Timer` to fire. Never used in production.
+    func runActivityTickForTesting() {
+        performActivityTick()
+    }
 #endif
 }

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -817,7 +817,14 @@ final class WorkspaceStore: ObservableObject {
     }
 
     /// Remove a session's indicator state entry (called on cleanup).
+    ///
+    /// Writing to the observed `globalIndicatorStates` dict unconditionally
+    /// fires `didSet` even for `removeValue(forKey:)` on a key that isn't
+    /// present, which busts `sessionGroupsCache` and the sectioned-projects
+    /// cache store-wide. Guard first so callers that remove an
+    /// already-absent (or already-removed) entry don't pay that cost.
     func removeIndicatorState(id: UUID) {
+        guard globalIndicatorStates[id] != nil else { return }
         globalIndicatorStates.removeValue(forKey: id)
     }
 

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
@@ -69,6 +69,36 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
         )
     }
 
+    /// `.error` must write a distinct `.error` indicator (not silently retain
+    /// whatever live value the session held before failing) and the session
+    /// must stay in the ACTIVE zone so failed sessions keep nagging until the
+    /// user relaunches or Removes them.
+    func testErrorSessionIndicatorStateIsErrorAndStaysActive() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock {
+            WorkspaceStore.shared.removeSessionStatus(id: id)
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        }
+
+        // Seed a live-looking indicator, mirroring what the 1Hz tick would
+        // have written while the session was actually running.
+        WorkspaceStore.shared.updateIndicatorState(id: id, state: .processing)
+
+        coordinator.setStatusForTesting(.error(exitCode: 1), for: id)
+
+        let indicatorState = WorkspaceStore.shared.globalIndicatorStates[id] ?? .inactive
+        XCTAssertEqual(
+            indicatorState,
+            .error,
+            "an errored session's indicator must become .error, not keep its last live value"
+        )
+        XCTAssertTrue(
+            RecentsListView.belongsInActive(indicatorState: indicatorState),
+            "an errored session must stay in the ACTIVE zone until relaunched or removed"
+        )
+    }
+
     /// Regression test for the relaunch bug: closing a session must also
     /// clear `SessionCoordinator`'s own `cachedIndicatorStates` entry, not
     /// just the store's. If it doesn't, relaunching the same session id and

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
@@ -99,6 +99,54 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
         )
     }
 
+    /// Regression test for the `.error` mirror of the relaunch bug: an
+    /// errored session must also clear its way out of
+    /// `SessionCoordinator`'s own `cachedIndicatorStates`, not just get
+    /// written into the store. If `cachedIndicatorStates?[id] = .error` is
+    /// missing, the cache stays on the session's pre-error value
+    /// (`.processing`, seeded here by the first tick). On relaunch, the next
+    /// tick recomputes that same `.processing` value, `Perf.publishIfChanged`
+    /// sees no change against the stale cache, and the publish (and store
+    /// write) is suppressed — leaving the store stuck showing `.error` for a
+    /// session that is actually running again.
+    ///
+    /// This test fails without the `cachedIndicatorStates?[id] = .error`
+    /// line in `setStatus(_:for:)` and passes with it.
+    func testRelaunchedSessionPublishesIndicatorAfterError() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock {
+            WorkspaceStore.shared.removeSessionStatus(id: id)
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        }
+
+        // 1. Session starts running and producing output; the tick populates
+        //    both the store and the coordinator's own comparator cache with
+        //    .processing.
+        coordinator.seedRunningSessionForTesting(id: id)
+        coordinator.runActivityTickForTesting()
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .processing)
+
+        // 2. The session exits non-zero.
+        coordinator.setStatusForTesting(.error(exitCode: 1), for: id)
+        XCTAssertEqual(
+            WorkspaceStore.shared.globalIndicatorStates[id],
+            .error,
+            "an errored session's indicator must become .error"
+        )
+
+        // 3. The same session id is relaunched and starts producing output
+        //    again before the next tick.
+        coordinator.seedRunningSessionForTesting(id: id)
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(
+            WorkspaceStore.shared.globalIndicatorStates[id],
+            .processing,
+            "a relaunched session must publish its live indicator again, not stay stuck on .error"
+        )
+    }
+
     /// Regression test for the relaunch bug: closing a session must also
     /// clear `SessionCoordinator`'s own `cachedIndicatorStates` entry, not
     /// just the store's. If it doesn't, relaunching the same session id and

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
@@ -1,0 +1,47 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+@testable import Ghostty
+
+/// Regression coverage for the stale-indicator bug: a session whose surface
+/// closes with a terminal `SessionStatus` must stop reporting a live
+/// indicator, so it leaves the Sessions tab's ACTIVE zone on its own instead
+/// of waiting for relaunch or an explicit Remove.
+///
+/// Drives `closeSession`, which shares the same `setStatus(_:for:)` path as
+/// `handleSurfaceClose` — both funnel terminal statuses through the single
+/// mutation point that clears the cached indicator state.
+@MainActor
+final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
+
+    /// A `.killed` session's cached indicator state must not survive its own
+    /// close: the 1Hz tick only recomputes indicators for sessions where
+    /// `status.isAlive`, so once a session goes terminal nothing else will
+    /// ever refresh a stale cached value.
+    func testClosedSessionIndicatorStateIsInactiveNotStale() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock {
+            WorkspaceStore.shared.removeSessionStatus(id: id)
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        }
+
+        // Seed a live-looking indicator, mirroring what the 1Hz tick would
+        // have written while the session was actually running.
+        WorkspaceStore.shared.updateIndicatorState(id: id, state: .processing)
+        coordinator.seedEmptySessionTreeForTesting(id: id)
+
+        coordinator.closeSession(id: id)
+
+        let indicatorState = WorkspaceStore.shared.globalIndicatorStates[id] ?? .inactive
+        XCTAssertEqual(
+            indicatorState,
+            .inactive,
+            "a closed session's indicator must fall back to .inactive, not the last live value"
+        )
+        XCTAssertFalse(
+            RecentsListView.belongsInActive(indicatorState: indicatorState),
+            "a closed session must leave the ACTIVE zone"
+        )
+    }
+}

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
@@ -44,4 +44,71 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
             "a closed session must leave the ACTIVE zone"
         )
     }
+
+    /// `.exited`/`.completed` are the statuses `handleSurfaceClose` actually
+    /// reports (as opposed to `closeSession`'s `.killed`, covered above).
+    /// Driven via `setStatusForTesting`, the closest reachable seam to
+    /// `handleSurfaceClose` without a live GhosttyKit surface.
+    func testExitedSessionIndicatorStateIsInactive() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock {
+            WorkspaceStore.shared.removeSessionStatus(id: id)
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        }
+
+        WorkspaceStore.shared.updateIndicatorState(id: id, state: .processing)
+
+        coordinator.setStatusForTesting(.exited, for: id)
+
+        let indicatorState = WorkspaceStore.shared.globalIndicatorStates[id] ?? .inactive
+        XCTAssertEqual(
+            indicatorState,
+            .inactive,
+            "an exited session's indicator must fall back to .inactive, not the last live value"
+        )
+    }
+
+    /// Regression test for the relaunch bug: closing a session must also
+    /// clear `SessionCoordinator`'s own `cachedIndicatorStates` entry, not
+    /// just the store's. If it doesn't, relaunching the same session id and
+    /// running the next 1Hz tick recomputes the identical pre-death state,
+    /// `Perf.publishIfChanged` sees no change against the stale cache, and
+    /// the store write is suppressed — leaving a live, running session with
+    /// no indicator entry at all.
+    ///
+    /// This test fails without the `cachedIndicatorStates?.removeValue`
+    /// line in `setStatus(_:for:)` and passes with it.
+    func testRelaunchedSessionPublishesIndicatorAfterClose() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock {
+            WorkspaceStore.shared.removeSessionStatus(id: id)
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        }
+
+        // 1. Session starts running and producing output; the tick populates
+        //    both the store and the coordinator's own comparator cache.
+        coordinator.seedRunningSessionForTesting(id: id)
+        coordinator.runActivityTickForTesting()
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .processing)
+
+        // 2. The session is closed (terminal status).
+        coordinator.setStatusForTesting(.killed, for: id)
+        XCTAssertNil(
+            WorkspaceStore.shared.globalIndicatorStates[id],
+            "closing must clear the store entry"
+        )
+
+        // 3. The same session id is relaunched (production reuses ids on
+        //    relaunch) and starts producing output again before the next tick.
+        coordinator.seedRunningSessionForTesting(id: id)
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(
+            WorkspaceStore.shared.globalIndicatorStates[id],
+            .processing,
+            "a relaunched session must get a live indicator entry again, not stay empty"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Stopped/exited agent sessions were staying in the Sessions tab's ACTIVE zone forever, still wearing a stale live indicator, until relaunched or explicitly Removed.

Root cause: `SessionCoordinator`'s 1Hz tick only recomputes indicator state for sessions where `status.isAlive`. Once `handleSurfaceClose`/`closeSession` marked a session `.exited`/`.completed`/`.killed`, its last live indicator value (`.idle`, `.waiting`, `.processing`, etc.) stayed cached in `WorkspaceStore.globalIndicatorStates` forever — nothing ever ran `indicatorState(for:)` again to recompute it.

## Fix
`SessionCoordinator.setStatus(_:for:)` — the single mutation point both `handleSurfaceClose` and `closeSession` funnel through — now clears the cached indicator entry via the existing `WorkspaceStore.removeIndicatorState(id:)` helper (same mechanism already used by `clearRuntime` and `deinit`) when the new status is `.completed`, `.exited`, or `.killed`. Read sites already fall back to `.inactive` via `?? .inactive`, so this matches what `indicatorState(for:)` would compute if it were called again.

`.error` is deliberately untouched — `indicatorState(for:)` returns `.error` for that status to keep failed sessions visible, and this PR does not change that.

## Scope
- `macos/Sources/Features/Ghostties/SessionCoordinator.swift` — the fix, in `setStatus(_:for:)`
- `macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift` — new regression test

No other files touched (avoids conflicts with open PRs #56/#57/#58/#59/#90 per the task brief's file-ownership boundaries).

## Test plan
- [x] New test `testClosedSessionIndicatorStateIsInactiveNotStale` drives `closeSession` (shares `setStatus` with `handleSurfaceClose`) and asserts the resulting indicator reads `.inactive` and `RecentsListView.belongsInActive` returns `false`.
- [x] Verified fail-without-fix / pass-with-fix by stashing the production change and re-running the test.
- [x] Full unfiltered suite: 626 unique tests (625 baseline + 1 new), 0 failed, 1 skipped (`BenchmarkTests/example()`).
- [x] SwiftLint clean on both changed files (one pre-existing, unrelated warning at `SessionCoordinator.swift:117`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqQb3MidbaFrgmv7hys61E
## Review follow-up (commit b4b98a146)

The initial fix cleared `WorkspaceStore.globalIndicatorStates` but missed a second cache: `SessionCoordinator.cachedIndicatorStates`, the comparator `Perf.publishIfChanged` uses to decide whether to publish on the 1Hz tick. Since `createSession` reuses the same session id on relaunch and the tick is the only writer to the store, a relaunched session recomputing the same pre-death state on its first tick got suppressed by the stale coordinator-side cache — leaving a live, running session with **no** indicator entry at all until its computed state happened to change. Fixed by clearing `cachedIndicatorStates` alongside the store entry in `setStatus(_:for:)`.

Also from review:
- Corrected the doc comment on `setStatus(_:for:)`: it previously claimed `.error` sessions show a distinct "error dot." They don't — `indicatorState(for:)` is gated by `status.isAlive`, so an errored session simply retains whatever indicator it last held while alive. `.error` behavior itself is unchanged (open design decision, out of scope here).
- Added a guard to `WorkspaceStore.removeIndicatorState`, mirroring its `updateIndicatorState` sibling, so removing an already-absent key doesn't unconditionally fire `didSet`'s cache invalidation (`sessionGroupsCache.removeAll()` + sectioned-projects invalidation) — relevant given `closeAllSessions(forProject:)` can call this up to 2N times per project removal.
- Extracted the 1Hz timer closure body into `performActivityTick()` (pure refactor, no behavior change) and added DEBUG-only test seams (`setStatusForTesting`, `seedRunningSessionForTesting`, `runActivityTickForTesting`) so tests can drive the `.exited`/`.completed` path and the relaunch regression directly, without a live GhosttyKit surface.
- New tests: `testExitedSessionIndicatorStateIsInactive` (the `.exited`/`.completed` path `handleSurfaceClose` actually reports) and `testRelaunchedSessionPublishesIndicatorAfterClose` (the coordinator-cache regression — verified fails without the fix, passes with it).

Full unfiltered suite re-run after all fixes: 0 failed, 1 skipped (`BenchmarkTests/example()`), no regressions.
## Design decision follow-up (commit 43302c36a)

`.error` behavior is no longer an open question: a session that exits non-zero now shows a distinct **error indicator and stays in the ACTIVE zone** until relaunched or Removed, instead of silently keeping whatever live indicator it held right before failing.

`setStatus(_:for:)`'s `.error` case now writes `.error` into **both** indicator caches:
- `WorkspaceStore.shared.updateIndicatorState(id:, state: .error)` — the store every view reads.
- `cachedIndicatorStates?[id] = .error` — the coordinator's own tick comparator.

The second write matters for the same reason clearing that cache mattered for `.completed`/`.exited`/`.killed`: `.error` is excluded from the 1Hz tick (`status.isAlive` gates it), so if it was the session's last alive entry, `hasRunning` goes false and the tick body — including the wholesale `cached = current` swap — never runs again. Without writing `.error` into `cachedIndicatorStates` too, a later relaunch of the same session id could recompute a value that coincidentally matches the stale pre-error cache entry, suppressing the publish and leaving the store stuck showing `.error` for a session that's actually running again. Traced this end-to-end rather than assuming — confirmed the direct store write lands (no downstream tick/`clearRuntime`/`didSet` overwrites it), and that only an explicit relaunch + tick can now correctly replace it.

New test `testErrorSessionIndicatorStateIsErrorAndStaysActive`: asserts the indicator becomes `.error` and `RecentsListView.belongsInActive(indicatorState: .error)` is `true`. Verified it fails without the `.error` write (falls through to the old `case .running, .error: break`) and passes with it.

Full unfiltered suite re-run: 0 failed, 1 skipped (`BenchmarkTests/example()`), no regressions.
