### PR TITLE
fix(terminal): derive window titlebar bg from real terminal theme

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -607,18 +607,18 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         // Call this last in case it uses any of the properties above.
+        //
+        // MARK: - Ghostties fork fence (titlebar bg sync)
+        // This used to be immediately followed by an override that forced
+        // window.backgroundColor to the static chrome token in workspace mode.
+        // That fought with TerminalWindow.syncAppearance's own real-theme
+        // computation (whichever ran last won), and neither was the terminal's
+        // actual background — hence the titlebar strip reading a fixed grey
+        // regardless of the active Ghostty theme. Do not reintroduce a static
+        // override here; window.backgroundColor must stay derived from the
+        // focused surface's real background (see TerminalWindow.syncAppearance).
         window.syncAppearance(surfaceConfig)
-
-        // In workspace mode the window floor (the strip below the terminal card)
-        // is chrome, not terminal content. Override window.backgroundColor so the
-        // bottom gutter matches the sidebar chrome instead of bleeding the terminal
-        // theme's pure black.
-        if window.contentView is WorkspaceViewContainer {
-            let isLight = window.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua
-            window.backgroundColor = isLight
-                ? WorkspaceLayout.chromeBackgroundLight
-                : WorkspaceLayout.chromeBackgroundDark
-        }
+        // MARK: - End Ghostties fork fence (titlebar bg sync)
 
         terminalViewContainer?.ghosttyConfigDidChange(ghostty.config, preferredBackgroundColor: window.preferredBackgroundColor)
     }

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -567,18 +567,17 @@ class TerminalWindow: NSWindow {
         } else {
             isOpaque = true
 
+            // MARK: - Ghostties fork fence (titlebar bg sync)
+            // The window background shows through the transparent titlebar (and any
+            // uncovered window floor in workspace mode), so it must track the real
+            // terminal background — not a hardcoded design-system token — or the
+            // titlebar strip won't match the canvas for themes other than the one
+            // the token was tuned against. `preferredBackgroundColor` already reads
+            // the focused surface's live derived config, which itself already
+            // resolves light/dark via the user's Ghostty theme config.
             let backgroundColor = preferredBackgroundColor ?? NSColor(surfaceConfig.backgroundColor)
             self.backgroundColor = backgroundColor.withAlphaComponent(1)
-
-            // MARK: - Ghostties fork fence (titlebar bg sync)
-            // In workspace mode, the window background shows through the transparent titlebar.
-            // Override to the canvas background so the titlebar strip matches the canvas.
-            if self.contentView is WorkspaceViewContainer {
-                let isDark = self.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                self.backgroundColor = isDark
-                    ? WorkspaceLayout.canvasBackgroundDark
-                    : WorkspaceLayout.canvasBackgroundLight
-            }
+            // MARK: - End Ghostties fork fence (titlebar bg sync)
         }
     }
 


### PR DESCRIPTION
## What changed

The window titlebar strip above the terminal canvas (visible wherever the window floor isn't covered by an inset card, e.g. workspace mode with the sidebar closed) was painted from a hardcoded design-system token instead of the terminal's actual background color. Confirmed by reading the code, not assuming the pre-supplied diagnosis — the real bug was two competing hardcoded overrides, not one:

- `TerminalWindow.syncAppearance` (`macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift`) forced `WorkspaceLayout.canvasBackground{Light,Dark}` whenever `contentView` was `WorkspaceViewContainer` — overwriting the correct theme-derived value computed one line above it.
- `TerminalController.syncAppearance` (`macos/Sources/Features/Terminal/TerminalController.swift`) then ran a *second*, later override forcing `WorkspaceLayout.chromeBackground{Light,Dark}` — which always won since it ran last.

Neither token tracked the user's actual Ghostty theme, which is why this kept "regressing" across prior fixes — each one just retuned one of the two dueling hardcoded constants.

## Fix

Removed both overrides. `window.backgroundColor` now stays whatever `TerminalWindow.syncAppearance` already derives from the focused surface's live `derivedConfig` (`preferredBackgroundColor ?? NSColor(surfaceConfig.backgroundColor)`) — the same mechanism `WorkspaceViewContainer`'s own focused-surface theme binding uses for the card chrome. Light/dark and runtime theme reload fall out for free since Ghostty's own theme resolution already handles them; no new Swift logic needed for either.

Both fork-fence blocks left in place with comments explaining why no static override belongs there, so a future "fix" doesn't reintroduce the same regression.

## Boundaries respected

- Only touched `TerminalWindow.swift` and `TerminalController.swift`. Did not touch `WorkspaceSidebarView.swift`, `WorkspaceViewContainer.swift`, `TemplatePickerView.swift`, or `web/`.
- Did not refactor `WorkspaceLayout.swift` — `canvasBackground{Light,Dark}` and `chromeBackground{Light,Dark}` tokens are untouched and still used by their other legitimate call sites (`OrphanTriageCardView.swift`, `WorkspaceViewContainer.swift`, `TaskSidebarView.swift`, `NewTaskComposerView.swift`).
- No titlebar geometry/toolbar/traffic-light changes — colour only.

## Verification

**Build:** Debug build via `xcodebuild`, `derivedDataPath macos/build`, `ONLY_ACTIVE_ARCH=YES ARCHS=arm64` — succeeded.

**Tests — full unfiltered suite:** 632 total, **631 passed, 0 failed, 1 skipped**. No filtering applied.

**Traffic-light DEBUG assertion:** compiled in (Debug config) and did not fire during the test run or app launch — traffic-light alignment unaffected.

**Pixel sample (measured, not eyeballed):** captured a real running Debug build in a workspace-mode window with no card inset (the exact seam the bug report describes — native titlebar sitting directly above the terminal canvas with no chrome strip between them). Sampled two points straddling the seam:

| Location | RGB |
|---|---|
| Titlebar strip (above traffic lights) | `(8, 3, 0)` |
| Terminal canvas (background, avoiding glyphs) | `(8, 3, 0)` |

Identical. (Theme in that live session was `3024 Night`, `#090300` — the 1-value channel offset from the hex is screenshot color-management rounding, not a real mismatch; both sides sampled equal.)

**What I could not complete cleanly:** I set out to also sample a second, clearly-non-black theme (Dracula) and force a light-mode + runtime-appearance-switch pass, per the acceptance criteria. Attempting this ran me into a real hazard: this app's workspace windows reattach to your actual live session data regardless of which build or `$HOME` launches them (not sandboxed, not env-scoped), so every window I opened surfaced your real active orchestrator sessions instead of an isolated test surface. While chasing a workspace-mode window to screenshot, one of my keystrokes (`Cmd+Shift+E`) landed as literal text in a live session's prompt input instead of being caught as an app shortcut. I saw a stray "E" appear, sent Backspace to remove it, and on the next screenshot saw the input field showing what looks like your own real-time typing — meaning I may have collided with you actively typing and can't rule out that my backspace ate one of your characters. **Please check that session's prompt before trusting it.** I stopped all further GUI/keyboard automation at that point, restored the system appearance and Ghostty config I'd temporarily changed for testing (diffed clean against a backup), and did not attempt the remaining two theme/light-mode passes live.

The code fix itself doesn't depend on that testing gap — it's a straightforward "stop overriding with a static value, let the already-computed real value survive" change, verified by full test suite + one direct pixel-identical measurement. But the second-theme and light-mode passes are unverified by me; worth a quick manual glance before merge if that matters to you.

## Commits

Do not merge — stopping at open PR per instructions.