### PR TITLE
fix(sidebar): reject status-glyph, dir-basename, and abbreviated-path terminal titles

### DIFF
--- a/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
+++ b/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
@@ -21,6 +21,37 @@ enum SessionTitleSanitizer {
         "claude", "claude code", "zsh", "bash", "-zsh", "-bash", "sh", "-sh", "fish", "-fish"
     ]
 
+    /// Fixed status/spinner glyphs Claude Code (and similar CLI agents) prefix
+    /// onto a terminal title while working, e.g. `"✳ Claude Code"`. Distinct
+    /// from the Braille Patterns block (below), which covers the *animated*
+    /// spinner frames (`⠐`, `⠄`, `⠁`, …) rather than a fixed marker character.
+    private static let leadingStatusMarkerCharacters: Set<Character> = ["✳", "✻", "✽", "*", "·", "•"]
+
+    /// Braille Patterns block (U+2800–U+28FF) — Claude Code's terminal spinner
+    /// cycles through glyphs in this range as its status animation. Matched
+    /// as a range rather than an enumerated set since the spinner can use any
+    /// of the 256 codepoints in the block.
+    private static let brailleSpinnerRange: ClosedRange<UInt32> = 0x2800...0x28FF
+
+    /// Strips a single leading status/spinner marker — and any whitespace
+    /// immediately following it — from `segment`, if present. This exists
+    /// only so the bare-program-name and directory-name checks below can see
+    /// past a transient marker like `"✳ "` or `"⠐ "`; it must never be used
+    /// to change what's actually persisted as a session name; the full,
+    /// unstripped title is what gets returned when a title is accepted.
+    private static func strippingLeadingStatusMarker(from segment: Substring) -> Substring {
+        var result = segment
+        guard let first = result.first else { return result }
+        let isBrailleSpinnerFrame = first.unicodeScalars.count == 1
+            && brailleSpinnerRange.contains(first.unicodeScalars[first.unicodeScalars.startIndex].value)
+        guard isBrailleSpinnerFrame || leadingStatusMarkerCharacters.contains(first) else { return result }
+        result.removeFirst()
+        while let next = result.first, next.isWhitespace {
+            result.removeFirst()
+        }
+        return result
+    }
+
     /// Separators terminal titles commonly use to glue a program/repo name
     /// onto the "real" content, e.g. `"repo-name | Claude Code"` or
     /// `"repo-name — zsh"`. Deliberately excludes a bare, unspaced `-` —
@@ -44,7 +75,13 @@ enum SessionTitleSanitizer {
         )
         let dirLower = projectDirectoryName.lowercased()
         for rawSegment in replaced.split(separator: placeholder, omittingEmptySubsequences: true) {
-            let segment = rawSegment.trimmingCharacters(in: .whitespaces)
+            let trimmedSegment = rawSegment.trimmingCharacters(in: .whitespaces)
+            guard !trimmedSegment.isEmpty else { continue }
+            // Strip a leading status/spinner marker (e.g. "✳ " or "⠐ ") before
+            // judging whether this segment is informative — a marker prefix
+            // on an otherwise-bare program/directory name must not make it
+            // look informative.
+            let segment = String(strippingLeadingStatusMarker(from: Substring(trimmedSegment)))
             guard !segment.isEmpty else { continue }
             let segmentLower = segment.lowercased()
             if segmentLower == dirLower { continue }
@@ -52,6 +89,64 @@ enum SessionTitleSanitizer {
             return true
         }
         return false
+    }
+
+    /// True when `cleaned`, once split on `titleSeparatorPattern`, ends in a
+    /// bare "Claude Code" segment — e.g. `"Code | Claude Code"` or
+    /// `"2026-web-playground — Claude Code"`. Claude Code's idle terminal
+    /// title has the shape `"<cwd-basename> | Claude Code"`, where the
+    /// segment before "Claude Code" is always a directory basename, never a
+    /// description — so a trailing "Claude Code" segment marks the whole
+    /// title as boilerplate regardless of what precedes it or what the
+    /// project directory happens to be. Deliberately unconditional (no
+    /// `projectDirectoryName` needed): the leading segment's identity
+    /// doesn't matter here.
+    ///
+    /// This does mean a leading segment that reads as informative on its own
+    /// (e.g. `"Fixing the parser | Claude Code"`) is still rejected. That's
+    /// intentional, not an oversight: Claude Code's *working* title uses a
+    /// marker prefix instead (`"<glyph> <task description>"`), never a
+    /// trailing "| Claude Code" — so this exact shape doesn't occur for a
+    /// genuine description, and the simple, unconditional rule is worth more
+    /// than guarding an edge case that can't happen.
+    private static func endsWithBareClaudeCodeSegment(_ cleaned: String) -> Bool {
+        let placeholder: Character = "\u{0}"
+        let replaced = cleaned.replacingOccurrences(
+            of: titleSeparatorPattern,
+            with: String(placeholder),
+            options: .regularExpression
+        )
+        guard let lastSegment = replaced.split(separator: placeholder, omittingEmptySubsequences: true).last else {
+            return false
+        }
+        return lastSegment.trimmingCharacters(in: .whitespaces).lowercased() == "claude code"
+    }
+
+    /// True when `cleaned` is an *abbreviated* filesystem path — the shape a
+    /// terminal title uses to fit a long path into limited width, e.g.
+    /// `"…/Code/_experiments/2026-web-playground"` or
+    /// `".../Users/sean/projects/thing"`. The existing bare-path check below
+    /// only recognizes a path that starts with `/` or `~` outright; an
+    /// elided prefix defeats it.
+    ///
+    /// Distinguished from ordinary prose that happens to start with an
+    /// ellipsis (`"… and then it worked"`) by requiring a `/` to follow the
+    /// ellipsis once any whitespace between them is skipped — a real
+    /// abbreviated path always continues straight into the next path
+    /// segment; prose does not.
+    private static func hasAbbreviatedPathPrefix(_ cleaned: String) -> Bool {
+        var remainder = Substring(cleaned)
+        if remainder.hasPrefix("...") {
+            remainder = remainder.dropFirst(3)
+        } else if remainder.hasPrefix("…") {
+            remainder = remainder.dropFirst()
+        } else {
+            return false
+        }
+        while let next = remainder.first, next.isWhitespace {
+            remainder = remainder.dropFirst()
+        }
+        return remainder.hasPrefix("/")
     }
 
     /// The `titleFromTerminal` fallback `SurfaceView_AppKit` writes ~500ms after
@@ -137,6 +232,17 @@ enum SessionTitleSanitizer {
 
         let lowercased = cleaned.lowercased()
         if bareProgramNames.contains(lowercased) { return nil }
+        // Same check, but past a leading status/spinner marker — Claude Code
+        // prefixes its title with a marker like "✳ " or an animated Braille
+        // spinner frame ("⠐ ") that changes every couple of seconds, so
+        // "✳ Claude Code" must be caught here just like "claude code" is
+        // above. Only the check uses the stripped value; the title returned
+        // below (if accepted) is always the untouched `cleaned` string.
+        let markerStrippedLowercased = strippingLeadingStatusMarker(from: Substring(lowercased))
+        if bareProgramNames.contains(String(markerStrippedLowercased)) { return nil }
+        // Reject a title ending in a bare "Claude Code" segment regardless of
+        // what precedes it — see `endsWithBareClaudeCodeSegment` doc comment.
+        if endsWithBareClaudeCodeSegment(cleaned) { return nil }
         // Reject a title whose only content, once split on common title
         // separators (`|`, em/en dash, spaced `-`, `:`, `·`, `»`, `>`), is
         // the project directory name and/or a bare program name — e.g.
@@ -154,7 +260,7 @@ enum SessionTitleSanitizer {
         // "~/Code/my project" is still just a path, not a description of
         // work) — so gate on word count rather than requiring the whole
         // string to be space-free.
-        if cleaned.hasPrefix("/") || cleaned.hasPrefix("~") {
+        if cleaned.hasPrefix("/") || cleaned.hasPrefix("~") || hasAbbreviatedPathPrefix(cleaned) {
             let wordCount = cleaned.split(separator: " ").count
             if wordCount <= 3 { return nil }
         }

--- a/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
+++ b/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
@@ -56,7 +56,7 @@ enum SessionTitleSanitizer {
     /// onto the "real" content, e.g. `"repo-name | Claude Code"` or
     /// `"repo-name — zsh"`. Deliberately excludes a bare, unspaced `-` —
     /// project/repo directory names are routinely hyphenated
-    /// (`2026-web-playground`), and splitting on every hyphen would shred
+    /// (`sample-web-project`), and splitting on every hyphen would shred
     /// that single informative segment into fragments that individually
     /// look like noise. Only a *spaced* hyphen (`" - "`) is treated as a
     /// separator, matching how humans actually punctuate a title.
@@ -93,7 +93,7 @@ enum SessionTitleSanitizer {
 
     /// True when `cleaned`, once split on `titleSeparatorPattern`, ends in a
     /// bare "Claude Code" segment — e.g. `"Code | Claude Code"` or
-    /// `"2026-web-playground — Claude Code"`. Claude Code's idle terminal
+    /// `"sample-web-project — Claude Code"`. Claude Code's idle terminal
     /// title has the shape `"<cwd-basename> | Claude Code"`, where the
     /// segment before "Claude Code" is always a directory basename, never a
     /// description — so a trailing "Claude Code" segment marks the whole
@@ -124,8 +124,8 @@ enum SessionTitleSanitizer {
 
     /// True when `cleaned` is an *abbreviated* filesystem path — the shape a
     /// terminal title uses to fit a long path into limited width, e.g.
-    /// `"…/Code/_experiments/2026-web-playground"` or
-    /// `".../Users/sean/projects/thing"`. The existing bare-path check below
+    /// `"…/Code/sandbox/sample-web-project"` or
+    /// `".../Users/someone/projects/thing"`. The existing bare-path check below
     /// only recognizes a path that starts with `/` or `~` outright; an
     /// elided prefix defeats it.
     ///

--- a/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
+++ b/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
@@ -21,7 +21,7 @@ final class SessionTitleSanitizerTests: XCTestCase {
 
     func testBarePathRejected() {
         XCTAssertNil(SessionTitleSanitizer.sanitize(
-            title: "/Users/sean/Code/ghostties",
+            title: "/Users/someone/Code/ghostties",
             currentName: "Session 1"
         ))
         XCTAssertNil(SessionTitleSanitizer.sanitize(
@@ -266,7 +266,7 @@ final class SessionTitleSanitizerTests: XCTestCase {
 
     func testBarePathWithSpacesInDirectoryNameRejected() {
         XCTAssertNil(SessionTitleSanitizer.sanitize(
-            title: "/Users/sean/My Code/thing",
+            title: "/Users/someone/My Code/thing",
             currentName: "Session 1"
         ))
         XCTAssertNil(SessionTitleSanitizer.sanitize(
@@ -345,12 +345,12 @@ final class SessionTitleSanitizerTests: XCTestCase {
     func testCwdBasenamePipeClaudeCodeRejectedEvenWhenNotProjectDirectory() {
         // Observed live shape: cwd is a subdirectory of the project (e.g.
         // "~/Code"), so its basename ("Code") doesn't match the project
-        // directory name ("2026-web-playground") that #107's check compares
+        // directory name ("sample-web-project") that #107's check compares
         // against — this must still be rejected.
         XCTAssertNil(SessionTitleSanitizer.sanitize(
             title: "Code | Claude Code",
             currentName: "Session 1",
-            projectDirectoryName: "2026-web-playground"
+            projectDirectoryName: "sample-web-project"
         ))
     }
 
@@ -382,7 +382,7 @@ final class SessionTitleSanitizerTests: XCTestCase {
 
     func testEllipsisAbbreviatedPathRejected() {
         XCTAssertNil(SessionTitleSanitizer.sanitize(
-            title: "…/Code/_experiments/2026-web-playground",
+            title: "…/Code/sandbox/sample-web-project",
             currentName: "Session 1"
         ))
     }

--- a/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
+++ b/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
@@ -274,4 +274,140 @@ final class SessionTitleSanitizerTests: XCTestCase {
             currentName: "Session 1"
         ))
     }
+
+    // MARK: - Status/spinner-glyph-prefixed titles (Claude Code's title
+    // shape while working: a leading marker or animated Braille spinner
+    // frame glued onto "Claude Code" or another bare program/directory name)
+
+    func testAsteriskMarkerPrefixedClaudeCodeRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "✳ Claude Code",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testBrailleSpinnerFramePrefixedClaudeCodeRejected() {
+        // Claude Code's terminal spinner is an animated Braille Patterns
+        // (U+2800–U+28FF) frame that changes every couple of seconds.
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "⠐ Claude Code",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testAlternateAsteriskMarkerPrefixedClaudeCodeRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "✻ Claude Code",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testMiddleDotMarkerPrefixedShellNameRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "· zsh",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testMarkerPrefixedProjectDirectoryNameRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "✳ invented-project",
+            currentName: "Session 1",
+            projectDirectoryName: "invented-project"
+        ))
+    }
+
+    func testMarkerPrefixedInformativeTitleKept() {
+        // A marker prefix on a real, informative title must not cause a
+        // rejection — and the accepted value stays the FULL sanitized
+        // title, glyph included. Rewriting the stored name to a de-glyphed
+        // version is a separate product decision, not made here.
+        let result = SessionTitleSanitizer.sanitize(
+            title: "✳ Refactoring the auth module",
+            currentName: "Session 1"
+        )
+        XCTAssertEqual(result, "✳ Refactoring the auth module")
+    }
+
+    func testAsteriskNotAtStartOfTitleDoesNotTriggerRejection() {
+        // A leading-marker strip must never fire on an asterisk that isn't
+        // actually a leading status marker.
+        let result = SessionTitleSanitizer.sanitize(
+            title: "5 * 3 results",
+            currentName: "Session 1"
+        )
+        XCTAssertEqual(result, "5 * 3 results")
+    }
+
+    // MARK: - Leak 2: a title ending in a bare "Claude Code" segment is
+    // boilerplate regardless of what directory basename precedes it.
+
+    func testCwdBasenamePipeClaudeCodeRejectedEvenWhenNotProjectDirectory() {
+        // Observed live shape: cwd is a subdirectory of the project (e.g.
+        // "~/Code"), so its basename ("Code") doesn't match the project
+        // directory name ("2026-web-playground") that #107's check compares
+        // against — this must still be rejected.
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "Code | Claude Code",
+            currentName: "Session 1",
+            projectDirectoryName: "2026-web-playground"
+        ))
+    }
+
+    func testArbitraryDirectoryPipeClaudeCodeRejectedWithNoProjectDirectory() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "anything-at-all | Claude Code",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testBareClaudeCodeAloneStillRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(title: "Claude Code", currentName: "Session 1"))
+    }
+
+    func testInformativePrefixBeforeClaudeCodeSuffixStillRejected() {
+        // Deliberate: Claude Code never actually emits "<description> |
+        // Claude Code" — its working title uses a marker prefix instead,
+        // with no trailing "| Claude Code". A trailing "Claude Code" segment
+        // is always boilerplate, so this is rejected even though the
+        // leading segment reads as informative on its own.
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "Fixing the parser | Claude Code",
+            currentName: "Session 1"
+        ))
+    }
+
+    // MARK: - Leak 3: an ellipsis-abbreviated path defeats the bare-path
+    // shape check unless the leading "…"/"..." is accounted for.
+
+    func testEllipsisAbbreviatedPathRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "…/Code/_experiments/2026-web-playground",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testTripleDotAbbreviatedPathRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: ".../Users/someone/projects/thing",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testShortEllipsisAbbreviatedPathRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "…/src",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testEllipsisPrefixedProseKept() {
+        // A leading ellipsis followed by prose (not a path) must survive —
+        // the strip only applies when what follows actually reads as a path.
+        let result = SessionTitleSanitizer.sanitize(
+            title: "… and then it worked",
+            currentName: "Session 1"
+        )
+        XCTAssertEqual(result, "… and then it worked")
+    }
 }


### PR DESCRIPTION
## Summary

PR #107 rejected terminal titles that are just the project directory name plus boilerplate (e.g. `"repo-name | Claude Code"`), and added `"claude code"` to the bare-program-name set. Not enough — three related leaks were found by watching a live `workspace.json`:

1. **Status/spinner glyph prefix.** Claude Code prefixes its title with a marker (`✳`, `✻`, `✽`) or an animated Braille-spinner frame (`⠐`, U+2800-U+28FF) that changes every couple of seconds — `"✳ Claude Code"`, `"⠐ Claude Code"` are not exact matches for `"claude code"`, so they slipped through and the sidebar name animated through spinner frames, persisting every frame to disk.
2. **Directory-basename echo beyond the project root.** `"<cwd-basename> | Claude Code"` is only caught when the cwd basename equals the project directory name. A session running in a subdirectory (e.g. cwd `~/Code` inside project `2026-web-playground`) produces `"Code | Claude Code"`, which leaked straight through.
3. **Ellipsis-abbreviated path.** `"…/Code/_experiments/thing"` defeats the bare-path check, which only recognized a literal leading `/` or `~`.

## Fixes

- Strip a leading status/spinner marker (fixed glyph set + full Braille Patterns block U+2800-U+28FF) before the bare-program-name and directory-name checks *only* — the accepted return value is always the untouched, full title. A marker-prefixed but genuinely informative title (`"✳ Refactoring the auth module"`) is still kept, glyph included.
- Reject any title ending in a bare `"Claude Code"` segment, regardless of what precedes it — Claude Code's idle title always has this shape, and its working title never does (it uses a marker prefix, no trailing `"| Claude Code"`), so this can't discard a real description.
- Recognize a leading `…`/`...` immediately followed by `/` (after skipping whitespace) as an abbreviated path; prose starting with an ellipsis (`"… and then it worked"`) is unaffected since it isn't followed by a `/`.

## Test plan

- [x] `xcodebuild ... build` — BUILD SUCCEEDED
- [x] `xcodebuild ... test` (full suite, no filter) — TEST SUCCEEDED
- [x] `xcrun xcresulttool get test-results summary` — **673 total / 672 passed / 0 failed / 1 skipped** (main baseline: 658/657/0/1; 15 new tests, all passing, no regressions)
- [x] Named tests cover all 7 required glyph cases, the accepted-value-unchanged case, all 4 Leak-2 cases (including the deliberate "informative prefix still rejected" case), and all 4 Leak-3 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
