### PR TITLE
fix(sidebar): sort Archive by lastActiveAt, not reverse insertion order

### DIFF
--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -347,9 +347,10 @@ struct RecentsListView: View {
     /// not active AND no live surface this launch — restored from disk,
     /// never started. Together with `activeSessions` and `inactiveSessions`
     /// this is an exact three-way partition — every session lands in
-    /// exactly one bucket. Newest-first (reverse append/creation order) —
-    /// the one bucket that does NOT keep append order, per Sean's call that
-    /// Archive should read reverse-chronological.
+    /// exactly one bucket. Sorted newest-first by `lastActiveAt` — the one
+    /// bucket that does NOT keep append order, per Sean's call that Archive
+    /// should read reverse-chronological. Sessions with a `nil`
+    /// `lastActiveAt` sort last, after every timestamped session.
     static func archiveSessions(
         from sessions: [AgentSession],
         indicatorStates: [UUID: SessionIndicatorState],
@@ -359,7 +360,25 @@ struct RecentsListView: View {
             !belongsInActive(indicatorState: indicatorStates[$0.id] ?? .inactive)
                 && !sessionIdsWithLiveSurface.contains($0.id)
         })
-        return Array(archived.reversed())
+        // Sort newest-first by `lastActiveAt`, nil last. `Array.sort` is not
+        // guaranteed stable, so ties (and nil-vs-nil) are broken on the
+        // original index to preserve incoming relative order.
+        return archived
+            .enumerated()
+            .sorted { lhs, rhs in
+                switch (lhs.element.lastActiveAt, rhs.element.lastActiveAt) {
+                case let (l?, r?):
+                    if l != r { return l > r }
+                case (nil, .some):
+                    return false
+                case (.some, nil):
+                    return true
+                case (nil, nil):
+                    break
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
     }
 
     // MARK: - Auto-Expand Override (static so tests can call without a view instance)

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -337,24 +337,74 @@ final class RecentsListViewTests: XCTestCase {
         XCTAssertTrue(inactive.isEmpty, "must not also land in Inactive")
     }
 
-    // MARK: - Ordering (Archive newest-first; Active/Inactive unchanged)
+    // MARK: - Ordering (Archive newest-first by lastActiveAt; Active/Inactive unchanged)
 
-    /// Archive renders newest-first (reverse append/creation order) — Sean's
-    /// call. Active and Inactive keep the existing append-order behavior
-    /// (see `testLastActiveAtDoesNotAffectOrder` etc. above) unchanged.
-    func testArchiveOrdersNewestFirst() {
-        let oldest = session(name: "oldest")
-        let middle = session(name: "middle")
-        let newest = session(name: "newest")
+    /// Archive renders newest-first by `lastActiveAt` — Sean's call. This
+    /// fixture deliberately inserts sessions in an order that DISAGREES with
+    /// reverse-insertion-order: append order is [twoHoursAgo, fiveMinAgo,
+    /// oneHourAgo], so a naive `Array(archived.reversed())` would produce
+    /// [oneHourAgo, fiveMinAgo, twoHoursAgo] — wrong. Only a real sort on
+    /// `lastActiveAt` produces the correct [fiveMinAgo, oneHourAgo,
+    /// twoHoursAgo]. Active and Inactive keep the existing append-order
+    /// behavior (see `testLastActiveAtDoesNotAffectOrder` etc. above)
+    /// unchanged.
+    func testArchiveOrdersNewestFirstByLastActiveAt() {
+        let twoHoursAgo = session(name: "twoHoursAgo", lastActiveAt: Date(timeIntervalSinceNow: -7200))
+        let fiveMinAgo = session(name: "fiveMinAgo", lastActiveAt: Date(timeIntervalSinceNow: -300))
+        let oneHourAgo = session(name: "oneHourAgo", lastActiveAt: Date(timeIntervalSinceNow: -3600))
 
-        // Passed in append/creation order: oldest, middle, newest.
+        // Append/creation order: twoHoursAgo, fiveMinAgo, oneHourAgo —
+        // NOT chronological, so reverse-insertion-order and newest-first
+        // disagree here.
         let archive = RecentsListView.archiveSessions(
-            from: [oldest, middle, newest],
+            from: [twoHoursAgo, fiveMinAgo, oneHourAgo],
             indicatorStates: [:],
             sessionIdsWithLiveSurface: []
         )
 
-        XCTAssertEqual(archive.map(\.name), ["newest", "middle", "oldest"], "Archive must render newest-first")
+        XCTAssertEqual(
+            archive.map(\.name),
+            ["fiveMinAgo", "oneHourAgo", "twoHoursAgo"],
+            "Archive must sort by lastActiveAt descending, not reverse insertion order"
+        )
+    }
+
+    /// Sessions with a `nil` `lastActiveAt` sort last, after every
+    /// timestamped session — regardless of insertion position.
+    func testArchiveSortsNilLastActiveAtLast() {
+        let noTimestamp = session(name: "noTimestamp", lastActiveAt: nil)
+        let oneHourAgo = session(name: "oneHourAgo", lastActiveAt: Date(timeIntervalSinceNow: -3600))
+        let fiveMinAgo = session(name: "fiveMinAgo", lastActiveAt: Date(timeIntervalSinceNow: -300))
+
+        // noTimestamp is inserted FIRST, but must still render LAST.
+        let archive = RecentsListView.archiveSessions(
+            from: [noTimestamp, oneHourAgo, fiveMinAgo],
+            indicatorStates: [:],
+            sessionIdsWithLiveSurface: []
+        )
+
+        XCTAssertEqual(
+            archive.map(\.name),
+            ["fiveMinAgo", "oneHourAgo", "noTimestamp"],
+            "nil lastActiveAt must sort after every timestamped session"
+        )
+    }
+
+    /// When every session lacks a `lastActiveAt` (all nil), the sort must be
+    /// stable and preserve incoming (append/creation) order rather than
+    /// reordering arbitrarily.
+    func testArchivePreservesAppendOrderWhenAllLastActiveAtAreNil() {
+        let first = session(name: "first", lastActiveAt: nil)
+        let second = session(name: "second", lastActiveAt: nil)
+        let third = session(name: "third", lastActiveAt: nil)
+
+        let archive = RecentsListView.archiveSessions(
+            from: [first, second, third],
+            indicatorStates: [:],
+            sessionIdsWithLiveSurface: []
+        )
+
+        XCTAssertEqual(archive.map(\.name), ["first", "second", "third"], "all-nil list must preserve insertion order")
     }
 
     /// Active's ordering is unchanged by the three-way split — still


### PR DESCRIPTION
## Summary

PR #108 intended Archive (Sessions tab) to render newest-first, but
`archiveSessions()` reversed the store's insertion order instead of
sorting by any timestamp — `Array(archived.reversed())`. It looked
approximately right because insertion order roughly tracks creation
order, which is why it slipped through. Observed live: `Shell 5 (1h)`,
`testing (1h)`, `testing too (5m)` — a 5-minute-old row below two
1-hour-old ones.

Fix: sort the Archive bucket by `session.lastActiveAt` descending.
`nil` sorts last. Ties (and nil-vs-nil) are broken on the original
index for a deterministic, stable ordering — `Array.sort` isn't
guaranteed stable — matching the existing decorate-sort-undecorate
convention already used in `WorkspaceStore.swift`.

`sorted(sessions:)`, and Active/Inactive ordering, are untouched —
those sections deliberately render in store order.

## Why the old test didn't catch it

`testArchiveOrdersNewestFirst` built its fixture sessions with no
`lastActiveAt` set at all and in an order where reverse-insertion-order
happened to equal newest-first, so it passed against the broken
implementation. Replaced with `testArchiveOrdersNewestFirstByLastActiveAt`,
which inserts sessions in the order `[twoHoursAgo, fiveMinAgo, oneHourAgo]`
— append order that disagrees with chronological order — and asserts the
output is `[fiveMinAgo, oneHourAgo, twoHoursAgo]`. A naive
`Array(archived.reversed())` on that fixture would produce
`[oneHourAgo, fiveMinAgo, twoHoursAgo]`, which fails the assertion, so
this test can only pass against a real timestamp sort.

Also added:
- `testArchiveSortsNilLastActiveAtLast` — a `nil`-timestamp session
  inserted first still renders last.
- `testArchivePreservesAppendOrderWhenAllLastActiveAtAreNil` — an
  all-nil list keeps insertion order rather than reordering arbitrarily.

Existing `testActiveOrderingUnchangedByThreeWaySplit` and
`testInactiveOrderingIsAppendOrderNotReversed` (unmodified) confirm
Active/Inactive ordering is unaffected.

## Test plan

- [x] `xcodebuild ... build` — BUILD SUCCEEDED
- [x] Full suite, no filter: 658 total / 657 passed / 0 failed / 1
      skipped (via `xcresulttool get test-results summary`)
- [x] Confirmed by inspection that the new ordering test fails against
      `Array(archived.reversed())` (reasoning above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)