### PR TITLE
Split Sessions tab into Active/Inactive/Archive zones

### DIFF
--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -6,7 +6,8 @@ import SwiftUI
 ///   + New Session (full-width row → native flyout menu for project selection)
 ///   ─────────────────────────────────
 ///   ACTIVE    (sessions with a live indicator state)
-///   ARCHIVE   (exited / never-run sessions)
+///   INACTIVE  (exited this launch, but still holds a live surface — ran, then stopped)
+///   ARCHIVE   (restored from disk, never started this launch)
 struct RecentsListView: View {
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
@@ -15,16 +16,20 @@ struct RecentsListView: View {
     @State private var editingName: String = ""
     @FocusState private var renameFieldFocused: Bool
 
-    /// Section-collapse state, persisted across launches. Active defaults open
-    /// (the sessions the user is working with today); Archive defaults closed.
+    /// Section-collapse state, persisted across launches. Active and
+    /// Inactive default open (sessions the user is working with today, or
+    /// just stopped); Archive defaults closed.
     @AppStorage("ghostties.sessionsSection.active") private var isActiveExpanded = true
+    @AppStorage("ghostties.sessionsSection.inactive") private var isInactiveExpanded = true
     @AppStorage("ghostties.sessionsSection.archive") private var isArchiveExpanded = false
 
     var body: some View {
-        // Bound once per body pass — `activeSessions`/`archiveSessions` each
-        // filter + build a Dictionary internally, and were previously
-        // evaluated twice (once for an `isEmpty` check, once for `ForEach`).
+        // Bound once per body pass — `activeSessions`/`inactiveSessions`/
+        // `archiveSessions` each filter + build a Dictionary internally, and
+        // were previously evaluated twice (once for an `isEmpty` check, once
+        // for `ForEach`).
         let active = activeSessions
+        let inactive = inactiveSessions
         let archive = archiveSessions
         let selectedId = coordinator.activeSessionId
 
@@ -38,22 +43,27 @@ struct RecentsListView: View {
                 // clears. See `effectiveExpanded(...)`.
                 let activeExpanded = Self.effectiveExpanded(
                     storedPreference: isActiveExpanded,
-                    isArchiveSection: false,
+                    section: .active,
                     sectionContainsSelectedSession: selectedId.map { id in active.contains { $0.id == id } } ?? false
+                )
+                let inactiveExpanded = Self.effectiveExpanded(
+                    storedPreference: isInactiveExpanded,
+                    section: .inactive,
+                    sectionContainsSelectedSession: selectedId.map { id in inactive.contains { $0.id == id } } ?? false
                 )
                 let archiveExpanded = Self.effectiveExpanded(
                     storedPreference: isArchiveExpanded,
-                    isArchiveSection: true,
+                    section: .archive,
                     sectionContainsSelectedSession: selectedId.map { id in archive.contains { $0.id == id } } ?? false
                 )
 
                 ScrollView {
                     LazyVStack(spacing: 2) {
-                        // Both headers always render (when there's at least
-                        // one session anywhere) — membership adapts, but the
-                        // ACTIVE/ARCHIVE headers themselves never disappear.
-                        // Every header carries a count; a collapsed header
-                        // with no count is illegible.
+                        // All three headers always render (when there's at
+                        // least one session anywhere) — membership adapts,
+                        // but the ACTIVE/INACTIVE/ARCHIVE headers themselves
+                        // never disappear. Every header carries a count; a
+                        // collapsed header with no count is illegible.
                         SessionSectionHeader(
                             title: "Active",
                             count: active.count,
@@ -62,6 +72,18 @@ struct RecentsListView: View {
                         )
                         if activeExpanded {
                             ForEach(active) { session in
+                                sessionRow(for: session)
+                            }
+                        }
+
+                        SessionSectionHeader(
+                            title: "Inactive",
+                            count: inactive.count,
+                            isExpanded: $isInactiveExpanded,
+                            isEffectivelyExpanded: inactiveExpanded
+                        )
+                        if inactiveExpanded {
+                            ForEach(inactive) { session in
                                 sessionRow(for: session)
                             }
                         }
@@ -170,16 +192,44 @@ struct RecentsListView: View {
     /// whichever section actually contains the selection without relocating
     /// the row itself. A selection-based membership guard here would make
     /// rows jump between sections — and everything below them shift ~38pt —
-    /// the instant the user clicks an Archive row, reintroducing exactly the
-    /// "rows reshuffling under the cursor" problem this feature set removed.
+    /// the instant the user clicks an Inactive/Archive row, reintroducing
+    /// exactly the "rows reshuffling under the cursor" problem this feature
+    /// set removed.
     var activeSessions: [AgentSession] {
         Self.activeSessions(from: store.sessions, indicatorStates: store.globalIndicatorStates)
     }
 
-    /// Sessions that have exited, completed, or never had a live process this
-    /// launch. See `activeSessions` — membership is indicator-state-only.
+    /// Sessions that exited (or completed) THIS launch but still hold a live
+    /// surface — `coordinator.hasLiveSurface(id:)` is true. This is the
+    /// "ran, then stopped" bucket: a session the user actually interacted
+    /// with this run, as opposed to one restored from disk that never
+    /// started. See `archiveSessions` for the complement.
+    var inactiveSessions: [AgentSession] {
+        Self.inactiveSessions(
+            from: store.sessions,
+            indicatorStates: store.globalIndicatorStates,
+            sessionIdsWithLiveSurface: sessionIdsWithLiveSurface
+        )
+    }
+
+    /// Sessions with no live indicator state AND no live surface this
+    /// launch — restored from `workspace.json`, never started this run.
+    /// Exact complement of `activeSessions` + `inactiveSessions` combined.
     var archiveSessions: [AgentSession] {
-        Self.archiveSessions(from: store.sessions, indicatorStates: store.globalIndicatorStates)
+        Self.archiveSessions(
+            from: store.sessions,
+            indicatorStates: store.globalIndicatorStates,
+            sessionIdsWithLiveSurface: sessionIdsWithLiveSurface
+        )
+    }
+
+    /// Session ids that currently have a live surface in `coordinator`
+    /// (`sessionTrees` or `browserManagers`) — the same liveness check
+    /// `WorkspaceSidebarView.sessionsTabCycleOrder` already uses via
+    /// `coordinator.hasLiveSurface(id:)`. Computed once per `body` pass via
+    /// the `inactiveSessions`/`archiveSessions` instance properties above.
+    private var sessionIdsWithLiveSurface: Set<UUID> {
+        Set(store.sessions.map(\.id).filter { coordinator.hasLiveSurface(id: $0) })
     }
 
     // MARK: - Actions
@@ -276,44 +326,78 @@ struct RecentsListView: View {
         })
     }
 
-    /// Pure, testable variant of the `archiveSessions` instance property.
-    /// Exact complement of `activeSessions` — every session is in exactly one
-    /// of the two.
-    static func archiveSessions(
+    /// Pure, testable variant of the `inactiveSessions` instance property:
+    /// not active (no live indicator state) AND still has a live surface
+    /// this launch — `sessionIdsWithLiveSurface` is passed in rather than
+    /// read from a coordinator so this stays a pure function callers can
+    /// test directly. Ordering matches `activeSessions` (append order) —
+    /// only `archiveSessions` reverses.
+    static func inactiveSessions(
         from sessions: [AgentSession],
-        indicatorStates: [UUID: SessionIndicatorState]
+        indicatorStates: [UUID: SessionIndicatorState],
+        sessionIdsWithLiveSurface: Set<UUID>
     ) -> [AgentSession] {
         sorted(sessions: sessions.filter {
             !belongsInActive(indicatorState: indicatorStates[$0.id] ?? .inactive)
+                && sessionIdsWithLiveSurface.contains($0.id)
         })
     }
 
+    /// Pure, testable variant of the `archiveSessions` instance property:
+    /// not active AND no live surface this launch — restored from disk,
+    /// never started. Together with `activeSessions` and `inactiveSessions`
+    /// this is an exact three-way partition — every session lands in
+    /// exactly one bucket. Newest-first (reverse append/creation order) —
+    /// the one bucket that does NOT keep append order, per Sean's call that
+    /// Archive should read reverse-chronological.
+    static func archiveSessions(
+        from sessions: [AgentSession],
+        indicatorStates: [UUID: SessionIndicatorState],
+        sessionIdsWithLiveSurface: Set<UUID>
+    ) -> [AgentSession] {
+        let archived = sorted(sessions: sessions.filter {
+            !belongsInActive(indicatorState: indicatorStates[$0.id] ?? .inactive)
+                && !sessionIdsWithLiveSurface.contains($0.id)
+        })
+        return Array(archived.reversed())
+    }
+
     // MARK: - Auto-Expand Override (static so tests can call without a view instance)
+
+    /// One of the three Sessions-tab sections. Used only to decide which
+    /// sections get the selected-session force-expand override below — not
+    /// a membership concept (see `belongsInActive`, `inactiveSessions`,
+    /// `archiveSessions` for that).
+    enum Section {
+        case active, inactive, archive
+    }
 
     /// Whether a section renders expanded. This is a RENDER-TIME override
     /// only — callers must never write the result back into the persisted
     /// `@AppStorage` preference, or a temporary condition (e.g. the selected
     /// session moving) would permanently clobber the user's stored choice.
     ///
-    /// Expands, regardless of `storedPreference`, when `isArchiveSection` is
-    /// true and `sectionContainsSelectedSession` is true — a session that
-    /// drops into a collapsed Archive stays visible, without relocating the
-    /// session itself (see `belongsInActive`). This override is
-    /// Archive-only: Active has no equivalent vanishing problem, and a
-    /// selected, running session lives in Active essentially all the time
-    /// during normal use, so applying the override there would make the
-    /// Active header a dead control.
+    /// Expands, regardless of `storedPreference`, when `section` is
+    /// `.inactive` or `.archive` AND `sectionContainsSelectedSession` is
+    /// true — a session that drops into a collapsed Inactive or Archive
+    /// section stays visible, without relocating the session itself (see
+    /// `belongsInActive`). This override excludes `.active`: a selected,
+    /// running session lives in Active essentially all the time during
+    /// normal use, so applying the override there would make the Active
+    /// header a dead control.
     ///
     /// Otherwise falls through to `storedPreference` unchanged — including
-    /// when Active is empty. An empty Active section is not, by itself, a
-    /// reason to force Archive open; the user's collapsed/expanded choice
-    /// for Archive is honored either way.
+    /// when another section is empty. An empty section is not, by itself, a
+    /// reason to force a different section open; the user's
+    /// collapsed/expanded choice is honored either way. (This "expand
+    /// because another section is empty" rule was deliberately removed in
+    /// PR #106 — do not reintroduce it.)
     static func effectiveExpanded(
         storedPreference: Bool,
-        isArchiveSection: Bool,
+        section: Section,
         sectionContainsSelectedSession: Bool
     ) -> Bool {
-        if isArchiveSection && sectionContainsSelectedSession { return true }
+        if section != .active && sectionContainsSelectedSession { return true }
         return storedPreference
     }
 

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -158,27 +158,29 @@ final class RecentsListViewTests: XCTestCase {
         }
     }
 
-    // MARK: - Active/Archive Sessions (pure helpers)
+    // MARK: - Active/Inactive/Archive Sessions (pure helpers)
 
     /// Sean hit this directly: at cold launch every session resolves
-    /// `.inactive` (no `globalIndicatorStates` entries yet), Active is empty,
-    /// nothing is selected, and Archive's stored preference is `false`
-    /// (its default). Archive must render COLLAPSED — an empty Active
-    /// section is not a reason to override the user's collapsed/expanded
-    /// choice for Archive. A bare sidebar in this state is the accepted
-    /// outcome; it is not this helper's job to prevent it.
+    /// `.inactive` (no `globalIndicatorStates` entries yet) and has no live
+    /// surface, Active is empty, nothing is selected, and Archive's stored
+    /// preference is `false` (its default). Archive must render COLLAPSED —
+    /// an empty Active section is not a reason to override the user's
+    /// collapsed/expanded choice for Archive. A bare sidebar in this state
+    /// is the accepted outcome; it is not this helper's job to prevent it.
     func testColdLaunchArchiveStaysCollapsedWhenActiveIsEmpty() {
         let sessions = (0..<14).map { session(name: "s\($0)") }
 
         let active = RecentsListView.activeSessions(from: sessions, indicatorStates: [:])
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:])
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
 
         XCTAssertTrue(active.isEmpty)
+        XCTAssertTrue(inactive.isEmpty)
         XCTAssertEqual(archive.count, 14)
 
         let archiveExpanded = RecentsListView.effectiveExpanded(
             storedPreference: false,
-            isArchiveSection: true,
+            section: .archive,
             sectionContainsSelectedSession: false
         )
         XCTAssertFalse(archiveExpanded, "Archive must honor the collapsed stored preference even when Active is empty")
@@ -194,17 +196,51 @@ final class RecentsListViewTests: XCTestCase {
         let indicatorStates: [UUID: SessionIndicatorState] = [other.id: .processing]
 
         let active = RecentsListView.activeSessions(from: sessions, indicatorStates: indicatorStates)
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates)
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsWithLiveSurface: [])
 
         XCTAssertTrue(archive.contains { $0.id == selected.id }, "selected session must stay in Archive")
         XCTAssertFalse(active.contains { $0.id == selected.id }, "selected session must NOT be promoted into Active")
 
         let archiveExpanded = RecentsListView.effectiveExpanded(
             storedPreference: false,
-            isArchiveSection: true,
+            section: .archive,
             sectionContainsSelectedSession: archive.contains { $0.id == selected.id }
         )
         XCTAssertTrue(archiveExpanded, "Archive must expand because it contains the selected session")
+    }
+
+    /// Same as above, but for the new INACTIVE section: a selected session
+    /// that ran-then-stopped (has a live surface) stays in Inactive — no
+    /// promotion into Active, no relocation into Archive — but its section
+    /// force-expands so it's visible without moving. This is the exact case
+    /// Sean hit: stop a running session, expect it somewhere other than
+    /// Archive, and it must be reachable even if Inactive were collapsed.
+    func testSelectedInactiveSessionStaysInInactiveButSectionExpands() {
+        let selected = session(name: "selected")
+        let other = session(name: "other")
+        let sessions = [selected, other]
+        let indicatorStates: [UUID: SessionIndicatorState] = [other.id: .processing]
+
+        let inactive = RecentsListView.inactiveSessions(
+            from: sessions,
+            indicatorStates: indicatorStates,
+            sessionIdsWithLiveSurface: [selected.id]
+        )
+        let archive = RecentsListView.archiveSessions(
+            from: sessions,
+            indicatorStates: indicatorStates,
+            sessionIdsWithLiveSurface: [selected.id]
+        )
+
+        XCTAssertTrue(inactive.contains { $0.id == selected.id }, "stopped-but-surfaced session must land in Inactive")
+        XCTAssertFalse(archive.contains { $0.id == selected.id }, "must NOT be lumped into Archive")
+
+        let inactiveExpanded = RecentsListView.effectiveExpanded(
+            storedPreference: false,
+            section: .inactive,
+            sectionContainsSelectedSession: true
+        )
+        XCTAssertTrue(inactiveExpanded, "Inactive must expand because it contains the selected session")
     }
 
     /// The auto-expand override is render-time only — it must never depend on
@@ -214,19 +250,19 @@ final class RecentsListViewTests: XCTestCase {
     func testEffectiveExpandedOverrideIgnoresStoredPreferenceWhenTriggered() {
         XCTAssertTrue(RecentsListView.effectiveExpanded(
             storedPreference: false,
-            isArchiveSection: true,
+            section: .archive,
             sectionContainsSelectedSession: true
         ))
         // No override condition met — falls through to the stored preference.
         XCTAssertFalse(RecentsListView.effectiveExpanded(
             storedPreference: false,
-            isArchiveSection: true,
+            section: .archive,
             sectionContainsSelectedSession: false
         ))
     }
 
-    /// FIX (dead ACTIVE header): the selected-session override must be
-    /// Archive-only. A selected, running session lives in Active essentially
+    /// FIX (dead ACTIVE header): the selected-session override must exclude
+    /// `.active`. A selected, running session lives in Active essentially
     /// all the time during normal use, so applying the override there would
     /// make the ACTIVE header collapse control permanently dead — tapping it
     /// while a session is selected must actually collapse the section, honoring
@@ -234,9 +270,123 @@ final class RecentsListViewTests: XCTestCase {
     func testActiveSectionRespectsStoredPreferenceEvenWhenItContainsSelectedSession() {
         XCTAssertFalse(RecentsListView.effectiveExpanded(
             storedPreference: false,
-            isArchiveSection: false,
+            section: .active,
             sectionContainsSelectedSession: true
-        ), "Active must not force-expand for the selected session — only Archive gets that override")
+        ), "Active must not force-expand for the selected session — only Inactive/Archive get that override")
+    }
+
+    /// The three static buckets must be an EXACT partition: every session
+    /// lands in exactly one of Active/Inactive/Archive, never zero, never
+    /// two. Mixes all combinations of indicator state x live-surface
+    /// presence across a set of sessions.
+    func testActiveInactiveArchivePartitionIsExact() {
+        let liveNoSurface = session(name: "liveNoSurface") // active, no surface (impossible in prod but must still partition)
+        let liveWithSurface = session(name: "liveWithSurface") // active, has surface
+        let stoppedWithSurface = session(name: "stoppedWithSurface") // inactive, has surface -> Inactive
+        let neverStarted = session(name: "neverStarted") // inactive, no surface -> Archive
+        let sessions = [liveNoSurface, liveWithSurface, stoppedWithSurface, neverStarted]
+
+        let indicatorStates: [UUID: SessionIndicatorState] = [
+            liveNoSurface.id: .processing,
+            liveWithSurface.id: .idle,
+            // stoppedWithSurface, neverStarted absent -> resolve .inactive.
+        ]
+        let sessionIdsWithLiveSurface: Set<UUID> = [liveWithSurface.id, stoppedWithSurface.id]
+
+        let active = RecentsListView.activeSessions(from: sessions, indicatorStates: indicatorStates)
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
+
+        for s in sessions {
+            let memberships = [active, inactive, archive].filter { bucket in bucket.contains { $0.id == s.id } }
+            XCTAssertEqual(memberships.count, 1, "\(s.name) must land in exactly one section, found in \(memberships.count)")
+        }
+        XCTAssertEqual(active.count + inactive.count + archive.count, sessions.count, "buckets must cover every session exactly once")
+
+        XCTAssertTrue(active.contains { $0.id == liveNoSurface.id })
+        XCTAssertTrue(active.contains { $0.id == liveWithSurface.id })
+        XCTAssertTrue(inactive.contains { $0.id == stoppedWithSurface.id })
+        XCTAssertTrue(archive.contains { $0.id == neverStarted.id })
+    }
+
+    /// The exact bug Sean hit: a session that RAN and was stopped (inactive
+    /// indicator, but still holds a live surface this launch) must land in
+    /// INACTIVE, not ARCHIVE.
+    func testStoppedButStillSurfacedSessionLandsInInactiveNotArchive() {
+        let stopped = session(name: "stopped")
+        let sessions = [stopped]
+        let sessionIdsWithLiveSurface: Set<UUID> = [stopped.id]
+
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
+
+        XCTAssertTrue(inactive.contains { $0.id == stopped.id }, "a stopped-but-surfaced session must land in Inactive")
+        XCTAssertTrue(archive.isEmpty, "must not also land in Archive")
+    }
+
+    /// A session with no live surface this launch (restored from disk,
+    /// never started) must land in ARCHIVE, not INACTIVE.
+    func testNeverStartedSessionLandsInArchiveNotInactive() {
+        let neverStarted = session(name: "neverStarted")
+        let sessions = [neverStarted]
+
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
+
+        XCTAssertTrue(archive.contains { $0.id == neverStarted.id }, "a never-started session must land in Archive")
+        XCTAssertTrue(inactive.isEmpty, "must not also land in Inactive")
+    }
+
+    // MARK: - Ordering (Archive newest-first; Active/Inactive unchanged)
+
+    /// Archive renders newest-first (reverse append/creation order) — Sean's
+    /// call. Active and Inactive keep the existing append-order behavior
+    /// (see `testLastActiveAtDoesNotAffectOrder` etc. above) unchanged.
+    func testArchiveOrdersNewestFirst() {
+        let oldest = session(name: "oldest")
+        let middle = session(name: "middle")
+        let newest = session(name: "newest")
+
+        // Passed in append/creation order: oldest, middle, newest.
+        let archive = RecentsListView.archiveSessions(
+            from: [oldest, middle, newest],
+            indicatorStates: [:],
+            sessionIdsWithLiveSurface: []
+        )
+
+        XCTAssertEqual(archive.map(\.name), ["newest", "middle", "oldest"], "Archive must render newest-first")
+    }
+
+    /// Active's ordering is unchanged by the three-way split — still
+    /// append/creation order, exactly like before.
+    func testActiveOrderingUnchangedByThreeWaySplit() {
+        let first = session(name: "first")
+        let second = session(name: "second")
+        let third = session(name: "third")
+        let indicatorStates: [UUID: SessionIndicatorState] = [
+            first.id: .processing, second.id: .idle, third.id: .waiting,
+        ]
+
+        let active = RecentsListView.activeSessions(from: [first, second, third], indicatorStates: indicatorStates)
+
+        XCTAssertEqual(active.map(\.name), ["first", "second", "third"], "Active must keep append order")
+    }
+
+    /// Inactive's ordering is append/creation order too, NOT reversed like
+    /// Archive.
+    func testInactiveOrderingIsAppendOrderNotReversed() {
+        let first = session(name: "first")
+        let second = session(name: "second")
+        let third = session(name: "third")
+        let sessionIdsWithLiveSurface: Set<UUID> = [first.id, second.id, third.id]
+
+        let inactive = RecentsListView.inactiveSessions(
+            from: [first, second, third],
+            indicatorStates: [:],
+            sessionIdsWithLiveSurface: sessionIdsWithLiveSurface
+        )
+
+        XCTAssertEqual(inactive.map(\.name), ["first", "second", "third"], "Inactive must keep append order, not reverse like Archive")
     }
 
     // MARK: - Sessions-tab Cmd+Shift+[/] cycle order (single shared source)


### PR DESCRIPTION
## Summary
- Adds an INACTIVE zone between ACTIVE and ARCHIVE in the Sessions tab: a session that ran and was stopped this launch (still holds a live surface via `coordinator.hasLiveSurface`) now lands in Inactive, not Archive. Archive is now reserved for sessions restored from disk that never started this launch.
- Archive now sorts newest-first. Active and Inactive keep their existing (append/creation order) ordering unchanged.
- `RecentsListView.effectiveExpanded`'s selected-session force-expand override now applies to whichever non-Active section contains the selection (Inactive or Archive), generalized via a `Section` enum replacing the old `isArchiveSection` bool. Does NOT reintroduce the "expand because another section is empty" rule removed in #106.
- The three static bucketing functions (`activeSessions`, `inactiveSessions`, `archiveSessions`) remain pure/testable — liveness is passed in as `sessionIdsWithLiveSurface: Set<UUID>` rather than reached from a coordinator inside the function.

## Why
Sean stopped a running session, expected it to land somewhere other than Archive, and it went straight to Archive — because Archive was membership-testing on indicator state alone (`!= .inactive`), with no distinction between "ran, then stopped" and "never started this launch."

## Test plan
- [x] `xcodebuild test` full suite (no filter): **650 total / 649 passed / 0 failed / 1 skipped** (up from baseline 643/642/0/1 — 7 new tests, 0 removed)
- [x] `testActiveInactiveArchivePartitionIsExact` — three-way partition is exact
- [x] `testStoppedButStillSurfacedSessionLandsInInactiveNotArchive` — the exact bug Sean hit
- [x] `testNeverStartedSessionLandsInArchiveNotInactive`
- [x] `testArchiveOrdersNewestFirst`, `testActiveOrderingUnchangedByThreeWaySplit`, `testInactiveOrderingIsAppendOrderNotReversed`
- [x] `testSelectedInactiveSessionStaysInInactiveButSectionExpands` — selected session in a collapsed Inactive header still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)