### PR TITLE
Session keyboard nav: Cmd+T / Cmd+W / Cmd+1-9 against the sidebar session list

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -400,6 +400,10 @@ class AppDelegate: NSObject,
         // see `setupCloseSessionShortcut()`.
         setupCloseSessionShortcut()
 
+        // Reclaims ⌘1-9 for positional session focus in project-first
+        // workspace mode — see `setupSessionIndexShortcuts()`.
+        setupSessionIndexShortcuts()
+
         // Setup signal handlers
         setupSignals()
 
@@ -1021,6 +1025,33 @@ class AppDelegate: NSObject,
             guard let window = NSApp.keyWindow, Self.isProjectFirstWorkspaceWindow(window) else { return event }
 
             NotificationCenter.default.post(name: .workspaceCloseSession, object: window)
+            return nil
+        }
+    }
+
+    /// Reclaims ⌘1-9 for positional session focus in project-first workspace
+    /// mode, overriding Ghostty's native `goto_tab`/`last_tab` bindings
+    /// (which act on real NSWindow tabs — irrelevant here, the sidebar IS
+    /// the tab strip; see `TerminalController.relabelTabs()`). Posts
+    /// `.workspaceFocusSessionAtIndex` with the pressed digit in `userInfo`;
+    /// `WorkspaceSidebarView` resolves it against whichever list the current
+    /// sidebar tab renders. ⌘9 always means "last visible session", not
+    /// literally the 9th.
+    private func setupSessionIndexShortcuts() {
+        _ = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection([.command, .shift, .control, .option]) == [.command],
+                  let characters = event.charactersIgnoringModifiers,
+                  characters.count == 1,
+                  let digit = Int(characters), (1...9).contains(digit)
+            else { return event }
+
+            guard let window = NSApp.keyWindow, Self.isProjectFirstWorkspaceWindow(window) else { return event }
+
+            NotificationCenter.default.post(
+                name: .workspaceFocusSessionAtIndex,
+                object: window,
+                userInfo: ["index": digit]
+            )
             return nil
         }
     }

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -396,6 +396,10 @@ class AppDelegate: NSObject,
         // see `setupNewSessionShortcut()`.
         setupNewSessionShortcut()
 
+        // Reclaims ⌘W for "Close Session" in project-first workspace mode —
+        // see `setupCloseSessionShortcut()`.
+        setupCloseSessionShortcut()
+
         // Setup signal handlers
         setupSignals()
 
@@ -997,6 +1001,26 @@ class AppDelegate: NSObject,
             guard let window = NSApp.keyWindow, Self.isProjectFirstWorkspaceWindow(window) else { return event }
 
             NSApp.sendAction(#selector(TerminalController.newWorkspaceSession(_:)), to: nil, from: nil)
+            return nil
+        }
+    }
+
+    /// Reclaims ⌘W for "Close Session" in project-first workspace mode,
+    /// overriding Ghostty's native `close_surface` binding (which closes the
+    /// terminal surface with its own "Close Terminal?" confirmation and no
+    /// notion of a sidebar session). Posts `.workspaceCloseSession`;
+    /// `WorkspaceSidebarView` observes it and calls
+    /// `SessionCoordinator.closeCurrentSessionWithConfirmation()`, which owns
+    /// the confirm / focus-neighbor / close-window logic.
+    private func setupCloseSessionShortcut() {
+        _ = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection([.command, .shift, .control, .option]) == [.command],
+                  event.charactersIgnoringModifiers?.lowercased() == "w"
+            else { return event }
+
+            guard let window = NSApp.keyWindow, Self.isProjectFirstWorkspaceWindow(window) else { return event }
+
+            NotificationCenter.default.post(name: .workspaceCloseSession, object: window)
             return nil
         }
     }

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -392,6 +392,10 @@ class AppDelegate: NSObject,
         // the chord before our "Next/Previous Session" menu items ever fire).
         setupSessionCyclingShortcut()
 
+        // Reclaims ⌘T for "New Session" in project-first workspace mode —
+        // see `setupNewSessionShortcut()`.
+        setupNewSessionShortcut()
+
         // Setup signal handlers
         setupSignals()
 
@@ -718,14 +722,30 @@ class AppDelegate: NSObject,
         prevProjectItem.keyEquivalentModifierMask = [.command, .control]
         prevProjectItem.setImageIfDesired(systemSymbolName: "chevron.left.2")
 
-        // "New Session" — Cmd+Shift+T
+        // "New Session" — Cmd+T (browser-tab convention). Reclaimed from
+        // Ghostty's native `new_tab` in project-first workspace mode by
+        // `setupNewSessionShortcut()`'s local event monitor, which fires
+        // before AppKit's key-equivalent dispatch ever reaches this menu
+        // item or the terminal surface.
         let newSessionItem = NSMenuItem(
             title: "New Session",
             action: #selector(TerminalController.newWorkspaceSession(_:)),
             keyEquivalent: "t"
         )
-        newSessionItem.keyEquivalentModifierMask = [.command, .shift]
+        newSessionItem.keyEquivalentModifierMask = [.command]
         newSessionItem.setImageIfDesired(systemSymbolName: "plus.rectangle")
+
+        // Hidden duplicate: Cmd+Shift+T also creates a new session — kept as
+        // an alias so muscle memory from earlier betas (where Cmd+Shift+T was
+        // the only binding) still works, same pattern as `sidebarItemCmdS` above.
+        let newSessionItemCmdShiftT = NSMenuItem(
+            title: "New Session",
+            action: #selector(TerminalController.newWorkspaceSession(_:)),
+            keyEquivalent: "t"
+        )
+        newSessionItemCmdShiftT.keyEquivalentModifierMask = [.command, .shift]
+        newSessionItemCmdShiftT.isHidden = true
+        newSessionItemCmdShiftT.allowsKeyEquivalentWhenHidden = true
 
         // "Sidebar View" submenu — radio group for the three sidebar views.
         let projectsSubItem = NSMenuItem(
@@ -770,8 +790,9 @@ class AppDelegate: NSObject,
         viewMenu.insertItem(nextProjectItem, at: 5)
         viewMenu.insertItem(prevProjectItem, at: 6)
         viewMenu.insertItem(newSessionItem, at: 7)
-        viewMenu.insertItem(sidebarViewParent, at: 8)
-        viewMenu.insertItem(NSMenuItem.separator(), at: 9)
+        viewMenu.insertItem(newSessionItemCmdShiftT, at: 8)
+        viewMenu.insertItem(sidebarViewParent, at: 9)
+        viewMenu.insertItem(NSMenuItem.separator(), at: 10)
 
     }
 
@@ -936,6 +957,47 @@ class AppDelegate: NSObject,
             default:
                 return event
             }
+        }
+    }
+
+    // MARK: - Session Keyboard Navigation (⌘T / ⌘W / ⌘1-9)
+
+    /// Shared gate for the ⌘T/⌘W/⌘1-9 workspace-session shortcuts below:
+    /// only intercept in **project-first** workspace windows — the mode with
+    /// an actual session list (Projects tab or Sessions tab; see
+    /// `WorkspaceSidebarView`). `contentView is WorkspaceViewContainer` is
+    /// the same test the rest of the fork uses to distinguish workspace from
+    /// non-workspace windows (see `TerminalController.swift`), extended with
+    /// a `sidebarViewMode` check so task-first mode — which has no session
+    /// list these shortcuts could act on (`TaskSidebarView` doesn't observe
+    /// `.workspaceCloseSession` / `.workspaceFocusSessionAtIndex`) — falls
+    /// through to upstream Ghostty ⌘T/⌘W behavior instead of going silently
+    /// dead. Non-workspace windows (e.g. Quick Terminal) always fall through.
+    private static func isProjectFirstWorkspaceWindow(_ window: NSWindow) -> Bool {
+        guard window.contentView is WorkspaceViewContainer else { return false }
+        let mode = UserDefaults.standard.string(forKey: "ghostties.sidebarViewMode") ?? "projectFirst"
+        return mode == "projectFirst"
+    }
+
+    /// Reclaims ⌘T for "New Session" in project-first workspace mode,
+    /// overriding Ghostty's native `new_tab` binding — which would otherwise
+    /// create a real NSWindow tab, or fall back to opening a whole new
+    /// window (see `TerminalController.newTab(_:)`), neither of which
+    /// matches the sidebar-session model. Same intercept-before-
+    /// `performKeyEquivalent` technique as `setupSessionCyclingShortcut()`
+    /// above — a local monitor runs before AppKit's key-equivalent dispatch
+    /// entirely, so it reliably wins the race regardless of what's bound in
+    /// `src/config/Config.zig` or the user's own keybinds.
+    private func setupNewSessionShortcut() {
+        _ = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection([.command, .shift, .control, .option]) == [.command],
+                  event.charactersIgnoringModifiers?.lowercased() == "t"
+            else { return event }
+
+            guard let window = NSApp.keyWindow, Self.isProjectFirstWorkspaceWindow(window) else { return event }
+
+            NSApp.sendAction(#selector(TerminalController.newWorkspaceSession(_:)), to: nil, from: nil)
+            return nil
         }
     }
 

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -637,6 +637,43 @@ final class SessionCoordinator: ObservableObject {
         }
     }
 
+    /// "Close Session" — Cmd+W, browser-tab semantics. Confirms via
+    /// `NSAlert` (never SwiftUI `confirmationDialog` — see
+    /// `BaseTerminalController.closeSurface(_:withConfirmation:)`'s doc
+    /// comment for why a Cmd+W handler can't risk a dialog that Cmd+W itself
+    /// can dismiss) when the current session is "active" — the same
+    /// live/inactive split `RecentsListView` already uses for its
+    /// Active/Archive sections (`indicatorState != .inactive`). Closing then
+    /// runs through the existing `closeSession(id:)`, which already focuses
+    /// a replacement session if one is running. If that leaves this window
+    /// with no live session at all, closes the window — browser standard:
+    /// closing your last tab closes the window.
+    func closeCurrentSessionWithConfirmation() {
+        guard let id = activeSessionId else { return }
+
+        let indicatorState = WorkspaceStore.shared.globalIndicatorStates[id] ?? .inactive
+        let isActive = indicatorState != .inactive
+
+        func performClose() {
+            closeSession(id: id)
+            if sessionTrees.isEmpty && browserManagers.isEmpty {
+                terminalController?.window?.close()
+            }
+        }
+
+        guard isActive, let controller = terminalController else {
+            performClose()
+            return
+        }
+
+        controller.confirmClose(
+            messageText: "Close Session?",
+            informativeText: "This session is still active. Closing it will stop the running process."
+        ) {
+            performClose()
+        }
+    }
+
     /// Clean up runtime state for a session (after removing from the store).
     func clearRuntime(id: UUID) {
         sessionTrees.removeValue(forKey: id)

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -649,7 +649,15 @@ final class SessionCoordinator: ObservableObject {
     /// with no live session at all, closes the window — browser standard:
     /// closing your last tab closes the window.
     func closeCurrentSessionWithConfirmation() {
-        guard let id = activeSessionId else { return }
+        guard let id = activeSessionId else {
+            // Nothing to close, and nothing live left in this window — browser
+            // convention: ⌘W then closes the window. If live sessions DO exist but
+            // none is active, stay a no-op rather than closing out from under them.
+            if sessionTrees.isEmpty && browserManagers.isEmpty {
+                terminalController?.window?.close()
+            }
+            return
+        }
 
         let indicatorState = WorkspaceStore.shared.globalIndicatorStates[id] ?? .inactive
         let isActive = indicatorState != .inactive

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -303,9 +303,16 @@ extension Notification.Name {
     /// running sessions before the store deletes the project's records.
     static let workspaceProjectWillBeRemoved = Notification.Name("com.seansmithdesign.ghostties.workspace.projectWillBeRemoved")
 
-    /// Posted by TerminalController when the user presses Cmd+Shift+T.
+    /// Posted by TerminalController when the user presses Cmd+T.
     /// The notification object is the originating NSWindow.
     static let workspaceNewSession = Notification.Name("com.seansmithdesign.ghostties.workspace.newSession")
+
+    /// Posted by AppDelegate's Cmd+W local-event monitor, project-first
+    /// workspace mode only (see `AppDelegate.isProjectFirstWorkspaceWindow(_:)`).
+    /// The notification object is the originating NSWindow.
+    /// `WorkspaceSidebarView` observes this and calls
+    /// `SessionCoordinator.closeCurrentSessionWithConfirmation()`.
+    static let workspaceCloseSession = Notification.Name("com.seansmithdesign.ghostties.workspace.closeSession")
 
     /// Posted by MenuBarDropdownView when the user clicks a session row.
     /// userInfo contains "sessionId" (UUID). SessionCoordinators observe this

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -314,6 +314,14 @@ extension Notification.Name {
     /// `SessionCoordinator.closeCurrentSessionWithConfirmation()`.
     static let workspaceCloseSession = Notification.Name("com.seansmithdesign.ghostties.workspace.closeSession")
 
+    /// Posted by AppDelegate's Cmd+1-9 local-event monitor, project-first
+    /// workspace mode only. The notification object is the originating
+    /// NSWindow; `userInfo["index"]` carries the digit pressed (1-9, where 9
+    /// always means "last visible session", not literally the 9th).
+    /// `WorkspaceSidebarView` resolves the index against whichever list the
+    /// active sidebar tab renders.
+    static let workspaceFocusSessionAtIndex = Notification.Name("com.seansmithdesign.ghostties.workspace.focusSessionAtIndex")
+
     /// Posted by MenuBarDropdownView when the user clicks a session row.
     /// userInfo contains "sessionId" (UUID). SessionCoordinators observe this
     /// to focus the tapped session and bring its window to the front.

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -140,6 +140,11 @@ struct WorkspaceSidebarView: View {
             guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
             coordinator.closeCurrentSessionWithConfirmation()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceFocusSessionAtIndex)) { notification in
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            guard let index = notification.userInfo?["index"] as? Int else { return }
+            focusVisibleSession(atIndex: index)
+        }
         .sheet(isPresented: Binding(
             get: { !hasSeenOnboarding },
             set: { _ in }
@@ -272,21 +277,63 @@ struct WorkspaceSidebarView: View {
     /// writing them is redundant with `focusSession`, which already updates
     /// `lastActiveSessionPerProject`. Scoped to the Projects-tab branch only.
     private func selectAdjacentLiveSession(offset: Int) {
-        let liveSessions: [AgentSession]
-        if sidebarTab == .sessions {
-            liveSessions = Self.sessionsTabCycleOrder(
-                sessions: store.sessions,
-                indicatorStates: store.globalIndicatorStates,
-                coordinator: coordinator
-            )
-        } else {
-            liveSessions = store.sessionsInVisualOrder(coordinator: coordinator)
-        }
+        let liveSessions = currentTabLiveSessions()
         guard let target = coordinator.focusAdjacentLiveSession(offset: offset, in: liveSessions) else { return }
         if sidebarTab == .projects {
             expandedProjectIds.insert(target.projectId)
             selectedProjectId = target.projectId
         }
+    }
+
+    /// The visible session list for whichever sidebar tab is showing right
+    /// now — shared by Cmd+Shift+[/] cycling (`selectAdjacentLiveSession`)
+    /// and Cmd+1-9 positional focus (`focusVisibleSession(atIndex:)`) so
+    /// both shortcuts always agree with what's actually on screen. See
+    /// `selectAdjacentLiveSession`'s doc comment for why the two tabs pull
+    /// from different sources.
+    private func currentTabLiveSessions() -> [AgentSession] {
+        if sidebarTab == .sessions {
+            return Self.sessionsTabCycleOrder(
+                sessions: store.sessions,
+                indicatorStates: store.globalIndicatorStates,
+                coordinator: coordinator
+            )
+        } else {
+            return store.sessionsInVisualOrder(coordinator: coordinator)
+        }
+    }
+
+    /// Cmd+1..8 focuses the Nth visible session (1-indexed); Cmd+9 always
+    /// focuses the LAST visible session regardless of how many there are.
+    /// Out-of-range (e.g. Cmd+7 with 4 sessions visible) is a no-op — no
+    /// wrap, no clamp, matching browser-tab convention. `index` is the raw
+    /// digit pressed (1-9).
+    private func focusVisibleSession(atIndex index: Int) {
+        let liveSessions = currentTabLiveSessions()
+        guard let target = index == 9
+            ? Self.lastSession(in: liveSessions)
+            : Self.session(at: index, in: liveSessions)
+        else { return }
+
+        coordinator.focusSession(id: target.id)
+        if sidebarTab == .projects {
+            expandedProjectIds.insert(target.projectId)
+            selectedProjectId = target.projectId
+        }
+    }
+
+    /// Pure index lookup for Cmd+1..8 — static so tests can call it without
+    /// a view instance, same pattern as `sessionsTabCycleOrder`. `index` is
+    /// 1-indexed; anything outside `1...liveSessions.count` is a no-op.
+    static func session(at index: Int, in liveSessions: [AgentSession]) -> AgentSession? {
+        guard index >= 1, index <= liveSessions.count else { return nil }
+        return liveSessions[index - 1]
+    }
+
+    /// Pure "last visible session" lookup for Cmd+9 — always the last entry
+    /// regardless of `liveSessions.count`. Nil for an empty list.
+    static func lastSession(in liveSessions: [AgentSession]) -> AgentSession? {
+        liveSessions.last
     }
 
     /// The Sessions-tab cycle order: the ACTIVE zone in render order,

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -136,6 +136,10 @@ struct WorkspaceSidebarView: View {
             guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
             createNewSessionForSelectedProject()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceCloseSession)) { notification in
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            coordinator.closeCurrentSessionWithConfirmation()
+        }
         .sheet(isPresented: Binding(
             get: { !hasSeenOnboarding },
             set: { _ in }

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -353,6 +353,111 @@ final class RecentsListViewTests: XCTestCase {
         XCTAssertEqual(coordinator.activeSessionId, c.id, "cycling forward from a must skip b and land on c")
     }
 
+    // MARK: - Cmd+1-9 positional session focus (index mapping)
+
+    /// `WorkspaceSidebarView.session(at:in:)` — Cmd+1..8. Pure index math:
+    /// 1-indexed, first visible session for Cmd+1.
+    func testSessionAtIndexOneReturnsFirstVisible() {
+        let a = session(name: "a")
+        let b = session(name: "b")
+        let c = session(name: "c")
+
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 1, in: [a, b, c])?.name, "a")
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 2, in: [a, b, c])?.name, "b")
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 3, in: [a, b, c])?.name, "c")
+    }
+
+    /// Out-of-range is a no-op — not a wrap, not a clamp. Cmd+7 with only 4
+    /// sessions visible must return nil, never wrap to session 3 or clamp to
+    /// session 4.
+    func testSessionAtOutOfRangeIndexIsNoOp() {
+        let sessions = (0..<4).map { session(name: "s\($0)") }
+
+        XCTAssertNil(WorkspaceSidebarView.session(at: 7, in: sessions), "out-of-range must be a no-op, not a wrap or clamp")
+        XCTAssertNil(WorkspaceSidebarView.session(at: 0, in: sessions), "index 0 is out of range (1-indexed)")
+        XCTAssertNil(WorkspaceSidebarView.session(at: -1, in: sessions))
+        XCTAssertNil(WorkspaceSidebarView.session(at: 5, in: sessions), "one past the end must still be a no-op")
+    }
+
+    func testSessionAtIndexOnEmptyListIsNoOp() {
+        XCTAssertNil(WorkspaceSidebarView.session(at: 1, in: []))
+    }
+
+    /// `WorkspaceSidebarView.lastSession(in:)` — Cmd+9. Always the LAST
+    /// visible session, regardless of count — never literally "index 9".
+    func testLastSessionReturnsLastRegardlessOfCount() {
+        let three = (0..<3).map { session(name: "s\($0)") }
+        XCTAssertEqual(WorkspaceSidebarView.lastSession(in: three)?.name, "s2", "with 3 sessions, Cmd+9 must land on the 3rd, not no-op")
+
+        let twelve = (0..<12).map { session(name: "s\($0)") }
+        XCTAssertEqual(WorkspaceSidebarView.lastSession(in: twelve)?.name, "s11", "with 12 sessions, Cmd+9 must land on the 12th, not the 9th")
+    }
+
+    func testLastSessionOnEmptyListIsNoOp() {
+        XCTAssertNil(WorkspaceSidebarView.lastSession(in: []))
+    }
+
+    /// Sessions-tab composition: Cmd+1..9 must index the ACTIVE zone only —
+    /// Archive rows (no live indicator state) are excluded, same source as
+    /// the Cmd+Shift+[/] cycle (`sessionsTabCycleOrder`).
+    @MainActor
+    func testSessionAtIndexExcludesArchiveRowsOnSessionsTab() {
+        let project = Project(name: "p", rootPath: "~/p")
+        let a = AgentSession(name: "a", templateId: UUID(), projectId: project.id)
+        let b = AgentSession(name: "b", templateId: UUID(), projectId: project.id)
+        let archived = AgentSession(name: "archived", templateId: UUID(), projectId: project.id)
+
+        let indicatorStates: [UUID: SessionIndicatorState] = [
+            a.id: .processing,
+            b.id: .idle,
+            // archived.id intentionally absent -> resolves .inactive -> Archive.
+        ]
+
+        let coordinator = SessionCoordinator()
+        coordinator.seedEmptySessionTreeForTesting(id: a.id)
+        coordinator.seedEmptySessionTreeForTesting(id: b.id)
+        coordinator.seedEmptySessionTreeForTesting(id: archived.id)
+
+        let visible = WorkspaceSidebarView.sessionsTabCycleOrder(
+            sessions: [a, b, archived],
+            indicatorStates: indicatorStates,
+            coordinator: coordinator
+        )
+
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 1, in: visible)?.name, "a")
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 2, in: visible)?.name, "b")
+        // Only 2 visible sessions -> Cmd+3 is out of range even though a
+        // 3rd session exists in the Archive.
+        XCTAssertNil(WorkspaceSidebarView.session(at: 3, in: visible), "the archived session must not be reachable by index")
+        XCTAssertEqual(WorkspaceSidebarView.lastSession(in: visible)?.name, "b")
+    }
+
+    /// Projects-tab composition: Cmd+1..9 indexes
+    /// `WorkspaceStore.sessionsInVisualOrder(coordinator:)` — every session
+    /// with a live surface, not just running ones (browser-tab mental
+    /// model), matching what `selectAdjacentLiveSession`'s Projects-tab
+    /// branch already cycles through.
+    @MainActor
+    func testSessionAtIndexUsesVisualOrderOnProjectsTab() {
+        let project = Project(name: "p", rootPath: "~/p")
+        let store = WorkspaceStore(testingProjects: [project])
+        let a = store.addSession(name: "a", templateId: UUID(), projectId: project.id)
+        let b = store.addSession(name: "b", templateId: UUID(), projectId: project.id)
+        let noSurface = store.addSession(name: "noSurface", templateId: UUID(), projectId: project.id)
+
+        let coordinator = SessionCoordinator()
+        coordinator.seedEmptySessionTreeForTesting(id: a.id)
+        coordinator.seedEmptySessionTreeForTesting(id: b.id)
+        // noSurface never gets a live surface -> excluded from visual order.
+
+        let visible = store.sessionsInVisualOrder(coordinator: coordinator)
+
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 1, in: visible)?.name, "a")
+        XCTAssertEqual(WorkspaceSidebarView.session(at: 2, in: visible)?.name, "b")
+        XCTAssertNil(WorkspaceSidebarView.session(at: 3, in: visible), "noSurface has no live surface and must not be reachable by index")
+        XCTAssertEqual(WorkspaceSidebarView.lastSession(in: visible)?.name, "b")
+    }
+
     // MARK: - Relative Time Labels
 
     func testRelativeLabelJustNow() {

--- a/macos/Tests/Ghostties/SessionCoordinatorCloseWithoutActiveSessionTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorCloseWithoutActiveSessionTests.swift
@@ -1,0 +1,58 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+@testable import Ghostty
+
+/// Regression coverage for the dead-⌘W bug: `closeCurrentSessionWithConfirmation()`
+/// used to `return` immediately whenever `activeSessionId` was `nil`, which the
+/// AppDelegate ⌘W local monitor always reaches for (it unconditionally swallows
+/// the keystroke after posting `.workspaceCloseSession`). A freshly launched
+/// project-first window with no session started yet, or a window that just ran
+/// out of running sessions via `switchToNextSession()`, made ⌘W do nothing at all.
+///
+/// `terminalController` resolves through `containerView?.window`, which isn't
+/// available without a live AppKit window in this test target, so these tests
+/// can't observe the window actually closing. What they do prove: the new
+/// no-active-session branch is reachable and doesn't crash or mutate coordinator
+/// state it shouldn't touch, for both outcomes of the `sessionTrees.isEmpty &&
+/// browserManagers.isEmpty` check the fix added.
+@MainActor
+final class SessionCoordinatorCloseWithoutActiveSessionTests: XCTestCase {
+
+    /// Nothing active, nothing live left in the window — the branch this bug
+    /// fix exists for. Must not crash even though `terminalController` (and so
+    /// its `window`) is nil in this test target.
+    func testCloseWithNoActiveSessionAndNoLiveSessionsDoesNotCrash() {
+        let coordinator = SessionCoordinator()
+
+        XCTAssertNil(coordinator.activeSessionId)
+
+        coordinator.closeCurrentSessionWithConfirmation()
+
+        XCTAssertNil(
+            coordinator.activeSessionId,
+            "closing with nothing active must not leave activeSessionId in some other state"
+        )
+    }
+
+    /// Nothing active, but a live session still exists in this window — must
+    /// stay a no-op rather than closing the window out from under it.
+    func testCloseWithNoActiveSessionButLiveSessionIsANoOp() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock {
+            WorkspaceStore.shared.removeSessionStatus(id: id)
+            WorkspaceStore.shared.removeIndicatorState(id: id)
+        }
+
+        coordinator.seedEmptySessionTreeForTesting(id: id)
+        XCTAssertNil(coordinator.activeSessionId)
+
+        coordinator.closeCurrentSessionWithConfirmation()
+
+        XCTAssertNotNil(
+            coordinator.sessionTrees[id],
+            "a live session must survive a ⌘W with nothing active"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Browser-tab keyboard navigation against the workspace sidebar's session list (not native macOS window tabs), in project-first workspace mode only.

- **Cmd+T** — new session in the current window. Rebound from Cmd+Shift+T (kept as a hidden alias for muscle memory). A local `NSEvent` monitor reclaims the chord from Ghostty's native `new_tab` before AppKit's key-equivalent dispatch reaches it — same intercept technique `setupSessionCyclingShortcut()` already uses for Cmd+Shift+[/].
- **Cmd+W** — closes the current session. Confirms via `NSAlert` (never SwiftUI `confirmationDialog` — see `BaseTerminalController.swift`'s doc comment on why a Cmd+W handler can't risk a dialog Cmd+W itself dismisses) when the session is "active" (`indicatorState != .inactive`, the same predicate `RecentsListView` uses for Active/Archive). Focuses a neighbor via the existing `closeSession(id:)` → `switchToNextSession()`. Closing the last live session in the window closes the window.
- **Cmd+1..8 / Cmd+9** — focus the Nth visible session / the last visible session. Indexes whichever list the active sidebar tab actually renders (`RecentsListView.activeSessions` on the Sessions tab, `WorkspaceStore.sessionsInVisualOrder` on the Projects tab) — the same two sources #90's Cmd+Shift+[/] fix uses, so positional and cyclical nav can never disagree. Archive rows and sessions without a live surface are excluded. Out-of-range is a no-op, not a wrap or clamp.

All three shortcuts are scoped to **project-first** workspace windows (`contentView is WorkspaceViewContainer` + `sidebarViewMode == "projectFirst"`). Non-workspace windows and task-first mode (no session list) keep upstream Ghostty Cmd+T/Cmd+W/Cmd+1-9 unchanged — task-first mode has no observer for the new notifications, so scoping out the interception there avoids silently swallowing the keys with nothing to handle them.

**Deviation from the brief, flagged:** the brief's Cmd+T gate was `contentView is WorkspaceViewContainer` alone. I added a `sidebarViewMode == "projectFirst"` check on top for all three shortcuts, because task-first mode also satisfies `contentView is WorkspaceViewContainer` but has no session-list surface these shortcuts act on (`TaskSidebarView` doesn't observe the new notifications) — without the extra guard, Cmd+T/Cmd+W would go from "native behavior" to "silently swallowed, does nothing" for task-first users. Cmd+Shift+T's existing gap (already broken in task-first mode pre-this-PR) confirmed this asymmetry exists; I didn't want to widen it onto Cmd+W too.

**Branch base note:** branched off `main` per the brief, not off open PR #102 (`feat/sidebar-toolbar-actions`), which also touches `WorkspaceSidebarView.swift`/`RecentsListView.swift`. Edits here are confined to the notification-handling/focus-logic regions (new `.onReceive` blocks, new private/static helper functions) and shouldn't conflict, but #102 should merge first per the brief's instruction.

**Known pre-existing behavior, not touched:** `SessionCoordinator.switchToNextSession()` (used by Cmd+W's neighbor-focus) picks the first `.running` session from a dictionary, not a true positional neighbor, and can leave `activeSessionId` nil if remaining sessions are merely idle (not `.running`) even though they're still live. This is existing `closeSession(id:)` behavior, unrelated to the `focusAdjacentLiveSession` bug the brief calls out — left alone per the surgical-change instruction.

## Files changed

- `macos/Sources/App/macOS/AppDelegate.swift` — menu item rebind + three new `NSEvent` local monitors + shared `isProjectFirstWorkspaceWindow` gate
- `macos/Sources/Features/Ghostties/WorkspaceLayout.swift` — two new `Notification.Name`s
- `macos/Sources/Features/Ghostties/SessionCoordinator.swift` — `closeCurrentSessionWithConfirmation()`
- `macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift` — two new `.onReceive` handlers, `currentTabLiveSessions()`, `focusVisibleSession(atIndex:)`, static `session(at:in:)` / `lastSession(in:)`
- `macos/Tests/Ghostties/RecentsListViewTests.swift` — 7 new tests for the index mapping

## Test plan (automated)

- [x] `xcodebuild build` succeeds after each of the 3 commits individually (bisectable)
- [x] Full unfiltered `GhosttyTests` suite: **688 passed, 0 failed, 1 skipped** (`** TEST SUCCEEDED **`), including the 7 new index-mapping tests
- [x] Code-path review confirms: Cmd+T never opens `NSWindow`/tab; Cmd+T still native in non-workspace windows; Cmd+W confirmation is `NSAlert`; Cmd+1-9 index the rendered list on both tabs

## Manual check recipe (Sean) — runtime verification deferred per the safety boundary

This task explicitly forbids driving the running app with synthetic input (the Dev build attaches to real live Claude sessions). Please verify by hand, in `Ghostties Dev`, in **project-first** mode (default):

1. **Cmd+T**: focus a workspace window, press Cmd+T. A new session should appear in the *same* window's sidebar and become active — no new window, no macOS tab bar. Cmd+Shift+T should do the same thing (alias).
2. **Cmd+T, non-workspace**: if you have any classic (non-sidebar) Ghostty window, Cmd+T there should behave exactly as it does on `main` today (native tab/new-window fallback) — unchanged.
3. **Cmd+W, idle session**: select a session that's finished/idle (Archive or a quiet Active row), press Cmd+W. It should close immediately, no dialog, and focus should land on another session if one's running.
4. **Cmd+W, active session**: select a session that's actively processing/waiting, press Cmd+W. You should see an `NSAlert` sheet ("Close Session?") — confirm it's a native alert sheet, not a SwiftUI popover, and that Cmd+W while the alert is open does NOT dismiss the alert itself (this is the specific bug the brief calls out).
5. **Cmd+W, last session**: close sessions down to the last one in a window, Cmd+W it — the whole window should close.
6. **Cmd+1-9, Projects tab**: with several sessions open, switch to the Projects tab, press Cmd+1, Cmd+2, etc. — each should jump to the Nth session in the order you see it on screen (project-grouped). Cmd+9 always lands on the last one, however many there are. Try Cmd+7 with only 3-4 sessions — nothing should happen.
7. **Cmd+1-9, Sessions tab**: switch to the Sessions tab, repeat step 6 against the flat ACTIVE list. Confirm indices don't reach into a collapsed Archive section.
8. **Task-first mode**: toggle to task-first (Cmd+Shift+V), confirm Cmd+T and Cmd+W revert to native Ghostty behavior (they're intentionally not wired here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)