### PR TITLE
feat(web): conversion, trust, and mobile polish

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -112,6 +112,14 @@ means it shows for keyboard navigation and never for a mouse or touch tap.
 not `:focus-visible`, since the link is otherwise off-screen and needs to
 appear for any focus method that lands on it).
 
+**Decision (2026-08-05): the focus ring keeps `--accent`.** Terracotta being
+dropped as an *app brand* colour raised the question of whether it should
+still carry an *interaction* meaning on the web. It stays, for three
+reasons: it already passes AA (4.916:1), it is the site's only chromatic
+colour so there is nothing else to reach for, and inventing a second accent
+solely for focus would add a colour with no other purpose on the page. Don't
+reopen this without a concrete reason `--accent` itself is being replaced.
+
 ### Accent
 
 `--accent: #c97350` — terracotta. Two uses: product captions on the homepage,

--- a/web/download.html
+++ b/web/download.html
@@ -111,7 +111,7 @@
     <a class="back" href="/">&larr; ghostties</a>
 
     <h1>Download</h1>
-    <p class="lead">Ghostties is a multi-agent workspace terminal for macOS. Currently in beta.</p>
+    <p class="lead">Ghostties is a multi-agent workspace terminal for macOS &mdash; a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a>, built by Sean Smith. Currently in beta.</p>
 
     <h2>Current release</h2>
     <div class="download-block">
@@ -120,7 +120,8 @@
       </a>
       <div class="download-meta">
         v0.1.0-beta.21 &middot; August 1, 2026 &middot; 147 MB<br>
-        macOS 13 (Ventura) or later &middot; Apple Silicon
+        macOS 13 (Ventura) or later &middot; Apple Silicon<br>
+        Developer ID signed and notarized by Apple &mdash; opens without a Gatekeeper warning.
       </div>
     </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -276,6 +276,15 @@
       overflow: hidden;
     }
 
+    /* Intro line — reuses .lead's type but with a tighter margin than the
+       shared 40px. The homepage's fixed footer already overlaps in-flow
+       content on short viewports before this line existed (pre-existing,
+       out of scope here); a smaller margin keeps this addition from
+       widening that overlap more than it has to. */
+    .product .lead {
+      margin-bottom: 24px;
+    }
+
     /* Display heading — opts out of the shared uppercase eyebrow h2. */
     .product h2 {
       font-family: var(--font-ui);
@@ -431,8 +440,8 @@
       .ghost { width: 64px; height: 64px; }
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
-      .terminal { font-size: 1rem; } /* 16px */
-      footer { padding: 12px 16px; font-size: 0.625rem; } /* 10px */
+      .terminal { font-size: 1rem; max-width: calc(100vw - 72px); } /* 16px; .scene 20px + body 16px per side at this width */
+      footer { padding: 8px 16px; font-size: 0.625rem; } /* 10px; matches the document-page footer padding trim */
       .product { padding: 16px 20px 72px; }
       .product h2 { font-size: 1.375rem; margin-bottom: 28px; } /* 22px */
       .product-window { margin-bottom: 28px; }
@@ -571,6 +580,7 @@
     </div>
 
     <section class="product">
+      <p class="lead">Ghostties is a multi-agent workspace terminal for macOS &mdash; a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a>, built by Sean Smith.</p>
       <h2><span>Multiple agents.</span><span>One window.</span></h2>
       <div class="product-window product-window--sessions">
         <div class="product-card">

--- a/web/style.css
+++ b/web/style.css
@@ -402,7 +402,7 @@ footer svg {
   }
 
   footer {
-    padding: 12px 16px;
+    padding: 8px 16px;
     font-size: var(--size-caption);
   }
 
@@ -420,9 +420,12 @@ footer svg {
   /* No middot at mobile widths: a wrap can land at any point depending on
      link count and viewport, so any separator scheme risks a dangling
      leading or trailing "·" on some row. Dropping it removes the
-     possibility entirely; the flex gap above already separates items. */
+     possibility entirely; the flex gap above already separates items.
+     row-gap (the first value) is pure inter-row breathing room, not an
+     overlap guard — flex-wrap already reserves each row's full box height
+     regardless of gap, so this can go lower than the old 6px without risk. */
   .footer-links {
-    gap: 6px 12px;
+    gap: 4px 12px;
   }
 
   .footer-links > * + *::before {


### PR DESCRIPTION
## Summary

Ships the non-hero half of the ghostties.org backlog: a mobile terminal sizing fix, a footer height trim, download-page trust signals, fork credit on the two pages that matter, and a locked-in focus-ring decision recorded in `DESIGN.md`.

## What changed

1. **`.terminal` max-width over-subtraction (`web/index.html`)** — inside the `max-width: 480px` query, changed `calc(100vw - 112px)` to `calc(100vw - 72px)` (the correct value once `.scene` is 20px and body is 16px at that breakpoint, not their larger desktop values). The terminal now uses the full 40px it was leaving on the table on phones. Verified `scrollWidth <= clientWidth` at 320/375/414/480/481/600px — no change above 480px, +40px of terminal width below it.

2. **Mobile footer height (`web/style.css`, `web/index.html`)** — reduced footer outer padding `12px → 8px` and inter-row gap `6px → 4px`. These only affect whitespace outside/between the wrapped rows, never the link boxes themselves, so no tap target shrank. Document-page footer: 112px → 102px. Homepage footer: 106px → 96px. Zero overlapping hit boxes confirmed on all 7 pages at 320px and 375px; minimum tap-target height is unchanged at 41px (document pages) / 38px (homepage — pre-existing, not touched by this PR).
   - **Design call:** this is the maximum safe reduction. Getting the wrapped link row down to a single row is impossible at 320px regardless of padding (the link text alone exceeds the available width), so a second row is unavoidable at the narrowest supported width. Further reduction would require either fewer footer links or a different mobile footer layout — flagging that as a real option if Sean wants a bigger win, but it's a bigger change than "trim padding." **Reverse:** restore `padding: 12px 16px` on `footer` (both in `style.css` and `index.html`'s mobile block) and `gap: 6px 12px` on `.footer-links`.

3. **Trust signals on `/download` (`web/download.html`)** — added one line to `.download-meta`: "Developer ID signed and notarized by Apple — opens without a Gatekeeper warning." True today, no invented claims, no fabricated checksum. **Reverse:** delete that one `<br>` + line.

4. **Fork credit (`web/download.html`, `web/index.html`)** — both pages now state "a fork of Ghostty, built by Sean Smith" in their opening prose, linking to `github.com/ghostty-org/ghostty`. No "independent" language, per the locked decision in memory. **Reverse:** revert the two `<p class="lead">` edits.

5. **Focus-ring colour — decision recorded, not changed (`web/DESIGN.md`)** — `:focus-visible` still uses `--accent`. Added a dated decision paragraph in `DESIGN.md` §3 explaining why (passes AA, only chromatic colour on the site, a second accent purely for focus would be worse), so this doesn't get relitigated. No CSS changed. **Reverse:** delete the paragraph if the rationale needs revisiting.

6. **Homepage prose (`web/index.html`)** — added a one-line, human-readable description ("Ghostties is a multi-agent workspace terminal for macOS — a fork of Ghostty, built by Sean Smith.") in the `.product` section, **entirely outside `.scene`** — the hero itself is untouched. This also carries item 4's credit.
   - **Design call:** placed it in the product section rather than above the hero, specifically to avoid pushing the hero's initial framing down on load. Gave it a tighter `margin-bottom: 24px` (vs. the shared `.lead`'s 40px) as a mitigation — see the flag below. **Reverse:** delete the `<p class="lead">` line and the `.product .lead` margin override.

## Flagged, not fixed — pre-existing, out of scope

The homepage's fixed mobile footer already overlaps in-flow content at short viewports (verified: baseline `origin/main` collides at 375×667 with no changes at all — `.product h2` top sits below the footer's top edge). This branch's new intro paragraph lands in the same zone and marginally widens that overlap window; the tightened margin above is a minimal mitigation, not a fix. A real fix means either making the homepage footer non-fixed past some content length or changing what's allowed to render in that vertical band — bigger than this task's scope and arguably hero-adjacent. Recommend a follow-up if it matters at 320–414×~600-700 viewports (iPhone SE class).

## Verification

- Compared `origin/main` (baseline) and this branch side by side via two local `python3 -m http.server` instances + Playwright (`prefers-reduced-motion: reduce`).
- No horizontal scroll (`scrollWidth <= clientWidth`) on any of the 7 pages at 320/375/414/480/481/600/700/900/1024/1280/1440.
- Zero overlapping footer hit boxes on all 7 pages at 320px and 375px (geometric rectangle-intersection check against measured `getBoundingClientRect()`).
- `/404` centring and footer bottom-anchoring confirmed byte-identical to baseline at 1280×900 (untouched file).
- Footer link accessible names re-checked via `Accessibility.getFullAXTree` on all 7 pages — clean text, no middot pollution.
- Screenshots taken and reviewed at 375 and 1280 for every changed/affected page.

## Test plan

- [ ] Sean: skim the PR screenshots or pull the branch and eyeball `/` and `/download` on an actual phone
- [ ] Confirm the trust-signal line reads right against the real download experience
- [ ] Decide whether the flagged short-viewport footer overlap needs a follow-up ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)