### PR TITLE
Hide Tasks from Sidebar View menu

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -727,7 +727,10 @@ class AppDelegate: NSObject,
         newSessionItem.keyEquivalentModifierMask = [.command, .shift]
         newSessionItem.setImageIfDesired(systemSymbolName: "plus.rectangle")
 
-        // "Sidebar View" submenu — radio group for the three sidebar views.
+        // "Sidebar View" submenu — radio group for the sidebar views.
+        // Tasks is intentionally hidden here (not deleted) — see
+        // TerminalController.toggleTaskView(_:) and the
+        // `ghostties.sidebarViewMode` defaults escape hatch.
         let projectsSubItem = NSMenuItem(
             title: "Projects",
             action: #selector(TerminalController.showProjectsView(_:)),
@@ -744,18 +747,9 @@ class AppDelegate: NSObject,
         sessionsSubItem.keyEquivalentModifierMask = [.command, .shift]
         sessionsSubItem.setImageIfDesired(systemSymbolName: "clock")
 
-        let tasksSubItem = NSMenuItem(
-            title: "Tasks",
-            action: #selector(TerminalController.toggleTaskView(_:)),
-            keyEquivalent: "v"
-        )
-        tasksSubItem.keyEquivalentModifierMask = [.command, .shift]
-        tasksSubItem.setImageIfDesired(systemSymbolName: "checklist")
-
         let sidebarViewSubmenu = NSMenu()
         sidebarViewSubmenu.addItem(projectsSubItem)
         sidebarViewSubmenu.addItem(sessionsSubItem)
-        sidebarViewSubmenu.addItem(tasksSubItem)
 
         let sidebarViewParent = NSMenuItem(title: "Sidebar View", action: nil, keyEquivalent: "")
         sidebarViewParent.submenu = sidebarViewSubmenu


### PR DESCRIPTION
## Summary
- Removes the "Tasks" item and its Cmd+Shift+V shortcut from View > Sidebar View, leaving Projects and Sessions.
- This is a **hide, not a delete**. `TaskSidebarView`, `TaskRowView`, `BacklogZoneView`, `InboxZoneView`, `NeedsYouZoneView`, `ActiveZoneView`, `TaskModel`, and the `taskFirst` branch in `WorkspaceViewContainer` are all untouched.
- `defaults write ghostties.sidebarViewMode taskFirst` still works as the dev escape hatch — `WorkspaceViewContainer.swift:667-672` still routes `taskFirst` to `TaskSidebarView`, reading the same `ghostties.sidebarViewMode` key.

## Stranding check (from the code, not assumption)
Verified `TerminalController.swift:1358-1370`: `showProjectsView(_:)` and `showSessionsView(_:)` both explicitly set `ghostties.sidebarViewMode` to `"projectFirst"` and post `.workspaceSidebarViewModeChanged`, in addition to setting the tab. So a user already in `taskFirst` mode who presses Cmd+Shift+1 or Cmd+Shift+2 is pulled back to project-first mode — no stranding, no code change needed for this.

## Diff
```swift
-        // "Sidebar View" submenu — radio group for the three sidebar views.
+        // "Sidebar View" submenu — radio group for the sidebar views.
+        // Tasks is intentionally hidden here (not deleted) — see
+        // TerminalController.toggleTaskView(_:) and the
+        // `ghostties.sidebarViewMode` defaults escape hatch.
         let projectsSubItem = ...
         let sessionsSubItem = ...
-        let tasksSubItem = NSMenuItem(
-            title: "Tasks",
-            action: #selector(TerminalController.toggleTaskView(_:)),
-            keyEquivalent: "v"
-        )
-        tasksSubItem.keyEquivalentModifierMask = [.command, .shift]
-        tasksSubItem.setImageIfDesired(systemSymbolName: "checklist")
-
         let sidebarViewSubmenu = NSMenu()
         sidebarViewSubmenu.addItem(projectsSubItem)
         sidebarViewSubmenu.addItem(sessionsSubItem)
-        sidebarViewSubmenu.addItem(tasksSubItem)
```

## Test plan
- [x] `xcodebuild ... build` — BUILD SUCCEEDED
- [x] Full unfiltered test suite: **632 total, 631 passed, 0 failed, 1 skipped** (matches baseline)
- [x] Grepped for other Tasks-menu references — none in test targets, only AppDelegate/TerminalController/WorkspaceViewContainer (all reviewed, only AppDelegate needed a change)
- [ ] Screenshot of View > Sidebar View submenu — **deferred**. Per the hard safety boundary in this task, driving the running app's menu (even just opening it) to capture a screenshot counts as UI automation and was not attempted. Manual recipe for Sean: launch the Dev build, click **View > Sidebar View**, confirm only "Projects" and "Sessions" appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)