### PR TITLE
fix(overlay): give overlay sidebar mode the same floating-card treatment

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -1126,11 +1126,14 @@ class WorkspaceViewContainer: NSView {
                 sidebarWidthConstraint.animator().constant = currentSidebarWidth
                 widthModel.width = currentSidebarWidth
                 sidebarHostingView.animator().alphaValue = 1
-                // Terminal stays full-width (leading to superview, no insets).
-                shadowHostTopConstraint.animator().constant = 0
-                shadowHostLeadingToSuperview.animator().constant = 0
-                shadowHostTrailingConstraint.animator().constant = 0
-                shadowHostBottomConstraint.animator().constant = 0
+                // Terminal floats as a carded, inset canvas — same outer inset
+                // as pinned/closed. The sidebar (z-order above the card) floats
+                // over its left edge rather than sharing space with it.
+                shadowHostTopConstraint.animator().constant = inset
+                shadowHostLeadingToSuperview.animator().constant = inset
+                shadowHostTrailingConstraint.animator().constant = -inset
+                shadowHostBottomConstraint.animator().constant = -inset
+                // Title row stays hidden in overlay — unchanged from before.
                 terminalTopConstraint.animator().constant = 0
                 titleLabel.animator().alphaValue = 0
                 sidebarToggleButton.animator().alphaValue = 0
@@ -1177,15 +1180,21 @@ class WorkspaceViewContainer: NSView {
             layer?.backgroundColor = canvasBackgroundCGColor
             sidebarOverlayBackground.layer?.shadowOpacity = 0
         case .overlay:
-            terminalContainer.layer?.cornerRadius = 0
+            // Same carded canvas treatment as pinned/closed — the terminal
+            // always reads as a floating card, even while the sidebar hovers.
+            terminalContainer.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
             terminalContainer.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-            terminalShadowHost.layer?.shadowOpacity = 0
-            terminalShadowHost.layer?.cornerRadius = 0
-            terminalShadowHost.layer?.backgroundColor = nil
+            terminalShadowHost.layer?.shadowOpacity = WorkspaceLayout.canvasShadowOpacity
+            terminalShadowHost.layer?.cornerRadius = WorkspaceLayout.terminalCornerRadius
+            terminalShadowHost.layer?.backgroundColor = cardBackgroundCGColor
+            // Browser panel is force-collapsed on entry to overlay (see above);
+            // leave its own card styling untouched.
             browserShadowHost.layer?.cornerRadius = 0
             browserShadowHost.layer?.backgroundColor = nil
             browserShadowHost.layer?.shadowOpacity = 0
-            layer?.backgroundColor = nil
+            layer?.backgroundColor = canvasBackgroundCGColor
+            // The sidebar keeps its own separate shadow — it still genuinely
+            // floats over the terminal card, distinct from the card's shadow.
             sidebarOverlayBackground.layer?.shadowOpacity = 0.2
         }
 
@@ -1338,8 +1347,9 @@ class WorkspaceViewContainer: NSView {
         let initialMode = WorkspaceStore.shared.sidebarMode
         self.sidebarMode = initialMode
         let isPinned = initialMode == .pinned
-        // Both pinned and closed modes show the floating card with insets.
-        let hasCardInset = initialMode != .overlay
+        // All three modes show the floating card with insets — overlay floats
+        // the sidebar over the same carded terminal rather than a full-bleed one.
+        let hasCardInset = true
         let initialWidth: CGFloat = isPinned ? currentSidebarWidth : 0
         sidebarDragHandle.isHidden = !isPinned
 
@@ -1378,8 +1388,11 @@ class WorkspaceViewContainer: NSView {
         shadowHostLeadingToSuperview.isActive = !isPinned
 
         // Terminal top offset inside the shadow host — reserves title bar space
-        // when pinned or closed (card modes show title + toggle button).
-        let titlebarInset: CGFloat = hasCardInset ? WorkspaceLayout.terminalTitleBarHeight : 0
+        // when pinned or closed (those two card modes show title + toggle
+        // button). Overlay is carded now too, but keeps its title row hidden
+        // (unchanged from before this pass), so it's keyed on mode, not
+        // `hasCardInset`.
+        let titlebarInset: CGFloat = initialMode != .overlay ? WorkspaceLayout.terminalTitleBarHeight : 0
         terminalTopConstraint = terminalContainer.topAnchor.constraint(
             equalTo: terminalShadowHost.topAnchor, constant: titlebarInset)
 


### PR DESCRIPTION
## Summary

The terminal canvas was full-bleed (no inset, no corner radius, no shadow) whenever the sidebar was in overlay/hover mode — the only one of the three sidebar modes that didn't read as a floating card. This makes overlay match pinned/closed: an inset, 12pt-radius, shadowed card, with the sidebar continuing to float over its left edge with its own separate 0.2-opacity shadow.

A shadow without the inset is invisible (the window edge clips it), so this is a geometry change, not a one-line opacity flip — the outer inset, corner radius, shadow, and canvas background color all move together for `.overlay` now.

## What changed

`macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift`:

- **Setup (`hasCardInset`, ~line 1342-1348)**: now `true` for all three modes (was `initialMode != .overlay`). `titlebarInset` is decoupled and stays keyed on mode directly — overlay's title row/toggle button stay hidden, unchanged from before this PR.
- **Mode-change animation (`transitionTo(.overlay)`, ~line 1117)**: shadow-host top/leading/trailing/bottom constraints now animate to `WorkspaceLayout.terminalInset` instead of snapping to 0.
- **Non-animatable properties switch (~line 1179)**: overlay's corner radius/shadow opacity/background now match pinned/closed exactly, using the existing `WorkspaceLayout` tokens (`terminalCornerRadius`, `canvasShadowOpacity`, `cardBackgroundCGColor`, `canvasBackgroundCGColor`) — no new values introduced.
- `sidebarOverlayBackground`'s own 0.2 shadow is untouched — the sidebar still genuinely floats over the card in overlay, and that's a distinct shadow from the card's own.

No changes to `WorkspaceLayout` token values, `WorkspaceSidebarView.swift`, `RecentsListView.swift`, `TerminalWindow.swift`, `TerminalController.swift`, `AppDelegate.swift`, or `web/`.

## Why this is safe against the resize re-clamp (PR #58)

The `layout()` resize re-clamp at line 602 is scoped to `sidebarMode == .pinned` only and reads `bounds.width`/`isSidebarTransitionAnimating` — neither of which this change touches. The shadow-path computation for `terminalShadowHost`/`sidebarOverlayBackground` in `layout()` is unconditional and re-derives from `.bounds` every frame, so it automatically follows the new overlay geometry with no code change needed there.

## Overlapping PRs

**#102** and **#103** are open against `WorkspaceSidebarView.swift` and `RecentsListView.swift` — the same general area of the workspace UI as this change, but this PR does not touch either file.

## Test plan

- [x] `xcodebuild ... test` — full unfiltered suite, reconciled via `xcresulttool get test-results summary`: **632 total / 631 passed / 0 failed / 1 skipped**. Matches the documented baseline on `main` exactly (632/631/0/1) — no regression, no change in count.
- [ ] Manual visual check of pinned/closed/overlay modes — **screenshots not captured**. `screencapture` returned an all-black image (no Screen Recording permission granted to this session — a known per-app/per-session gotcha), and AppleScript window enumeration failed with `osascript is not allowed assistive access (-25211)`. I launched my freshly built `Ghostties Dev.app` from the worktree to smoke-test the build, confirmed it started cleanly, then quit that specific PID (not `killall`) once screenshot capture proved impossible — did not drive any UI or type into it. A second, unrelated `Ghostties Dev` instance was already running from the main checkout when I started; I left it untouched.

**Manual recipe for Sean:** grant Screen Recording to your terminal app (System Settings → Privacy & Security → Screen Recording), launch `Ghostties Dev.app` from `macos/build/Build/Products/Debug/`, cycle pinned → closed → overlay (hover the left edge) with `Cmd+Shift+[`/`]` or mouse-hover, and confirm the card shadow/corner-radius/inset now shows in all three modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cuqdbjnn3aVZAtpxkx7tzC