### PR TITLE
Reject sidebar session titles that just echo the repo name

### DIFF
--- a/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
+++ b/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
@@ -18,8 +18,41 @@ enum SessionTitleSanitizer {
     /// Bare shell/program names that show up as terminal titles but carry no
     /// information about what the session is doing.
     private static let bareProgramNames: Set<String> = [
-        "claude", "zsh", "bash", "-zsh", "-bash", "sh", "-sh", "fish", "-fish"
+        "claude", "claude code", "zsh", "bash", "-zsh", "-bash", "sh", "-sh", "fish", "-fish"
     ]
+
+    /// Separators terminal titles commonly use to glue a program/repo name
+    /// onto the "real" content, e.g. `"repo-name | Claude Code"` or
+    /// `"repo-name — zsh"`. Deliberately excludes a bare, unspaced `-` —
+    /// project/repo directory names are routinely hyphenated
+    /// (`2026-web-playground`), and splitting on every hyphen would shred
+    /// that single informative segment into fragments that individually
+    /// look like noise. Only a *spaced* hyphen (`" - "`) is treated as a
+    /// separator, matching how humans actually punctuate a title.
+    private static let titleSeparatorPattern = #"(?: - )|[|—–:·»>]"#
+
+    /// Returns `true` if `cleaned`, once split on `titleSeparatorPattern`,
+    /// contains at least one segment that isn't just `projectDirectoryName`
+    /// or a bare program name — i.e. the title carries information beyond
+    /// "this is project X, running program Y".
+    private static func hasInformativeSegment(in cleaned: String, projectDirectoryName: String) -> Bool {
+        let placeholder: Character = "\u{0}"
+        let replaced = cleaned.replacingOccurrences(
+            of: titleSeparatorPattern,
+            with: String(placeholder),
+            options: .regularExpression
+        )
+        let dirLower = projectDirectoryName.lowercased()
+        for rawSegment in replaced.split(separator: placeholder, omittingEmptySubsequences: true) {
+            let segment = rawSegment.trimmingCharacters(in: .whitespaces)
+            guard !segment.isEmpty else { continue }
+            let segmentLower = segment.lowercased()
+            if segmentLower == dirLower { continue }
+            if bareProgramNames.contains(segmentLower) { continue }
+            return true
+        }
+        return false
+    }
 
     /// The `titleFromTerminal` fallback `SurfaceView_AppKit` writes ~500ms after
     /// surface creation if no real title has arrived yet. It carries no
@@ -104,7 +137,13 @@ enum SessionTitleSanitizer {
 
         let lowercased = cleaned.lowercased()
         if bareProgramNames.contains(lowercased) { return nil }
-        if let projectDirectoryName, lowercased == projectDirectoryName.lowercased() {
+        // Reject a title whose only content, once split on common title
+        // separators (`|`, em/en dash, spaced `-`, `:`, `·`, `»`, `>`), is
+        // the project directory name and/or a bare program name — e.g.
+        // Claude Code's terminal title "repo-name | Claude Code" carries no
+        // information beyond what the sidebar already shows via the project
+        // row and the fact that a Claude session is running there.
+        if let projectDirectoryName, !hasInformativeSegment(in: cleaned, projectDirectoryName: projectDirectoryName) {
             return nil
         }
 

--- a/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
+++ b/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
@@ -45,6 +45,77 @@ final class SessionTitleSanitizerTests: XCTestCase {
         ))
     }
 
+    // MARK: - Directory-name-echo rejection (title is just the dir name plus
+    // boilerplate, e.g. Claude Code's "<repo> | Claude Code" terminal title)
+
+    func testProjectDirectoryNamePlusClaudeCodeSuffixRejected() {
+        // The reported bug: Claude Code emits "<repo> | Claude Code" and the
+        // old exact-equality check let it straight through.
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "invented-project | Claude Code",
+            currentName: "Session 1",
+            projectDirectoryName: "invented-project"
+        ))
+    }
+
+    func testProjectDirectoryNameWithEmDashShellSuffixRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "invented-project — zsh",
+            currentName: "Session 1",
+            projectDirectoryName: "invented-project"
+        ))
+    }
+
+    func testProjectDirectoryNameWithSpacedHyphenInformativeSuffixKept() {
+        // A spaced hyphen introduces a genuinely informative segment — must
+        // survive, and the full title (not just the surviving segment) is
+        // what gets returned.
+        let result = SessionTitleSanitizer.sanitize(
+            title: "invented-project - fix the sidebar",
+            currentName: "Session 1",
+            projectDirectoryName: "invented-project"
+        )
+        XCTAssertEqual(result, "invented-project - fix the sidebar")
+    }
+
+    func testInformativeTitleMentioningUnrelatedDirNameKept() {
+        XCTAssertEqual(
+            SessionTitleSanitizer.sanitize(
+                title: "Refactoring the auth module",
+                currentName: "Session 1",
+                projectDirectoryName: "invented-project"
+            ),
+            "Refactoring the auth module"
+        )
+    }
+
+    func testHyphenatedDirectoryNameWithNoSeparatorKept() {
+        // Regression guard: a hyphenated project directory name that merely
+        // appears as a prefix, with no separator, must not be shredded into
+        // fragments by a bare (unspaced) hyphen — the whole string is one
+        // segment and it isn't equal to the bare directory name, so it's
+        // informative and must be kept.
+        XCTAssertEqual(
+            SessionTitleSanitizer.sanitize(
+                title: "invented-hyphenated auth refactor",
+                currentName: "Session 1",
+                projectDirectoryName: "invented-hyphenated"
+            ),
+            "invented-hyphenated auth refactor"
+        )
+    }
+
+    func testHyphenatedDirectoryNamePlusClaudeCodeSuffixRejected() {
+        // Same shape as the reported bug, but with a project directory name
+        // that itself contains bare hyphens — proves splitting on " - "
+        // (spaced) rather than "-" (bare) doesn't cause a false negative.
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "invented-hyphenated-project | Claude Code",
+            currentName: "Session 1",
+            projectDirectoryName: "invented-hyphenated-project"
+        ))
+    }
+
     func testShellPromptRejected() {
         XCTAssertNil(SessionTitleSanitizer.sanitize(
             title: "sean@Seans-MacBook-Pro ghostties %",


### PR DESCRIPTION
## Summary
- `SessionTitleSanitizer` rejected a Claude Code session title as noise only on **exact** equality with the project directory name. Claude Code's real title shape is `"<repo> | Claude Code"`, which isn't an exact match, so it sailed through and duplicated the project row's subtitle in the sidebar with zero added information.
- Now splits the cleaned title on common title separators (`|`, em/en dash, spaced `-`, `:`, `·`, `»`, `>`) and rejects the whole title only when every resulting segment reduces to the directory name or a bare program name. A genuinely informative segment (e.g. "fix the sidebar") still keeps the full title.
- Added `"claude code"` (two-word form) to `bareProgramNames`; it already had `"claude"`.
- Deliberately split on spaced `" - "` rather than a bare `-` so hyphenated directory names (`2026-web-playground`) aren't shredded into false-noise fragments — covered by a dedicated regression test.

## Test plan
- [x] `testProjectDirectoryNamePlusClaudeCodeSuffixRejected` — the reported bug shape, now nil
- [x] `testProjectDirectoryNameWithEmDashShellSuffixRejected` — em-dash + shell suffix, nil
- [x] `testProjectDirectoryNameRejected` — existing exact-match behavior unchanged
- [x] `testProjectDirectoryNameWithSpacedHyphenInformativeSuffixKept` — informative segment survives, full title kept
- [x] `testInformativeTitleMentioningUnrelatedDirNameKept`
- [x] `testHyphenatedDirectoryNameWithNoSeparatorKept` / `testHyphenatedDirectoryNamePlusClaudeCodeSuffixRejected` — hyphenated dir name regression guard
- [x] Full unfiltered suite: 649 total / 648 passed / 0 failed / 1 skipped (baseline on main: 643/642/0/1 — the 6 new tests account for the delta, nothing regressed)

All test fixtures use invented project/dir names, not real session data.
