### PR TITLE
fix: INACTIVE zone uses started-this-launch, not has-a-surface-now

### DIFF
--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 ///   + New Session (full-width row → native flyout menu for project selection)
 ///   ─────────────────────────────────
 ///   ACTIVE    (sessions with a live indicator state)
-///   INACTIVE  (exited this launch, but still holds a live surface — ran, then stopped)
+///   INACTIVE  (started at some point this launch, currently not active — ran, then stopped)
 ///   ARCHIVE   (restored from disk, never started this launch)
 struct RecentsListView: View {
     @EnvironmentObject private var store: WorkspaceStore
@@ -199,37 +199,29 @@ struct RecentsListView: View {
         Self.activeSessions(from: store.sessions, indicatorStates: store.globalIndicatorStates)
     }
 
-    /// Sessions that exited (or completed) THIS launch but still hold a live
-    /// surface — `coordinator.hasLiveSurface(id:)` is true. This is the
-    /// "ran, then stopped" bucket: a session the user actually interacted
-    /// with this run, as opposed to one restored from disk that never
-    /// started. See `archiveSessions` for the complement.
+    /// Sessions that exited (or completed) THIS launch but were started at
+    /// some point this launch — `coordinator.sessionIdsStartedThisLaunch`
+    /// contains the id. This is the "ran, then stopped" bucket: a session
+    /// the user actually interacted with this run, as opposed to one
+    /// restored from disk that never started. See `archiveSessions` for the
+    /// complement.
     var inactiveSessions: [AgentSession] {
         Self.inactiveSessions(
             from: store.sessions,
             indicatorStates: store.globalIndicatorStates,
-            sessionIdsWithLiveSurface: sessionIdsWithLiveSurface
+            sessionIdsStartedThisLaunch: coordinator.sessionIdsStartedThisLaunch
         )
     }
 
-    /// Sessions with no live indicator state AND no live surface this
+    /// Sessions with no live indicator state AND never started this
     /// launch — restored from `workspace.json`, never started this run.
     /// Exact complement of `activeSessions` + `inactiveSessions` combined.
     var archiveSessions: [AgentSession] {
         Self.archiveSessions(
             from: store.sessions,
             indicatorStates: store.globalIndicatorStates,
-            sessionIdsWithLiveSurface: sessionIdsWithLiveSurface
+            sessionIdsStartedThisLaunch: coordinator.sessionIdsStartedThisLaunch
         )
-    }
-
-    /// Session ids that currently have a live surface in `coordinator`
-    /// (`sessionTrees` or `browserManagers`) — the same liveness check
-    /// `WorkspaceSidebarView.sessionsTabCycleOrder` already uses via
-    /// `coordinator.hasLiveSurface(id:)`. Computed once per `body` pass via
-    /// the `inactiveSessions`/`archiveSessions` instance properties above.
-    private var sessionIdsWithLiveSurface: Set<UUID> {
-        Set(store.sessions.map(\.id).filter { coordinator.hasLiveSurface(id: $0) })
     }
 
     // MARK: - Actions
@@ -327,24 +319,24 @@ struct RecentsListView: View {
     }
 
     /// Pure, testable variant of the `inactiveSessions` instance property:
-    /// not active (no live indicator state) AND still has a live surface
-    /// this launch — `sessionIdsWithLiveSurface` is passed in rather than
+    /// not active (no live indicator state) AND was started at some point
+    /// this launch — `sessionIdsStartedThisLaunch` is passed in rather than
     /// read from a coordinator so this stays a pure function callers can
     /// test directly. Ordering matches `activeSessions` (append order) —
     /// only `archiveSessions` reverses.
     static func inactiveSessions(
         from sessions: [AgentSession],
         indicatorStates: [UUID: SessionIndicatorState],
-        sessionIdsWithLiveSurface: Set<UUID>
+        sessionIdsStartedThisLaunch: Set<UUID>
     ) -> [AgentSession] {
         sorted(sessions: sessions.filter {
             !belongsInActive(indicatorState: indicatorStates[$0.id] ?? .inactive)
-                && sessionIdsWithLiveSurface.contains($0.id)
+                && sessionIdsStartedThisLaunch.contains($0.id)
         })
     }
 
     /// Pure, testable variant of the `archiveSessions` instance property:
-    /// not active AND no live surface this launch — restored from disk,
+    /// not active AND never started this launch — restored from disk,
     /// never started. Together with `activeSessions` and `inactiveSessions`
     /// this is an exact three-way partition — every session lands in
     /// exactly one bucket. Sorted newest-first by `lastActiveAt` — the one
@@ -354,11 +346,11 @@ struct RecentsListView: View {
     static func archiveSessions(
         from sessions: [AgentSession],
         indicatorStates: [UUID: SessionIndicatorState],
-        sessionIdsWithLiveSurface: Set<UUID>
+        sessionIdsStartedThisLaunch: Set<UUID>
     ) -> [AgentSession] {
         let archived = sorted(sessions: sessions.filter {
             !belongsInActive(indicatorState: indicatorStates[$0.id] ?? .inactive)
-                && !sessionIdsWithLiveSurface.contains($0.id)
+                && !sessionIdsStartedThisLaunch.contains($0.id)
         })
         // Sort newest-first by `lastActiveAt`, nil last. `Array.sort` is not
         // guaranteed stable, so ties (and nil-vs-nil) are broken on the

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -42,6 +42,16 @@ final class SessionCoordinator: ObservableObject {
     /// sessionTrees (terminal) OR browserManagers (browser), never both.
     private(set) var browserManagers: [UUID: BrowserTabManager] = [:]
 
+    /// Every session ID that has ever had a live surface (terminal tree or
+    /// browser manager) during this process's lifetime. Inserted into wherever
+    /// a `sessionTrees` or `browserManagers` entry is first established; never
+    /// removed — not on close, not on `clearRuntime`, not on surface teardown.
+    /// In-memory only, never persisted to `workspace.json`: it resets naturally
+    /// on relaunch, which is the desired semantics. Distinguishes a
+    /// stopped-this-launch session (INACTIVE) from one restored from disk that
+    /// never started this launch (ARCHIVE) — see `RecentsListView`.
+    private(set) var sessionIdsStartedThisLaunch: Set<UUID> = []
+
     /// Bridges CEF callbacks to the browser UI. Keyed by session ID.
     private var browserBridges: [UUID: BrowserSessionBridge] = [:]
 
@@ -247,6 +257,7 @@ final class SessionCoordinator: ObservableObject {
         snapshotActiveTree()
 
         sessionTrees[session.id] = newTree
+        sessionIdsStartedThisLaunch.insert(session.id)
         setStatus(.running, for: session.id)
         subscribeToOutput(surface: newView, sessionId: session.id)
         activeSessionId = session.id
@@ -335,6 +346,7 @@ final class SessionCoordinator: ObservableObject {
         snapshotActiveTree()
 
         browserManagers[session.id] = manager
+        sessionIdsStartedThisLaunch.insert(session.id)
         setStatus(.running, for: session.id)
         activeSessionId = session.id
         lastActiveSessionPerProject[session.projectId] = session.id
@@ -1412,6 +1424,7 @@ final class SessionCoordinator: ObservableObject {
     /// Never used in production.
     func seedEmptySessionTreeForTesting(id: UUID) {
         sessionTrees[id] = SplitTree()
+        sessionIdsStartedThisLaunch.insert(id)
     }
 
     /// Test-only: current count of live name-sync subscriptions, so tests

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -171,8 +171,8 @@ final class RecentsListViewTests: XCTestCase {
         let sessions = (0..<14).map { session(name: "s\($0)") }
 
         let active = RecentsListView.activeSessions(from: sessions, indicatorStates: [:])
-        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsStartedThisLaunch: [])
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsStartedThisLaunch: [])
 
         XCTAssertTrue(active.isEmpty)
         XCTAssertTrue(inactive.isEmpty)
@@ -196,7 +196,7 @@ final class RecentsListViewTests: XCTestCase {
         let indicatorStates: [UUID: SessionIndicatorState] = [other.id: .processing]
 
         let active = RecentsListView.activeSessions(from: sessions, indicatorStates: indicatorStates)
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsWithLiveSurface: [])
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsStartedThisLaunch: [])
 
         XCTAssertTrue(archive.contains { $0.id == selected.id }, "selected session must stay in Archive")
         XCTAssertFalse(active.contains { $0.id == selected.id }, "selected session must NOT be promoted into Active")
@@ -210,11 +210,12 @@ final class RecentsListViewTests: XCTestCase {
     }
 
     /// Same as above, but for the new INACTIVE section: a selected session
-    /// that ran-then-stopped (has a live surface) stays in Inactive — no
-    /// promotion into Active, no relocation into Archive — but its section
-    /// force-expands so it's visible without moving. This is the exact case
-    /// Sean hit: stop a running session, expect it somewhere other than
-    /// Archive, and it must be reachable even if Inactive were collapsed.
+    /// that ran-then-stopped (started at some point this launch) stays in
+    /// Inactive — no promotion into Active, no relocation into Archive — but
+    /// its section force-expands so it's visible without moving. This is the
+    /// exact case Sean hit: stop a running session, expect it somewhere
+    /// other than Archive, and it must be reachable even if Inactive were
+    /// collapsed.
     func testSelectedInactiveSessionStaysInInactiveButSectionExpands() {
         let selected = session(name: "selected")
         let other = session(name: "other")
@@ -224,15 +225,15 @@ final class RecentsListViewTests: XCTestCase {
         let inactive = RecentsListView.inactiveSessions(
             from: sessions,
             indicatorStates: indicatorStates,
-            sessionIdsWithLiveSurface: [selected.id]
+            sessionIdsStartedThisLaunch: [selected.id]
         )
         let archive = RecentsListView.archiveSessions(
             from: sessions,
             indicatorStates: indicatorStates,
-            sessionIdsWithLiveSurface: [selected.id]
+            sessionIdsStartedThisLaunch: [selected.id]
         )
 
-        XCTAssertTrue(inactive.contains { $0.id == selected.id }, "stopped-but-surfaced session must land in Inactive")
+        XCTAssertTrue(inactive.contains { $0.id == selected.id }, "stopped-but-started-this-launch session must land in Inactive")
         XCTAssertFalse(archive.contains { $0.id == selected.id }, "must NOT be lumped into Archive")
 
         let inactiveExpanded = RecentsListView.effectiveExpanded(
@@ -281,9 +282,9 @@ final class RecentsListViewTests: XCTestCase {
     /// presence across a set of sessions.
     func testActiveInactiveArchivePartitionIsExact() {
         let liveNoSurface = session(name: "liveNoSurface") // active, no surface (impossible in prod but must still partition)
-        let liveWithSurface = session(name: "liveWithSurface") // active, has surface
-        let stoppedWithSurface = session(name: "stoppedWithSurface") // inactive, has surface -> Inactive
-        let neverStarted = session(name: "neverStarted") // inactive, no surface -> Archive
+        let liveWithSurface = session(name: "liveWithSurface") // active, started this launch
+        let stoppedWithSurface = session(name: "stoppedWithSurface") // inactive, started this launch -> Inactive
+        let neverStarted = session(name: "neverStarted") // inactive, never started -> Archive
         let sessions = [liveNoSurface, liveWithSurface, stoppedWithSurface, neverStarted]
 
         let indicatorStates: [UUID: SessionIndicatorState] = [
@@ -291,11 +292,11 @@ final class RecentsListViewTests: XCTestCase {
             liveWithSurface.id: .idle,
             // stoppedWithSurface, neverStarted absent -> resolve .inactive.
         ]
-        let sessionIdsWithLiveSurface: Set<UUID> = [liveWithSurface.id, stoppedWithSurface.id]
+        let sessionIdsStartedThisLaunch: Set<UUID> = [liveWithSurface.id, stoppedWithSurface.id]
 
         let active = RecentsListView.activeSessions(from: sessions, indicatorStates: indicatorStates)
-        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsStartedThisLaunch: sessionIdsStartedThisLaunch)
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: indicatorStates, sessionIdsStartedThisLaunch: sessionIdsStartedThisLaunch)
 
         for s in sessions {
             let memberships = [active, inactive, archive].filter { bucket in bucket.contains { $0.id == s.id } }
@@ -310,31 +311,83 @@ final class RecentsListViewTests: XCTestCase {
     }
 
     /// The exact bug Sean hit: a session that RAN and was stopped (inactive
-    /// indicator, but still holds a live surface this launch) must land in
-    /// INACTIVE, not ARCHIVE.
+    /// indicator, but was started at some point this launch) must land in
+    /// INACTIVE, not ARCHIVE. This is the pure-function analog of
+    /// `testStartedThenStoppedSessionLandsInInactiveNotArchive` below.
     func testStoppedButStillSurfacedSessionLandsInInactiveNotArchive() {
         let stopped = session(name: "stopped")
         let sessions = [stopped]
-        let sessionIdsWithLiveSurface: Set<UUID> = [stopped.id]
+        let sessionIdsStartedThisLaunch: Set<UUID> = [stopped.id]
 
-        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: sessionIdsWithLiveSurface)
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsStartedThisLaunch: sessionIdsStartedThisLaunch)
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsStartedThisLaunch: sessionIdsStartedThisLaunch)
 
-        XCTAssertTrue(inactive.contains { $0.id == stopped.id }, "a stopped-but-surfaced session must land in Inactive")
+        XCTAssertTrue(inactive.contains { $0.id == stopped.id }, "a stopped-but-started-this-launch session must land in Inactive")
         XCTAssertTrue(archive.isEmpty, "must not also land in Archive")
     }
 
-    /// A session with no live surface this launch (restored from disk,
+    /// A session that never started this launch (restored from disk,
     /// never started) must land in ARCHIVE, not INACTIVE.
     func testNeverStartedSessionLandsInArchiveNotInactive() {
         let neverStarted = session(name: "neverStarted")
         let sessions = [neverStarted]
 
-        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
-        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsWithLiveSurface: [])
+        let inactive = RecentsListView.inactiveSessions(from: sessions, indicatorStates: [:], sessionIdsStartedThisLaunch: [])
+        let archive = RecentsListView.archiveSessions(from: sessions, indicatorStates: [:], sessionIdsStartedThisLaunch: [])
 
         XCTAssertTrue(archive.contains { $0.id == neverStarted.id }, "a never-started session must land in Archive")
         XCTAssertTrue(inactive.isEmpty, "must not also land in Inactive")
+    }
+
+    /// Integration-level regression test for PR #108's actual bug, exercised
+    /// through the real `SessionCoordinator` rather than a hand-built Set.
+    ///
+    /// A session is started this launch (`seedEmptySessionTreeForTesting`
+    /// establishes a tree, mirroring production's `createSession`, which
+    /// also inserts into `sessionIdsStartedThisLaunch`), then stopped
+    /// (`closeSession` removes the tree — mirroring every real way a
+    /// session stops: `closeSession`, natural process exit, and
+    /// `clearRuntime` all remove the tree). The session now has NO current
+    /// surface and indicator state resolves to `.inactive`.
+    ///
+    /// It must land in INACTIVE. This is the exact case that broke: under
+    /// the OLD `hasLiveSurface(id:)`-based discriminator, a stopped session
+    /// has `sessionTrees[id] == nil` and `browserManagers[id] == nil`, so
+    /// `hasLiveSurface` returns `false` — the session would fail the
+    /// Inactive membership test and fall through to Archive instead. The
+    /// assertion below on `coordinator.sessionIdsStartedThisLaunch` (which
+    /// stays `true` after the stop, unlike `hasLiveSurface`) is what
+    /// distinguishes the fixed behavior from the old, broken one.
+    @MainActor
+    func testStartedThenStoppedSessionLandsInInactiveNotArchive() {
+        let stopped = session(name: "stopped")
+        let sessions = [stopped]
+
+        let coordinator = SessionCoordinator()
+        coordinator.seedEmptySessionTreeForTesting(id: stopped.id)
+        XCTAssertTrue(coordinator.hasLiveSurface(id: stopped.id), "sanity: session has a live surface right after starting")
+
+        coordinator.closeSession(id: stopped.id)
+
+        // Old, broken discriminator: this is now false — proving that a
+        // hasLiveSurface-based bucketing would misclassify this session.
+        XCTAssertFalse(coordinator.hasLiveSurface(id: stopped.id), "stopping removes the tree, so the OLD discriminator would (wrongly) exclude this session from Inactive")
+        // New discriminator: stays true for the rest of the launch.
+        XCTAssertTrue(coordinator.sessionIdsStartedThisLaunch.contains(stopped.id), "started-this-launch tracking must survive the stop")
+
+        let inactive = RecentsListView.inactiveSessions(
+            from: sessions,
+            indicatorStates: [:],
+            sessionIdsStartedThisLaunch: coordinator.sessionIdsStartedThisLaunch
+        )
+        let archive = RecentsListView.archiveSessions(
+            from: sessions,
+            indicatorStates: [:],
+            sessionIdsStartedThisLaunch: coordinator.sessionIdsStartedThisLaunch
+        )
+
+        XCTAssertTrue(inactive.contains { $0.id == stopped.id }, "a started-then-stopped session must land in Inactive")
+        XCTAssertTrue(archive.isEmpty, "must not fall through to Archive")
     }
 
     // MARK: - Ordering (Archive newest-first by lastActiveAt; Active/Inactive unchanged)
@@ -359,7 +412,7 @@ final class RecentsListViewTests: XCTestCase {
         let archive = RecentsListView.archiveSessions(
             from: [twoHoursAgo, fiveMinAgo, oneHourAgo],
             indicatorStates: [:],
-            sessionIdsWithLiveSurface: []
+            sessionIdsStartedThisLaunch: []
         )
 
         XCTAssertEqual(
@@ -380,7 +433,7 @@ final class RecentsListViewTests: XCTestCase {
         let archive = RecentsListView.archiveSessions(
             from: [noTimestamp, oneHourAgo, fiveMinAgo],
             indicatorStates: [:],
-            sessionIdsWithLiveSurface: []
+            sessionIdsStartedThisLaunch: []
         )
 
         XCTAssertEqual(
@@ -401,7 +454,7 @@ final class RecentsListViewTests: XCTestCase {
         let archive = RecentsListView.archiveSessions(
             from: [first, second, third],
             indicatorStates: [:],
-            sessionIdsWithLiveSurface: []
+            sessionIdsStartedThisLaunch: []
         )
 
         XCTAssertEqual(archive.map(\.name), ["first", "second", "third"], "all-nil list must preserve insertion order")
@@ -428,12 +481,12 @@ final class RecentsListViewTests: XCTestCase {
         let first = session(name: "first")
         let second = session(name: "second")
         let third = session(name: "third")
-        let sessionIdsWithLiveSurface: Set<UUID> = [first.id, second.id, third.id]
+        let sessionIdsStartedThisLaunch: Set<UUID> = [first.id, second.id, third.id]
 
         let inactive = RecentsListView.inactiveSessions(
             from: [first, second, third],
             indicatorStates: [:],
-            sessionIdsWithLiveSurface: sessionIdsWithLiveSurface
+            sessionIdsStartedThisLaunch: sessionIdsStartedThisLaunch
         )
 
         XCTAssertEqual(inactive.map(\.name), ["first", "second", "third"], "Inactive must keep append order, not reverse like Archive")


### PR DESCRIPTION
## Problem

PR #108 split the Sessions tab into ACTIVE / INACTIVE / ARCHIVE. INACTIVE membership used `SessionCoordinator.hasLiveSurface(id:)`, which is `sessionTrees[id] != nil || browserManagers[id] != nil`. Every way a session stops — `closeSession`, natural process exit, `clearRuntime` — removes the tree, so `hasLiveSurface` flips to `false` the instant a session stops. Net effect: a stopped session always skipped INACTIVE and landed in ARCHIVE, leaving INACTIVE permanently empty.

## Fix

Added `SessionCoordinator.sessionIdsStartedThisLaunch: Set<UUID>` — a launch-scoped, in-memory-only set inserted into wherever a `sessionTrees` or `browserManagers` entry is first created (the two production creation sites: `createSession` and `createBrowserSession`), never removed. Not persisted to `workspace.json` — resets on relaunch by design.

`RecentsListView`'s INACTIVE/ARCHIVE static bucketing functions now take `sessionIdsStartedThisLaunch` (renamed from `sessionIdsWithLiveSurface`) instead of a live-surface-right-now set. Shape and partition logic unchanged — only the discriminator's source changed from "has a surface now" to "ever had one this launch."

`hasLiveSurface(id:)` itself is untouched; other call sites (Cmd+Shift+[/] cycling, menu bar focus) depend on its existing semantics.

## Creation call sites found (complete list)

- `SessionCoordinator.createSession` — `sessionTrees[session.id] = newTree`
- `SessionCoordinator.createBrowserSession` — `browserManagers[session.id] = manager`
- `seedEmptySessionTreeForTesting` (DEBUG test seam, never used in production) — updated to insert too, so tests exercising the real lifecycle stay consistent

Confirmed complete by grepping every subscript-assignment site for `sessionTrees[` / `browserManagers[` in `SessionCoordinator.swift`: all other sites are either guarded re-writes of an already-existing key (`snapshotActiveTree`, the surface-close handler updating a live tree) or membership checks (`!= nil`), not new-key insertions.

## Tests

- `testStartedThenStoppedSessionLandsInInactiveNotArchive` — integration-level, drives the real `SessionCoordinator` (seed a tree, `closeSession`), asserts the session lands in INACTIVE and explicitly asserts `hasLiveSurface` is now `false` (proving the old discriminator would have misclassified it into ARCHIVE)
- `testNeverStartedSessionLandsInArchiveNotInactive` — a session with no launch-start marker lands in ARCHIVE
- `testActiveInactiveArchivePartitionIsExact` — updated to the renamed set; still asserts every session lands in exactly one bucket
- Archive newest-first-by-`lastActiveAt` ordering tests (`testArchiveOrdersNewestFirstByLastActiveAt`, `testArchiveSortsNilLastActiveAtLast`, `testArchivePreservesAppendOrderWhenAllLastActiveAtAreNil`) — unchanged behavior, updated only for the parameter rename

## Verification

- `xcodebuild ... build` — BUILD SUCCEEDED
- Full suite (`xcresulttool get test-results summary`): **659 total / 658 passed / 0 failed / 1 skipped** (baseline on main: 658/657/0/1 — the +1 is the new integration test)
- Confirmed no `Codable`/persistence change: `sessionIdsStartedThisLaunch` only appears in `SessionCoordinator.swift`/`RecentsListView.swift`/tests, not in any workspace-persistence path