### PR TITLE
Unify sidebar new-item toolbar controls into one labelled button per tab

### DIFF
--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -29,12 +29,6 @@ struct RecentsListView: View {
         let selectedId = coordinator.activeSessionId
 
         VStack(spacing: 0) {
-            newSessionRow
-
-            Rectangle()
-                .fill(Color.primary.opacity(0.10))
-                .frame(height: 1)
-
             if store.sessions.isEmpty {
                 emptyState
             } else {
@@ -97,52 +91,13 @@ struct RecentsListView: View {
         .background(.clear)
     }
 
-    // MARK: - New Session Row
-
-    private var newSessionRow: some View {
-        Menu {
-            ForEach(store.projects) { project in
-                let templates = availableTemplates(for: project)
-                if templates.count <= 1 {
-                    // Single template — tap creates directly, no submenu needed.
-                    Button(project.name) {
-                        startNewSession(in: project, template: templates.first)
-                    }
-                } else {
-                    // Multiple templates — submenu: project name → template list.
-                    Menu(project.name) {
-                        ForEach(templates) { template in
-                            Button(template.name) {
-                                startNewSession(in: project, template: template)
-                            }
-                        }
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: WorkspaceLayout.sidebarIconLabelSpacing) {
-                Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .medium))
-                    .frame(width: WorkspaceLayout.sidebarIconColumnWidth, alignment: .center)
-                Text("New Session")
-                    .font(.system(size: 12))
-                    .foregroundStyle(Color.primary)
-                Spacer(minLength: 4)
-            }
-            .padding(.leading, WorkspaceLayout.sidebarRowLeadingPadding)
-            .padding(.trailing, 10)
-            .frame(height: 36)
-            .contentShape(Rectangle())
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .disabled(store.projects.isEmpty)
-        .accessibilityLabel("New Session")
-    }
+    // MARK: - New Session (project-picker templates)
 
     /// Returns templates available for a given project: global templates plus
     /// any templates scoped to that project, with the project's default first.
-    private func availableTemplates(for project: Project) -> [AgentTemplate] {
+    /// Static so `NewSessionToolbarButton` (titlebar toolbar) can share the
+    /// exact same resolution logic without instantiating this view.
+    static func availableTemplates(for project: Project, store: WorkspaceStore) -> [AgentTemplate] {
         let candidates = store.templates.filter { $0.isGlobal || $0.projectId == project.id }
         // Lift the default template to the top of the list.
         if let defaultId = project.defaultTemplateId {
@@ -231,7 +186,9 @@ struct RecentsListView: View {
 
     // MARK: - Actions
 
-    private func startNewSession(in project: Project, template: AgentTemplate?) {
+    /// Static so `NewSessionToolbarButton` shares this exactly — see
+    /// `availableTemplates(for:store:)` above.
+    static func startNewSession(in project: Project, template: AgentTemplate?, store: WorkspaceStore, coordinator: SessionCoordinator) {
         let resolved: AgentTemplate = template ?? {
             if let defaultId = project.defaultTemplateId,
                let t = store.templates.first(where: { $0.id == defaultId }) {
@@ -386,6 +343,62 @@ struct RecentsListView: View {
     /// `workspace.json`, a file written by multiple windows).
     static func sorted(sessions: [AgentSession]) -> [AgentSession] {
         sessions
+    }
+}
+
+// MARK: - New Session Toolbar Button
+
+/// Labelled toolbar button for the Sessions tab, presented in
+/// `WorkspaceSidebarView.titlebarToolbar` right-aligned on the traffic-light
+/// row. Opens the same project-picker flyout menu the former `newSessionRow`
+/// showed inline in the list — see `RecentsListView.availableTemplates(for:store:)`
+/// and `RecentsListView.startNewSession(in:template:store:coordinator:)`, which
+/// this calls directly so the menu logic is never duplicated.
+struct NewSessionToolbarButton: View {
+    @EnvironmentObject private var store: WorkspaceStore
+    @EnvironmentObject private var coordinator: SessionCoordinator
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Menu {
+            ForEach(store.projects) { project in
+                let templates = RecentsListView.availableTemplates(for: project, store: store)
+                if templates.count <= 1 {
+                    // Single template — tap creates directly, no submenu needed.
+                    Button(project.name) {
+                        RecentsListView.startNewSession(in: project, template: templates.first, store: store, coordinator: coordinator)
+                    }
+                } else {
+                    // Multiple templates — submenu: project name → template list.
+                    Menu(project.name) {
+                        ForEach(templates) { template in
+                            Button(template.name) {
+                                RecentsListView.startNewSession(in: project, template: template, store: store, coordinator: coordinator)
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .medium))
+                Text("New Session")
+                    .font(.system(size: 12, weight: .medium))
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        // `Menu` can otherwise claim more horizontal space than its label
+        // content needs; this keeps it hugging the icon+text so the
+        // trailing-aligned `Spacer()` in `WorkspaceSidebarView.titlebarToolbar`
+        // has room to push it flush against the sidebar's trailing edge.
+        .fixedSize()
+        .foregroundStyle(isHovered ? .primary : .secondary)
+        .onHover { isHovered = $0 }
+        .disabled(store.projects.isEmpty)
+        .accessibilityLabel("New Session")
     }
 }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -151,9 +151,13 @@ struct WorkspaceSidebarView: View {
     private var titlebarToolbar: some View {
         HStack(spacing: 8) {
             Spacer()
-            // "+" only shown in Projects tab; Sessions view controls live in the content area.
+            // One labelled "new item" control per tab, right-aligned. Projects
+            // gets a plain action button; Sessions gets a menu-presenting
+            // button (project-picker flyout) — see `NewSessionToolbarButton`.
             if sidebarTab == .projects {
-                ToolbarIconButton(systemName: "plus", label: "Add project", action: presentFolderPicker)
+                ToolbarLabelButton(systemName: "plus", label: "New Project", action: presentFolderPicker)
+            } else {
+                NewSessionToolbarButton()
             }
         }
         .padding(.horizontal, 12)
@@ -438,10 +442,12 @@ private struct EmptyStateAddButton: View {
     }
 }
 
-// MARK: - Toolbar Icon Button
+// MARK: - Toolbar Label Button
 
-/// A small icon button with hover highlight for the sidebar toolbar.
-private struct ToolbarIconButton: View {
+/// A labelled icon+text button with hover feedback for the sidebar toolbar's
+/// primary "new item" action. Styled to match `EmptyStateAddButton` above
+/// (icon 10pt medium, text 12pt medium, 4pt spacing) per DESIGN.md.
+private struct ToolbarLabelButton: View {
     let systemName: String
     let label: String
     let action: () -> Void
@@ -450,16 +456,15 @@ private struct ToolbarIconButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 12, weight: .medium))
-                .frame(width: 24, height: 24)
-                .background(
-                    RoundedRectangle(cornerRadius: 5)
-                        .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
-                )
+            HStack(spacing: 4) {
+                Image(systemName: systemName)
+                    .font(.system(size: 10, weight: .medium))
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+            }
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(isHovered ? .primary : .secondary)
         .focusable()
         .onHover { isHovered = $0 }
         .accessibilityLabel(label)


### PR DESCRIPTION
## Summary

- Projects and Sessions tabs each show exactly one labelled "new item" control, right-aligned on the traffic-light row in `titlebarToolbar` (`WorkspaceSidebarView.swift`) — geometry (`.frame(height:)`, padding, `toolbarRowTopAnchorConstant`) is untouched.
  - Projects: **"+ New Project"** — same `presentFolderPicker` action as before, now with a text label added (was icon-only).
  - Sessions: **"+ New Session"** — new `NewSessionToolbarButton` (in `RecentsListView.swift`), a `Menu` that opens the exact same project-picker flyout the old inline `newSessionRow` presented.
- `newSessionRow` and its divider are removed from the Sessions list content area — the flyout logic (`availableTemplates(for:)`, `startNewSession(in:template:)`) was hoisted to `static` functions on `RecentsListView` so `NewSessionToolbarButton` calls the identical code path rather than duplicating it.
- Icon/label styling matches `EmptyStateAddButton`'s existing precedent (`HStack(spacing: 4)`, icon 10pt `.medium`, text 12pt `.medium`) per the task brief and `DESIGN.md`.
- `ToolbarIconButton` renamed to `ToolbarLabelButton` (its only call site was the Projects button being labelled).

## Width measurement

I could not get a verified screenshot of this worktree's own Dev build. The desktop had several pre-existing windows (including Sean's real, already-running production Ghostties.app, sharing the same on-disk session data since the Dev build isn't sandboxed), and repeated `osascript activate` + `screencapture` captures kept showing an unrelated foreground window instead of the freshly-launched process's own window — confirmed via a read-only Accessibility query (`System Events` window list for the Dev process's PID), which showed the Dev build's actual window was a *different* one than what I was capturing. Attempting to force-focus that specific window (`set frontmost of process`) was denied by the permission system as UI automation, which is correctly inside this task's hard safety boundary — so per "if a check needs the UI driven, don't attempt it," I stopped rather than work around it.

**What I did verify instead:**
- `Menu`'s default sizing behavior in an `HStack` + `Spacer()` is a documented SwiftUI/AppKit quirk (a custom-labelled `Menu` under `.menuStyle(.borderlessButton)` can claim more width than its label needs). Rather than leave that unaddressed, `NewSessionToolbarButton` applies `.fixedSize()` — the standard, minimal fix for exactly this case — so it hugs its icon+text content the same way the plain `ToolbarLabelButton` naturally does.
- No fallback/responsive branch was added, since the actual overflow threshold was never confirmed to exist — adding one without evidence would violate this repo's "simplest thing that works" rule.

**Manual recipe for Sean** (2 minutes):
1. `git fetch origin && git checkout feat/sidebar-toolbar-actions`
2. Open `macos/Ghostties.xcodeproj` in Xcode, Cmd+R (scheme "Ghostties")
3. Resize the sidebar to its minimum width (drag the divider left)
4. Check both tabs: does "+ New Project" / "+ New Session" stay on one line, right-aligned flush with the traffic-light row, with no clipping?
5. If it clips/wraps at minimum width, that's the one open item — flag it and I'll add an icon-only fallback below the measured threshold.

## Verification

- `xcodebuild build` (Debug, `ONLY_ACTIVE_ARCH=YES ARCHS=arm64`, `-derivedDataPath macos/build`): **BUILD SUCCEEDED**
- `xcodebuild test` (same flags), full unfiltered suite: **632 total, 631 passed, 0 failed, 1 skipped** — matches the stated baseline exactly.
- Traffic-light DEBUG assertion (`reference-traffic-light-alignment-solved.md` Guard 1/2): launched the Debug build directly (`open`-equivalent, no synthetic input) several times after clean rebuilds; the process stayed alive well past the one-shot `didBecomeKeyNotification` check each time with no `assertionFailure` crash. `WorkspaceViewContainer.swift` (Guard 2, AppKit layout) was not touched by this change.
- `RecentsListViewTests.swift`: no changes needed — it doesn't reference `newSessionRow`, `availableTemplates`, or `startNewSession` directly (only the already-`static` helpers like `sorted`/`belongsInActive`/`activeSessions`), so the row's removal and the two methods' static conversion don't break anything there.

## Test plan

- [ ] Sean: run the manual recipe above and confirm no clipping at minimum sidebar width
- [x] Full unfiltered `GhosttyTests` + `GhosttyUITests` suite green (632/631/0/1)
- [x] Debug build launches without the traffic-light DEBUG assertion firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)