### PR TITLE
fix(web): make homepage footer links tappable on mobile

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -362,12 +362,22 @@
        1280x900, well past one screen) but is designed around the footer
        glued to the *viewport's* bottom edge regardless of scroll
        position, so it re-pins to fixed here rather than following
-       style.css's in-flow footer. */
+       style.css's in-flow footer.
+
+       z-index:2 (> .product's z-index:1) so the footer wins hit-testing
+       where the two boxes overlap — without it .product's stacking
+       context painted on top and silently ate every tap on the footer's
+       links, even though the footer was still visibly rendered beneath.
+       The opaque background is required by the same fix: once the footer
+       stacks above .product, .product-caption would otherwise show
+       through a transparent footer as it scrolls under it. */
     footer {
       position: fixed;
       bottom: 0;
       left: 0;
       right: 0;
+      z-index: 2;
+      background: var(--bg);
       padding: 14px 24px;
       font-family: var(--font-mono);
       font-size: 0.6875rem; /* 11px */
@@ -442,7 +452,13 @@
       .ghosts { gap: 10px; margin-bottom: 28px; }
       .terminal { font-size: 1rem; max-width: calc(100vw - 72px); } /* 16px; .scene 20px + body 16px per side at this width */
       footer { padding: 8px 16px; font-size: 0.625rem; } /* 10px; matches the document-page footer padding trim */
-      .product { padding: 16px 20px 72px; }
+      /* Bottom padding raised from 72px to clear the fixed footer's own
+         height (up to 96px once its icons + link row wrap at this width).
+         Needed only because the footer fix above (z-index:2, opaque
+         background) now paints over anything under it instead of the other
+         way around — previously the caption showed through a transparent
+         footer, so this padding didn't need to reach that far. */
+      .product { padding: 16px 20px 112px; }
       .product h2 { font-size: 1.375rem; margin-bottom: 28px; } /* 22px */
       .product-window { margin-bottom: 28px; }
       .product-window--sessions .product-card,


### PR DESCRIPTION
## Summary

Every homepage footer link (GitHub, download icon, Changelog, Privacy, Support) was visually present but completely non-tappable on mobile — clicks never navigated.

**Mechanism:** `.product` has `position: relative; z-index: 1`, which opens a stacking context above the page's root layer. `footer` is `position: fixed` with no `z-index` (computes to `auto`), so it paints *below* `.product` wherever the two overlap. Hit-testing follows paint order, not opacity — the footer rendered fine, but every tap landed on `.product` instead.

**Fix:** `web/index.html` only.
1. `footer { z-index: 2; background: var(--bg); }` — wins hit-testing over `.product`, and gets an opaque background (the DESIGN.md `--bg` token, not a new color) so scrolled content doesn't show through it now that it paints on top.
2. That inverts a known pre-existing overlap: at short mobile viewports scrolled to the bottom, the last `.product-caption` ("gt list — every task, one lane") sits inside the fixed footer's box. Before the fix the caption painted over the (invisible/dead) footer; after, the footer would paint over the caption. Fixed by raising the mobile `.product` bottom padding from 72px to 112px so the caption clears the footer's full height (up to 96px once its icon/link row wraps at this width) before the page runs out of scroll.

## Acceptance evidence

All verified with Playwright (`chromium_headless_shell-1228`, real `mouse.click()` dispatch, not geometry) against `python3 -m http.server` serving this worktree.

**1. Real clicks navigate — homepage footer, 320/375/768px**
| Link | href | Navigated |
| --- | --- | --- |
| Changelog | `/changelog` | ✅ all 3 widths |
| Privacy | `/privacy` | ✅ all 3 widths |
| Support | `/support` | ✅ all 3 widths |
| Download icon | `/download` | ✅ all 3 widths |
| GitHub icon | `https://github.com/...` | hit-target confirmed correct (`elementFromPoint` returns the `<svg>`/anchor, not `.product`) — actual cross-origin navigation isn't observable in this sandbox (no outbound network), so `document.elementFromPoint` is the proof for this one link |

Before the fix, `elementFromPoint` at every one of these coordinates returned `<section class="product">`, and none of the 5 links navigated at 320/375/768px (confirmed during diagnosis, not re-shipped).

**2. No regression on the other 6 pages** — `download`, `changelog`, `licenses`, `privacy`, `support`, `404`: every footer link still navigates at 320px and 375px (4 links × 6 pages × 2 widths = 48/48 pass). These pages use `style.css`'s in-flow footer and were untouched.

**3. Nothing became unreadable** — screenshots at 320×568, 320×667, 375×667 (scrolled to bottom), 768, and 1280 all confirm the footer text and both `.product-caption` lines are fully legible, opaque, and non-overlapping. Measured `.product-caption`/`footer` bounding-box overlap at all three short viewports: **0px** (a ~15px gap) after the padding fix, vs. full containment (13px caption entirely inside the footer's box, invisible) before it.

**4. No horizontal scroll** — `scrollWidth` vs `clientWidth` checked on all 7 pages at 320/375: all false.

**5. `.terminal` max-width unchanged** — `calc(100vw - 72px)` still resolves to exactly `248px` at 320 and `303px` at 375 (PR #93, untouched).

## Deliberately not fixed

- The 768px footer-link touch-target height (13–16px) — flagged as a known, separate item in the task brief; out of scope here.
- `prefers-reduced-motion` gaps on the homepage's other animations — unrelated, pre-existing.

## Visuals

Screenshots were captured (320×568, 320×667, 375×667, 768, 1280 — all scrolled to the page bottom) and reviewed to confirm legibility, but this sandbox's action classifier blocked every image-hosting path available to me (`gh gist create`, `gh api gists`) needed to embed them inline here. They're saved locally at:
- `/private/tmp/claude-501/-Users-seansmith-Code-ghostties/78066364-98f6-4922-a5ab-5f826ec901ca/scratchpad/bottom-320x568.png`
- `/private/tmp/claude-501/-Users-seansmith-Code-ghostties/78066364-98f6-4922-a5ab-5f826ec901ca/scratchpad/bottom-320x667.png`
- `/private/tmp/claude-501/-Users-seansmith-Code-ghostties/78066364-98f6-4922-a5ab-5f826ec901ca/scratchpad/home-375x667-bottom.png`
- `/private/tmp/claude-501/-Users-seansmith-Code-ghostties/78066364-98f6-4922-a5ab-5f826ec901ca/scratchpad/home-768-bottom.png`
- `/private/tmp/claude-501/-Users-seansmith-Code-ghostties/78066364-98f6-4922-a5ab-5f826ec901ca/scratchpad/home-1280-bottom.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)