### PR TITLE
feat(templates): add built-in Codex template

### DIFF
--- a/macos/Sources/Features/Ghostties/Models/AgentTemplate.swift
+++ b/macos/Sources/Features/Ghostties/Models/AgentTemplate.swift
@@ -155,8 +155,24 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
         icon: "globe"
     )
 
+    /// Codex CLI agent session.
+    ///
+    /// Uses `.custom` rather than a dedicated `Kind` case — see the design note
+    /// in the PR that introduced this template. `agent` (Claude-CLI-specific
+    /// flags: system prompt, model, permissions, `--mcp-config`) is intentionally
+    /// nil; those flags don't map to the `codex` CLI.
+    static let codex = AgentTemplate(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!,
+        name: "Codex",
+        kind: .custom,
+        command: "codex",
+        isDefault: true,
+        isGlobal: true,
+        icon: "chevron.left.forwardslash.chevron.right"
+    )
+
     /// All built-in templates, in display order.
-    static let defaults: [AgentTemplate] = [shell, claudeCode, orchestrator, browser]
+    static let defaults: [AgentTemplate] = [shell, claudeCode, codex, orchestrator, browser]
 
     // MARK: - CLI Construction
 

--- a/macos/Tests/Workspace/AgentTemplateTests.swift
+++ b/macos/Tests/Workspace/AgentTemplateTests.swift
@@ -44,9 +44,20 @@ struct AgentTemplateTests {
         #expect(browser.templateDescription == "Embedded Chromium browser")
     }
 
+    @Test func builtInCodexTemplate() {
+        let codex = AgentTemplate.codex
+        #expect(codex.kind == .custom)
+        #expect(codex.command == "codex")
+        #expect(codex.agent == nil)
+        #expect(codex.isDefault == true)
+        #expect(codex.isGlobal == true)
+        #expect(codex.templateDescription == nil)  // stays in the BUILT-IN group, not PRESETS
+        #expect(codex.icon == "chevron.left.forwardslash.chevron.right")
+    }
+
     @Test func defaultsContainsAllBuiltIns() {
-        #expect(AgentTemplate.defaults.count == 4)
-        #expect(AgentTemplate.defaults.map(\.name) == ["Shell", "Claude Code", "Orchestrator", "Browser"])
+        #expect(AgentTemplate.defaults.count == 5)
+        #expect(AgentTemplate.defaults.map(\.name) == ["Shell", "Claude Code", "Codex", "Orchestrator", "Browser"])
     }
 
     @Test func deterministicUUIDs() {
@@ -55,6 +66,7 @@ struct AgentTemplateTests {
         #expect(AgentTemplate.claudeCode.id.uuidString == "00000000-0000-0000-0000-000000000002")
         #expect(AgentTemplate.orchestrator.id.uuidString == "00000000-0000-0000-0000-000000000003")
         #expect(AgentTemplate.browser.id.uuidString == "00000000-0000-0000-0000-000000000004")
+        #expect(AgentTemplate.codex.id.uuidString == "00000000-0000-0000-0000-000000000005")
     }
 
     // MARK: - Kind Enum Codable
@@ -277,6 +289,12 @@ struct AgentTemplateTests {
         #expect(cmd.contains("--model 'opus'"))
         #expect(cmd.contains("--permission-mode 'plan'"))
         #expect(cmd.contains("--effort 'max'"))
+    }
+
+    @Test func buildCommandCodex() {
+        let codex = AgentTemplate.codex
+        let cmd = codex.buildCommand()
+        #expect(cmd == "'codex'")  // no agent config -> just the command, shell-escaped
     }
 
     @Test func buildCommandCustomKind() {


### PR DESCRIPTION
## Summary

Adds a **Codex** built-in template to the session template picker, appearing in the BUILT-IN group next to Shell and Claude Code. Selecting it launches the `codex` CLI in a new session.

## Design decision: Option A (reuse `Kind.custom`)

Investigated whether anything behavioral keys off `kind == .claudeCode` before choosing between adding `Kind.codex` (Option B) or reusing `Kind.custom` (Option A).

Grep evidence (`grep -rn "claudeCode" macos/Sources/`):
- `TemplatePickerView.swift:310` — `iconName(for:)` picks `"cpu"`/`"sparkle"` for `.claudeCode`. Cosmetic only; the new Codex template sets an explicit `icon` field, which `resolvedIcon(for:)` prefers over the kind-based default, so this doesn't matter.
- `TemplatePickerView.swift:401` — the `TemplateEditForm`'s "Kind" segmented picker offers Shell/Claude Code/Custom. Only relevant if a user edits the template; built-ins are duplicated-and-edited, never edited in place (`isDefault` templates get "Duplicate and Edit..." in the context menu, not "Edit...").
- `AgentTemplate.swift` migration logic (`command == "claude" -> .claudeCode`) — legacy JSON migration only, irrelevant to a new built-in.
- No hits in `SessionCoordinator.swift`, `WorkspaceStore.swift`, or anywhere status/indicator/name-sync logic lives.

Nothing behavioral is gated on `.claudeCode`, so this went with **Option A**: `kind: .custom, command: "codex"`. No enum change, no forward-compat risk, no new switch cases to maintain. If real Codex-specific behavior shows up later (e.g. dedicated config UI), that's a new, scoped follow-up — not addressed speculatively here.

`agent: AgentConfig?` is left `nil`. Those fields (`--model`, `--append-system-prompt-file`, `--permission-mode`, `--mcp-config`, etc.) are Claude-CLI-specific flags with no equivalent mapping to the `codex` CLI; wiring them up would silently break or misrepresent Codex's actual flag surface.

## Proof the command reaches the launch path

Traced end to end, no UI automation:

1. `TemplatePickerView.createSession(from:)` → `coordinator.createQuickSession(for:template:)`
2. `SessionCoordinator.createQuickSession` → `createSession(session:template:project:...)`
3. In `createSession`, since `template.kind != .browser`, it falls into the terminal path: `template.buildCommand()` is called off the main thread. For `AgentTemplate.codex` (`command: "codex"`, `agent: nil`), `buildCommand()` returns `'codex'` (shell-escaped, no agent flags appended since `agent` is nil — verified by `buildCommandCodex()` test).
4. The base command (`codex`) is resolved to an absolute path via `Self.resolveCommand`, then set as `config.command` on the `Ghostty.SurfaceConfiguration` used to spawn the new `Ghostty.SurfaceView`.

## Existing templates unchanged

Shell and Claude Code are untouched — their `kind`, `command`, `agent`, and picker grouping (`templateDescription == nil && isDefault`) are unaffected by this change.

## Test plan

- [x] `xcodebuild build` (Release, `ONLY_ACTIVE_ARCH=YES ARCHS=arm64`, `derivedDataPath macos/build`) — **BUILD SUCCEEDED**
- [x] Full unfiltered `xcodebuild test` suite: **633 passed, 0 failed, 1 skipped, 634 total** (baseline was 631 passed / 0 failed / 1 skipped / 632 total — the +2 are the new Codex tests: `builtInCodexTemplate`, `buildCommandCodex`)
- [x] Added `defaultsContainsAllBuiltIns`/`deterministicUUIDs` updates for the 5th built-in
- [ ] Manual: launch the app and confirm Codex appears in the BUILT-IN picker group and spawns a `codex` session — deferred per the hard safety boundary (no synthetic UI input against a running instance in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)