### PR TITLE
Lead homepage/download with brew + npx install

### DIFF
--- a/docs/plans/website-install-paths.html
+++ b/docs/plans/website-install-paths.html
@@ -1,0 +1,715 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ghostties.org — surfacing brew + npx install paths</title>
+    <link rel="stylesheet" href="http://localhost:4849/assets/plan.css" />
+  </head>
+  <body>
+    <h1>Surfacing <code>brew</code> + <code>npx</code> on ghostties.org</h1>
+    <p class="doc-meta">
+      Ghostties · web lane · 2026-08-09 · <strong>Plan for review</strong>
+    </p>
+
+    <blockquote class="callout" data-anchor-id="tldr">
+      <p>
+        <strong
+          >Both terminal installs shipped and are verified live. The site still
+          presents the DMG as the only path.</strong
+        >
+        This plan closes that gap across two pages, fixes an un-automated
+        release step found along the way, and corrects one trust claim that is
+        no longer accurate.
+      </p>
+      <p>
+        Scope is deliberately narrow: no redesign, no new visual world, no
+        touching the hero's ghost choreography.
+      </p>
+    </blockquote>
+
+    <blockquote class="callout" data-anchor-id="status">
+      <p>
+        <strong>Status 2026-08-09: paused, nothing built for real.</strong>
+        Design is settled through mockups; no repo file has been changed.
+        Working mockups lived in a session scratchpad and are
+        <em>ephemeral</em> — if this is picked up in a new session, they are
+        gone and this document is the record.
+      </p>
+    </blockquote>
+
+    <h2 data-anchor-id="decisions">Decisions made</h2>
+
+    <table data-anchor-id="decisions-table">
+      <thead>
+        <tr>
+          <th>Question</th>
+          <th>Call</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Hero structure</td>
+          <td>
+            <strong>Six lines.</strong> Three separate install buttons — brew,
+            npx, download — each on its own line.
+          </td>
+        </tr>
+        <tr>
+          <td><code>- install soon</code> joke line</td>
+          <td>
+            <strong>Removed.</strong> Written as a promise months ago; the
+            promise shipped.
+          </td>
+        </tr>
+        <tr>
+          <td>Version + requirements</td>
+          <td>
+            <strong>Merged into one line</strong> —
+            <code>+ ghostties % v0.1.0-beta.21 · macOS 13+</code>. Drops the
+            date and "Apple Silicon"; both survive on <code>/download</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>Terminal width</td>
+          <td>
+            <strong>Stays 46ch.</strong> Short button labels rather than
+            widening the hero for the 54ch brew command.
+          </td>
+        </tr>
+        <tr>
+          <td>Timing</td>
+          <td>
+            <strong>Compressed</strong>, uniform 0.35s gaps. Ends ~9.25s vs
+            10.1s shipping today.
+          </td>
+        </tr>
+        <tr>
+          <td><code>+</code> prefixes</td>
+          <td>
+            <strong>Kept.</strong> With no red line left they stop being diff
+            grammar, but on screen they still read as one contiguous terminal
+            output block.
+          </td>
+        </tr>
+        <tr>
+          <td><code>/download</code> ordering</td>
+          <td><strong>Homebrew primary</strong>, npx second, DMG third.</td>
+        </tr>
+        <tr>
+          <td>Gatekeeper claim</td>
+          <td>
+            <strong>Soften.</strong> Keep "signed and notarized"; drop the
+            absolute no-warning promise.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 data-anchor-id="hero-final">Final hero structure</h2>
+
+    <pre><code>  cd ~/ghostties                              14ch  unchanged
+  https://github.com/SeanSmithWorks/ghostties 43ch  unchanged
++ ghostties % v0.1.0-beta.21 · macOS 13+      40ch  merged
++ [brew install ⧉]                            18ch  copies the FULL cask command
++ [npx ghostties-install ⧉]                   27ch  desktop · 25ch ≤480px, icon drops
++ [download now]                              16ch  → .dmg</code></pre>
+
+    <p>
+      Timing at the site's ~0.025s/char rate, uniform 0.35s gaps: line-3 @5.65s
+      · line-4 @7.0s · line-5 @7.825s · line-6 @8.85s, ending ~9.25s. Lines 1–2
+      and every ghost animation (<code>g0</code>–<code>g7</code>) are untouched.
+    </p>
+
+    <blockquote class="callout" data-anchor-id="domlesson">
+      <p>
+        <strong
+          >Build note that cost a round — the <code>.line</code> must stay a
+          block <code>&lt;div&gt;</code> with the button nested inside
+          it.</strong
+        >
+        Making the line itself a <code>&lt;button&gt;</code> breaks three things
+        at once: buttons are <code>inline-block</code> so brew and npx flow side
+        by side instead of stacking; <code>text-indent: -2ch</code> (the hanging
+        indent positioning the <code>+</code>) does not apply, so stray
+        <code>+</code> glyphs escape the <code>width: 0</code> clip and float on
+        the page mid-animation; and the green reveal background paints
+        per-button instead of across the line.
+      </p>
+      <p>
+        The shipped <code>line-6</code> already had the right pattern —
+        <code>&lt;span aria-hidden&gt;+ [&lt;/span&gt;</code>, then the
+        interactive element, then
+        <code>&lt;span aria-hidden&gt;]&lt;/span&gt;</code>. Copy it rather than
+        describing the behaviour and leaving the structure open.
+      </p>
+    </blockquote>
+
+    <h2 data-anchor-id="constraints">Three constraints that shaped this</h2>
+
+    <h3 data-anchor-id="c1">
+      1. The brew command cannot go in the hero terminal
+    </h3>
+    <p>
+      <code>brew install --cask seansmithworks/tap/ghostties</code> is 48
+      characters, 50 with the <code>+&nbsp;</code> diff prefix. The terminal is
+      <code>width: 46ch</code> on desktop, and below 480px it drops to 16px mono
+      inside <code>calc(100vw - 72px)</code> — roughly
+      <strong>25ch at 320px</strong>. It would clip mid-word on every phone.
+    </p>
+    <p>
+      This is why the hero carries the <em>short</em> path and
+      <code>/download</code> carries the <em>recommended</em> one in full.
+    </p>
+
+    <h3 data-anchor-id="c2">2. The typewriter cannot wrap</h3>
+    <p>
+      Every line animates <code>width: 0 → Nch</code> with
+      <code>steps(N)</code> under <code>white-space: nowrap</code>. A line that
+      reflows breaks the mechanism outright. So "two lines" means
+      <strong>two real <code>.line</code> divs</strong>, not one line that wraps
+      at a breakpoint.
+    </p>
+    <p>
+      On desktop they stack as two short options under the green block, which
+      reads as intentional rather than as overflow.
+    </p>
+
+    <h3 data-anchor-id="c3">
+      3. The copy glyph must sit outside the typed character count
+    </h3>
+    <p>Character budget at 320px is ~25ch. Measured:</p>
+    <table data-anchor-id="charcount">
+      <thead>
+        <tr>
+          <th>Candidate</th>
+          <th>Width</th>
+          <th>Fits 320px (~25ch)?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>+ npx ghostties-install</code></td>
+          <td>23ch</td>
+          <td>Yes, with margin</td>
+        </tr>
+        <tr>
+          <td><code>+ [npx ghostties-install]</code></td>
+          <td>25ch</td>
+          <td>Exactly at budget, zero margin</td>
+        </tr>
+        <tr>
+          <td><code>+ [npx ghostties-install ⧉]</code></td>
+          <td>27ch</td>
+          <td><strong>No — clips</strong></td>
+        </tr>
+        <tr>
+          <td><code>+ [download now]</code></td>
+          <td>16ch</td>
+          <td>Yes</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      So the copy button is rendered <em>after</em> the animated span, outside
+      the width animation. Note <code>.line</code> has
+      <code>overflow: hidden</code>, so the button needs a wrapper rather than
+      absolute positioning inside the line.
+    </p>
+
+    <h2 data-anchor-id="hero">The hero terminal</h2>
+
+    <p>
+      The last line becomes two lines. Brackets carry meaning:
+      <strong>bracketed = click, bare = copy.</strong> The bare-command form
+      already has precedent one line up — the GitHub URL on line 2 is a bare
+      link with no brackets.
+    </p>
+
+    <pre><code>  cd ~/ghostties
+  https://github.com/SeanSmithWorks/ghostties
+- ghostties % install soon
++ ghostties % v0.1.0-beta.21
++ 02Aug2026 · macOS 13+ · Apple Silicon
++ npx ghostties-install   ⧉        ← copy, 23ch typed
++ [download now]                   ← click → .dmg, 16ch</code></pre>
+
+    <blockquote class="callout" data-anchor-id="joke">
+      <p>
+        <strong>The joke finally pays off.</strong> Line 3 is
+        <code>- ghostties % install soon</code> — a red diff-<em>delete</em>
+        line, written as a promise. With a real install command on the green
+        side, the diff now literally reads <em>install soon → install now</em>.
+        That payoff was already set up on the page; it just needed the green
+        line to carry a command.
+      </p>
+    </blockquote>
+
+    <h3 data-anchor-id="timing">
+      Timing — this costs ~0.8s unless we compress
+    </h3>
+
+    <p>
+      I checked whether there was slack earlier in the sequence.
+      <strong>There is not</strong> — the 1.56s→4.2s gap I suspected was dead
+      air is the ghost pyramid assembling (<code>g1</code> at 1.8s through
+      <code>g7</code> ending 3.8s). That stays untouched.
+    </p>
+
+    <p>
+      The three gaps <em>inside</em> the green diff block are reclaimable
+      without touching the ghosts:
+    </p>
+
+    <table data-anchor-id="timing-table">
+      <thead>
+        <tr>
+          <th>Line</th>
+          <th>Today</th>
+          <th>Append as-is</th>
+          <th>Compressed <em>(recommended)</em></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>line-3 (26ch)</td>
+          <td>5.50 → 6.15</td>
+          <td>5.50 → 6.15</td>
+          <td>5.50 → 6.15</td>
+        </tr>
+        <tr>
+          <td>line-4 (28ch)</td>
+          <td>7.00 → 7.70</td>
+          <td>7.00 → 7.70</td>
+          <td>6.50 → 7.20</td>
+        </tr>
+        <tr>
+          <td>line-5 (39ch)</td>
+          <td>8.20 → 9.20</td>
+          <td>8.20 → 9.20</td>
+          <td>7.55 → 8.55</td>
+        </tr>
+        <tr>
+          <td>line-6 (23ch)</td>
+          <td>—</td>
+          <td>9.70 → 10.28</td>
+          <td>8.90 → 9.48</td>
+        </tr>
+        <tr>
+          <td>line-7 (16ch)</td>
+          <td>9.70 → <strong>10.10</strong></td>
+          <td>10.50 → <strong>10.90</strong></td>
+          <td>9.80 → <strong>10.20</strong></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      Compressing trims the inter-line gaps from 0.85 / 0.50 / 0.50s to a
+      uniform 0.35s. It lands at
+      <strong>~10.2s — parity with today</strong> while adding a whole line.
+      <code>BACKLOG.md</code> already lists "CTA gated behind ~10.1s of
+      animation" as an open complaint; appending without compressing makes a
+      known problem measurably worse.
+    </p>
+
+    <blockquote class="callout" data-anchor-id="open-timing">
+      <p>
+        <strong>Open for you:</strong> compressed (~10.2s, recommended) or
+        append as-is (10.9s)? Fully rebalancing the hero's pacing is a separate
+        <code>BACKLOG</code> item ("the hero half") and is <em>not</em> in this
+        scope either way.
+      </p>
+    </blockquote>
+
+    <h2 data-anchor-id="downloadpage">The <code>/download</code> page</h2>
+
+    <p>
+      Reordered around <em>install method</em> rather than "current release".
+      The existing <code>.download-btn</code> and
+      <code>.download-meta</code> survive as the third option — no rebuild.
+    </p>
+
+    <pre><code>Download
+───────────────────────────────────────────
+Install
+
+  brew install --cask seansmithworks/tap/ghostties   [copy]
+  Recommended · upgrades with brew, in-app via Sparkle
+
+  npx ghostties-install                              [copy]
+  One-off installer · pinned version + SHA256
+
+  [ Download v0.1.0-beta.21 for macOS ]
+  147 MB · macOS 13+ · Apple Silicon
+  Developer ID signed and notarized by Apple.
+
+Beta release — auto-updates via Sparkle once installed.
+View all releases → · What's new →
+───────────────────────────────────────────</code></pre>
+
+    <p>
+      <strong>Reuse, don't invent:</strong> <code>DESIGN.md</code> §6 notes that
+      <code>pre</code> is styled in <code>style.css</code> but no page uses it
+      today. The command blocks are exactly that use. The copy button is the
+      only genuinely new component, and it stays in <code>download.html</code>'s
+      page block per §2 (the hero's copy affordance lives in a different context
+      and shares no rules).
+    </p>
+
+    <h2 data-anchor-id="bug">
+      Bug found in scope — the homepage DMG URL is never bumped
+    </h2>
+
+    <p>
+      <code>index.html:594</code> hardcodes
+      <code>.../releases/download/v0.1.0-beta.21/Ghostties.dmg</code>, but
+      <code>scripts/update-web-version.py</code> rewrites that URL in
+      <code>download.html</code> only. Its own comment asserts the opposite:
+    </p>
+
+    <pre><code># 1. DMG download URL — only download.html has one. (index.html links to /download.)</code></pre>
+
+    <p>
+      That comment is wrong, and the HTML at
+      <code>index.html:590</code> confirms it is a known manual step ("Hardcoded
+      DMG URL — bump the version tag with each release"). It is correct today
+      only because someone remembered.
+    </p>
+
+    <p>
+      <strong>Fix at the root:</strong> add <code>web/index.html</code> to that
+      rule and correct the comment. The alternative — pointing the hero at
+      <code>/download</code> — routes around the bug instead of fixing it, and
+      costs a click.
+    </p>
+
+    <blockquote class="callout" data-anchor-id="noversions">
+      <p>
+        <strong>Neither new command carries a version number.</strong>
+        <code>brew install --cask seansmithworks/tap/ghostties</code> and
+        <code>npx ghostties-install</code> both resolve their own versions, so
+        they need no new regexes and cannot be mangled by the bump job. The only
+        version-bearing string added anywhere is the one already handled.
+      </p>
+    </blockquote>
+
+    <h2 data-anchor-id="trust">The Gatekeeper claim</h2>
+
+    <p><code>download.html:124</code> currently reads:</p>
+    <pre><code>Developer ID signed and notarized by Apple — opens without a Gatekeeper warning.</code></pre>
+    <p>
+      Per <code>BACKLOG.md</code> (2026-08-08) the release workflow runs
+      <code>create-dmg</code> <em>before</em> <code>xcrun stapler staple</code>,
+      so the DMG ships unstapled. The cask installs from that same DMG, so
+      <strong
+        >adding brew spreads the claim to a new path rather than leaving it
+        contained.</strong
+      >
+      Becoming:
+    </p>
+    <pre><code>Developer ID signed and notarized by Apple.</code></pre>
+    <p>
+      One clause deleted, no new claims. It becomes true again automatically
+      once the stapler ordering is fixed — which stays filed for the app lane,
+      not bundled here.
+    </p>
+
+    <h2 data-anchor-id="files">Files touched</h2>
+
+    <table data-anchor-id="files-table">
+      <thead>
+        <tr>
+          <th>File</th>
+          <th>Change</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>web/index.html</code></td>
+          <td>
+            line-6 → <code>npx ghostties-install</code> + copy button; new
+            line-7 <code>[download now]</code>; typing keyframes,
+            <code>steps()</code> counts, char-count comments; compressed delays;
+            copy handler JS
+          </td>
+        </tr>
+        <tr>
+          <td><code>web/download.html</code></td>
+          <td>
+            Restructure to Install-first with two command blocks; soften the
+            Gatekeeper line; copy handler
+          </td>
+        </tr>
+        <tr>
+          <td><code>scripts/update-web-version.py</code></td>
+          <td>
+            Add <code>web/index.html</code> to the DMG-URL rule; correct the
+            false comment
+          </td>
+        </tr>
+        <tr>
+          <td><code>web/DESIGN.md</code></td>
+          <td>
+            Record the command-block + copy-button component and the new
+            <code>pre</code> usage
+          </td>
+        </tr>
+        <tr>
+          <td><code>BACKLOG.md</code></td>
+          <td>
+            File the <code>create-dmg</code>/<code>stapler</code> reorder for
+            the app lane
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 data-anchor-id="a11y">Accessibility</h2>
+    <ul>
+      <li>
+        Copy controls are real <code>&lt;button&gt;</code>s with an accessible
+        name ("Copy install command"), not styled spans.
+      </li>
+      <li>
+        An <code>aria-live="polite"</code> region announces "Copied" — the
+        visual state change alone is not enough.
+      </li>
+      <li>
+        The hero copy button must toggle
+        <strong><code>visibility</code>, not just <code>opacity</code></strong
+        >, or a keyboard user tabbing during the 10s animation lands on an
+        invisible control.
+      </li>
+      <li>
+        Commands stay selectable text. Copy-to-clipboard is an accelerator,
+        never the only way to get the string.
+      </li>
+      <li>
+        <strong>Inherited debt, flagged not fixed:</strong>
+        <code>DESIGN.md</code> §7 records that 17 homepage animations already
+        ignore <code>prefers-reduced-motion</code>. This adds two more. Minimum
+        bar here: the copy affordance appears instantly under
+        <code>reduce</code>.
+      </li>
+    </ul>
+
+    <h2 data-anchor-id="verify">Verification</h2>
+
+    <blockquote class="callout" data-anchor-id="tworounds">
+      <p>
+        <strong>Two review rounds minimum, non-negotiable on this repo.</strong>
+        The website lane has a documented three-for-three record of each round's
+        <em>fixes</em> introducing the next round's defects. One passing round
+        is not evidence.
+      </p>
+    </blockquote>
+
+    <ol>
+      <li>
+        <strong>Dispatch real clicks</strong> on both hero CTAs and all three
+        <code>/download</code> actions at 320 / 375 / 768. A rendered element is
+        not a reachable one — that is exactly what PR&nbsp;#95 shipped to fix.
+      </li>
+      <li>
+        <strong>No horizontal page scroll at 320px</strong>, and confirm line-6
+        does not clip.
+      </li>
+      <li>
+        <strong>Screenshot diff</strong> at 1280 and 375, before/after, with an
+        ~11s settle. Treat anything under <strong>0.14%</strong> as noise (<code
+          >DESIGN.md</code
+        >
+        §2).
+      </li>
+      <li>
+        <strong>Clipboard actually receives the string</strong> — read it back,
+        don't trust a "Copied" label.
+      </li>
+      <li>
+        <strong>Dry-run the version script</strong> against a fake tag and
+        confirm it rewrites <em>both</em> pages.
+      </li>
+      <li>
+        Run the impeccable detector over both changed pages once, at the end.
+      </li>
+    </ol>
+
+    <h2 data-anchor-id="risks">Risks</h2>
+    <ul>
+      <li>
+        <strong>Merging to <code>main</code> is a production deploy</strong>
+        (<code>rootDirectory = web</code>). There is no staging step.
+      </li>
+      <li>
+        <strong>481–719px is unaddressed site-wide</strong> (<code
+          >DESIGN.md</code
+        >
+        §5) — the new command blocks must not overflow in that band, which the
+        existing audit already flagged as a trouble zone.
+      </li>
+      <li>
+        <strong>The hero is the most fragile surface on the site.</strong>
+        Editing the typewriter means touching <code>steps()</code> counts,
+        keyframe widths, and char-count comments that must stay in sync with the
+        visible text.
+      </li>
+    </ul>
+
+    <h2 data-anchor-id="alsofound">
+      Product section cleanup — IN SCOPE (added 2026-08-09)
+    </h2>
+
+    <blockquote class="callout" data-anchor-id="scopenote">
+      <p>
+        <strong>Scope expansion, deliberate.</strong> These are pre-existing
+        defects shipping on ghostties.org today, not caused by the install-path
+        work. Sean's call to fix them in the same pass rather than file them.
+      </p>
+    </blockquote>
+
+    <ul>
+      <li>
+        <strong>Product captions attach to the wrong window.</strong>
+        <code>.product-window { margin: 0 auto 56px }</code> puts 56px between a
+        window and its own caption, and <strong>0px</strong> between that
+        caption and the next window. So "four sessions, one window" sits flush
+        against the <em>second</em> window and reads as its header. Fix: move
+        the gap — window <code>margin-bottom: 12px</code>, caption
+        <code>margin-bottom: 56px</code>. Check the
+        <code>max-width: 480px</code> block too, which sets its own
+        <code>.product-window { margin-bottom: 28px }</code> and
+        <code>.product-caption { margin-top: 8px }</code> and has the same
+        inversion.
+      </li>
+
+      <li>
+        <strong
+          >The two product videos are framed inconsistently — RESOLVED as "leave
+          it".</strong
+        >
+        A CSS crop was built to hide the mismatch, then reverted
+        (<code>dbf0c5306</code>). It was the wrong direction: it deleted the
+        good asset's best feature to disguise the bad asset's flaw.
+        <p>
+          <strong>Proven by inspecting the sources, not by reading CSS.</strong>
+          Both files are <strong>1520×950</strong>.
+          <code>product-flow.mp4</code> contains full window chrome — traffic
+          lights, <code>+</code> button, tab icon, globe.
+          <code>product-sessions.mp4</code>'s top ~40px is blank background,
+          then straight into <code>PINNED</code> / <code>Last login:</code>.
+          <strong>The chrome was never captured.</strong> No CSS can recover
+          pixels that do not exist.
+        </p>
+        <p>
+          <strong>Standing decision (2026-08-09):</strong> the app has changed
+          substantially since these clips were recorded, so
+          <em>every</em> product asset needs re-shooting regardless. Fixing one
+          clip now is wasted work. This PR fixes the <em>container</em> so the
+          new recordings drop into a correct frame.
+        </p>
+      </li>
+    </ul>
+
+    <h2 data-anchor-id="capturespec">Capture spec for the eventual re-shoot</h2>
+
+    <p>
+      Measured during this work. Recording to these values means the existing
+      CSS needs no changes.
+    </p>
+
+    <table data-anchor-id="capture-table">
+      <thead>
+        <tr>
+          <th>Constraint</th>
+          <th>Value</th>
+          <th>Why</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Dimensions</td>
+          <td><strong>1520×950</strong></td>
+          <td>
+            What both current clips use; <code>.product-card</code> sizing and
+            the 860px <code>max-width</code> are tuned around this aspect ratio
+          </td>
+        </tr>
+        <tr>
+          <td>Window chrome</td>
+          <td><strong>Include it</strong> — traffic lights, tab strip</td>
+          <td>
+            <code>product-flow.mp4</code> is the reference. Chrome reads as a
+            real Mac app; its absence is what makes the sessions clip look wrong
+          </td>
+        </tr>
+        <tr>
+          <td>Chrome height</td>
+          <td>~40px of 950 (4.2%)</td>
+          <td>
+            Pixel-sampled from the flow video. Keep consistent across clips so
+            they sit identically in the card
+          </td>
+        </tr>
+        <tr>
+          <td>Posters</td>
+          <td>Re-shoot <code>*-poster.jpg</code> too</td>
+          <td>
+            They must match frame 1 of their clip or the page flashes a
+            mismatched still before playback
+          </td>
+        </tr>
+        <tr>
+          <td>Content vs caption</td>
+          <td>Must match the caption text</td>
+          <td>
+            Captions are "four sessions, one window" and "gt list — every task,
+            one lane" — the recording has to actually show that
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <blockquote class="callout" data-anchor-id="captureblocked">
+      <p>
+        <strong>Capture is currently blocked</strong> on two independent things:
+        demo capture is parked mid-build, and this machine has no Screen
+        Recording permission. There is also a hard safety constraint — Sean's
+        real terminal and the demo instance share the OS process name
+        <code>ghostty</code>, so AX targeting flaps between them and solo
+        automated driving is unsafe. Co-drive only.
+      </p>
+    </blockquote>
+
+    <h2 data-anchor-id="copy">Content change</h2>
+
+    <p>The product heading is currently two stacked sentences:</p>
+    <pre><code>&lt;h2&gt;&lt;span&gt;Multiple agents.&lt;/span&gt;&lt;span&gt;One window.&lt;/span&gt;&lt;/h2&gt;</code></pre>
+    <p>
+      Becomes a single line:
+      <strong>"Multiple agent terminals, one window"</strong>. Note
+      <code>.product h2 span</code> exists purely to force the two-line break —
+      check whether that rule is still needed once the copy is one sentence.
+    </p>
+
+    <h2 data-anchor-id="notdoing">Explicitly not doing</h2>
+    <ul>
+      <li>
+        Rebalancing the hero's overall pacing, or the CTA-gating question ("the
+        hero half" — separate <code>BACKLOG</code> item, needs your design
+        calls).
+      </li>
+      <li>
+        The <code>create-dmg</code>/<code>stapler</code> workflow reorder — app
+        lane, untestable without cutting a release.
+      </li>
+      <li>
+        A <code>curl | sh</code> installer. Not built, and not proposed here.
+      </li>
+      <li>
+        Terracotta / ghost-palette decisions, the fixed-footer question, or any
+        other open web item.
+      </li>
+    </ul>
+  </body>
+</html>

--- a/scripts/update-web-version.py
+++ b/scripts/update-web-version.py
@@ -37,8 +37,6 @@ short_version = version.lstrip("v")  # "0.1.0-beta.14"
 
 now = datetime.now()
 date_long = now.strftime("%B %-d, %Y")          # "April 30, 2026"
-date_compact = now.strftime("%-d%b%Y")          # "30Apr2026"
-date_compact = re.sub(r"^(\d)([A-Z])", r"0\1\2", date_compact)  # zero-pad single digit day → "01Apr2026"
 
 dmg_size_str = None
 if len(sys.argv) == 3:
@@ -48,12 +46,20 @@ if len(sys.argv) == 3:
 
 print(f"Bumping site to {version} ({date_long})")
 
-# 1. DMG download URL — only download.html has one. (index.html links to /download.)
+# 1. DMG download URL — both download.html and index.html hardcode one.
+#    (index.html's hero "download now" line links straight to the DMG, not
+#    to /download, so it needs the same bump.)
 replace(
     "web/download.html",
     r"releases/download/v[\d][^/]+/Ghostties\.dmg",
     f"releases/download/{version}/Ghostties.dmg",
     "download.html DMG URL",
+)
+replace(
+    "web/index.html",
+    r"releases/download/v[\d][^/]+/Ghostties\.dmg",
+    f"releases/download/{version}/Ghostties.dmg",
+    "index.html DMG URL",
 )
 
 # 2. download.html — button label  ("Download v0.1.0-beta.X for macOS")
@@ -89,40 +95,24 @@ replace(
     "download.html last-updated footer",
 )
 
-# 5. index.html — terminal line-4 displayed text "+ ghostties % v0.1.0-beta.X"
+# 5. index.html — terminal line-3 version string "% v0.1.0-beta.X"
+#    Matches every occurrence of the "% v<version>" fragment: the desktop
+#    span ("+ ghostties % v..."), the mobile-short span ("+ % v..." — no
+#    "ghostties", it's dropped there to fit the mobile character budget),
+#    the CSS comment above the desktop keyframe, the CSS comment above the
+#    mobile-override keyframe, the illustrative example in the mobile
+#    budget-math comment, and the HTML markup comment — same fixed
+#    "% v<version>" fragment in all of them, so one global replace covers
+#    all of them regardless of what precedes it. (The char-count numbers in
+#    those comments aren't touched here: like the rest of this script, a
+#    version bump is assumed not to change the string's length. If a beta
+#    number crosses a digit boundary — e.g. beta.9 → beta.10 — recheck the
+#    *ch counts by hand.)
 replace(
     "web/index.html",
-    r"\+ ghostties % v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
-    f"+ ghostties % {version}",
-    "index.html terminal line-4",
-)
-
-# 6. index.html — comments referencing the line (keep them in sync to aid grep)
-replace(
-    "web/index.html",
-    r'line-4: "?\+ ghostties % v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?"? = (\d+) chars',
-    lambda m: f'line-4: "+ ghostties % {version}" = {m.group(1)} chars',
-    "index.html line-4 char-count comment (CSS)",
-)
-replace(
-    "web/index.html",
-    r"line-4: (\d+) chars: \+ ghostties % v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
-    lambda m: f"line-4: {m.group(1)} chars: + ghostties % {version}",
-    "index.html line-4 char-count comment (HTML)",
-)
-
-# 7. index.html — terminal date line "+ <date> · macOS 13+ · Apple Silicon"
-replace(
-    "web/index.html",
-    r"\+ \d{1,2}[A-Z][a-z]+\d{4} &middot;",
-    f"+ {date_compact} &middot;",
-    "index.html terminal date",
-)
-replace(
-    "web/index.html",
-    r"line-5: (\d+) chars: \+ \d{1,2}[A-Z][a-z]+\d{4}",
-    lambda m: f"line-5: {m.group(1)} chars: + {date_compact}",
-    "index.html line-5 char-count comment",
+    r"% v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
+    f"% {version}",
+    "index.html terminal line-3 (all occurrences)",
 )
 
 print("Done.")

--- a/scripts/update-web-version.py
+++ b/scripts/update-web-version.py
@@ -95,23 +95,24 @@ replace(
     "download.html last-updated footer",
 )
 
-# 5. index.html — terminal line-3 version string "% v0.1.0-beta.X"
-#    Matches every occurrence of the "% v<version>" fragment: the desktop
-#    span ("+ ghostties % v..."), the mobile-short span ("+ % v..." — no
-#    "ghostties", it's dropped there to fit the mobile character budget),
+# 5. index.html — terminal line-3 version string.
+#    Matches every occurrence of "<+ or %> v<version>": the desktop span
+#    ("+ ghostties % v..."), the mobile-short span ("+ v..." — no "%",
+#    "ghostties" is dropped there too, to fit the mobile character budget),
 #    the CSS comment above the desktop keyframe, the CSS comment above the
 #    mobile-override keyframe, the illustrative example in the mobile
-#    budget-math comment, and the HTML markup comment — same fixed
-#    "% v<version>" fragment in all of them, so one global replace covers
-#    all of them regardless of what precedes it. (The char-count numbers in
-#    those comments aren't touched here: like the rest of this script, a
-#    version bump is assumed not to change the string's length. If a beta
-#    number crosses a digit boundary — e.g. beta.9 → beta.10 — recheck the
-#    *ch counts by hand.)
+#    budget-math comment, and the HTML markup comment. The lookbehind
+#    requires a literal "+ " or "% " immediately before "v" so it can't
+#    also match the unrelated "v<version>" inside the DMG URL (handled by
+#    rule 1 above), which is preceded by "/" instead. (The char-count
+#    numbers in those comments aren't touched here: like the rest of this
+#    script, a version bump is assumed not to change the string's length.
+#    If a beta number crosses a digit boundary — e.g. beta.9 → beta.10 —
+#    recheck the *ch counts by hand.)
 replace(
     "web/index.html",
-    r"% v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
-    f"% {version}",
+    r"(?<=[+%] )v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
+    version,
     "index.html terminal line-3 (all occurrences)",
 )
 

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -202,6 +202,22 @@ instead and must opt out explicitly with `text-transform: none` *and* a `margin-
 reset: `.product h2` on the homepage and `h2` on `/licenses`. Forgetting
 either is the most likely way to break a page from this file.
 
+`.product h2` is a single line as of 2026-08-09 ("Multiple agent terminals,
+one window"). It used to be two `<span>`s each forced to `display: block` to
+break the line manually; that selector is gone along with the spans — don't
+reintroduce a two-line heading without also reintroducing the rule that
+breaks it.
+
+**Product window/caption spacing:** the gap between a product window and the
+*next* window belongs to `.product-caption`'s `margin-bottom` (56px, 28px
+below 480px), not `.product-window`'s. `.product-window` itself only carries
+a small `margin-bottom` (12px, 8px below 480px) down to its own caption.
+Putting the large gap on the window instead — as it shipped originally —
+makes every caption collapse against the *next* window and read as its
+header instead of its own video's label. The last caption in the section
+zeroes its own `margin-bottom` (`.product-caption:last-of-type`) so the
+56px doesn't stack with `.product`'s own bottom padding.
+
 ---
 
 ## 5. Spacing, radius, motion
@@ -263,9 +279,31 @@ Two more things this file does not fix:
   bottom of `index.html` locks the final download line by writing
   `rgba(100,220,120,0.9)` and `rgba(80,210,100,0.13)` as inline styles. Those
   duplicate `--diff-add-fg` and `--diff-add-bg`. Change one, change both.
-- **`pre` is styled in `style.css` but no page uses a `<pre>` today.** It was
-  authored on `/licenses` and left in place rather than deleted as part of a
-  refactor.
+- **`--diff-del-fg` / `--diff-del-bg` are unused as of the install-paths
+  update (2026-08-09).** They backed the hero terminal's one red ("install
+  soon") line, which is gone now that the terminal offers real install
+  commands. Left as tokens, not deleted — nothing here mandates every token
+  stay wired to a use, and re-adding a red diff state later shouldn't mean
+  re-deriving the contrast math in DESIGN.md §3.
+
+### `pre` / copy-button component
+
+`pre` (styled in `style.css`, previously authored for `/licenses` and never
+used) is genuinely in use as of 2026-08-09: `/download`'s two install
+commands (`brew install --cask …`, `npx ghostties-install`) each render in a
+`pre > code` with a `.copy-btn` beside it. `.copy-btn` and its `pre` layout
+overrides (`display: flex` to sit the button beside the command,
+`min-width: 0` on `code` so it can shrink instead of forcing horizontal
+scroll) live in `download.html`'s own `<style>` block — a one-page component,
+not promoted to `style.css`.
+
+The homepage hero has its own, unrelated copy-button component: `.term-btn`,
+nested inside `.line-4`/`.line-5` of the typewriter terminal (see the CSS
+comment on `.term-btn` in `index.html` for why it must stay a plain `<div
+class="line">` with the button nested inside, not a `.line` that *is* a
+button). Both components copy to the clipboard and announce via a
+`role="status" aria-live="polite"` region; they don't share code because
+they don't share layout.
 
 ---
 

--- a/web/download.html
+++ b/web/download.html
@@ -34,6 +34,49 @@
   <style>
     /* Download page only. Shared base: /style.css */
 
+    .install-block {
+      margin: 24px 0 32px;
+    }
+
+    .install-block pre {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 0;
+    }
+
+    .install-block pre code {
+      background: transparent;
+      padding: 0;
+      overflow-wrap: anywhere;
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .copy-btn {
+      flex: 0 0 auto;
+      background: transparent;
+      border: 1px solid var(--line-strong);
+      border-radius: var(--radius-sm);
+      color: var(--text-meta);
+      font-family: var(--font-mono);
+      font-size: var(--size-caption);
+      padding: 4px 10px;
+      cursor: pointer;
+      transition: color var(--transition);
+    }
+
+    .copy-btn:hover {
+      color: var(--text-meta-hover);
+    }
+
+    .install-meta {
+      font-size: var(--size-small);
+      color: var(--text-meta);
+      margin: 8px 0 20px;
+    }
+
     .download-block {
       display: flex;
       flex-direction: column;
@@ -113,7 +156,17 @@
     <h1>Download</h1>
     <p class="lead">Ghostties is a multi-agent workspace terminal for macOS &mdash; a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a>, built by Sean Smith. Currently in beta.</p>
 
-    <h2>Current release</h2>
+    <h2>Install</h2>
+    <div class="install-block">
+      <pre><code>brew install --cask seansmithworks/tap/ghostties</code><button type="button" class="copy-btn" data-copy="brew install --cask seansmithworks/tap/ghostties" aria-label="Copy Homebrew install command">Copy</button></pre>
+      <p class="install-meta">Recommended &mdash; upgrades with brew, in-app via Sparkle.</p>
+
+      <pre><code>npx ghostties-install</code><button type="button" class="copy-btn" data-copy="npx ghostties-install" aria-label="Copy npx install command">Copy</button></pre>
+      <p class="install-meta">One-off installer &mdash; pinned version + SHA256.</p>
+    </div>
+
+    <div class="visually-hidden" role="status" aria-live="polite" id="copy-status"></div>
+
     <div class="download-block">
       <a class="download-btn" href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.21/Ghostties.dmg" download>
         Download v0.1.0-beta.21 for macOS
@@ -121,7 +174,7 @@
       <div class="download-meta">
         v0.1.0-beta.21 &middot; August 1, 2026 &middot; 147 MB<br>
         macOS 13 (Ventura) or later &middot; Apple Silicon<br>
-        Developer ID signed and notarized by Apple &mdash; opens without a Gatekeeper warning.
+        Developer ID signed and notarized by Apple.
       </div>
     </div>
 
@@ -148,5 +201,17 @@
       <a href="/licenses">Licenses</a>
     </span>
   </footer>
+
+  <script>
+    const copyStatus = document.getElementById('copy-status');
+    document.querySelectorAll('.copy-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+          copyStatus.textContent = 'Copied';
+          setTimeout(() => { copyStatus.textContent = ''; }, 2000);
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -182,6 +182,16 @@
       display: inline;
     }
 
+    /* Default (>480px): show the full line-3 string, hide the mobile-short
+       one. Without this rule both spans render above 480px — the
+       max-width: 480px block below only sets the mobile state, there was
+       no default-state rule, so the version string doubled in the DOM and
+       accessibility tree at every width above mobile (invisible on screen
+       only because .line's overflow:hidden + typewriter animation clips
+       the second span's pixels — an accident, not a design). */
+    .line-3-full { display: inline; }
+    .line-3-short { display: none; }
+
     /* Caret blink states */
     .animate .line-1.caret-visible {
       border-right-color: var(--terminal-fg);
@@ -394,9 +404,19 @@
     /* product-flow.mp4 includes its window titlebar and traffic lights;
        product-sessions.mp4 is already cropped above them. .product-card's
        overflow: hidden lets a negative top offset crop the flow video to
-       match without a re-capture. */
+       match without a re-capture.
+
+       The video is 1520x950 intrinsic; the titlebar chrome measures exactly
+       40px in the source frame (pixel-sampled: content pane background
+       starts at row 40, chrome background above it). Expressed as a
+       percentage of the containing block's WIDTH — not a fixed px value —
+       because percentage margins always resolve against container width,
+       and since the video's aspect ratio is fixed, width and height scale
+       together, so 40/1520 = 2.6316% crops the same proportion of the
+       titlebar at every viewport instead of biting a fixed pixel count out
+       of a shrinking frame. */
     .product-window--flow .product-card video {
-      margin-top: -34px;
+      margin-top: -2.6316%;
     }
 
     /* The 56px gap between a window and the next one lives here, not on
@@ -512,12 +532,13 @@
 
       /* line-3 drops "ghostties" and " · macOS 13+" (still on /download) —
          at this width even the "+ ghostties % v0.1.0-beta.21" wording
-         measures ~277px against a 248px .terminal, ~29px (3 chars) past the
-         budget and invisibly truncated by .terminal's overflow:hidden.
-         "ghostties" is redundant here (line-1 already establishes it) and
-         dropping it is enough to clear the budget with room for a 3-digit
-         beta number. Two spans, not visual-only hiding, so a screen reader
-         never reads the string twice. */
+         measures ~395.6px against a 248px .terminal, ~148px (about 15
+         chars) past the budget and invisibly truncated by .terminal's
+         overflow:hidden. Dropping "ghostties" (redundant — line-1 already
+         establishes it) and the bare "%" (had nothing in front of it, read
+         as a rendering bug rather than an abbreviation) clears the budget.
+         Two spans, not visual-only hiding, so a screen reader never reads
+         the string twice. */
       .line-3-full { display: none; }
       .line-3-short { display: inline; }
 
@@ -525,46 +546,47 @@
       .btn-icon { display: none; }
 
       /* Retimed so mobile stays coherent: line-3's shorter string types
-         faster (18 chars vs 40), and line-5 without its icon is 25 chars
-         vs 27, so every line after line-3 shifts earlier. Gaps stay a
-         uniform 0.35s. Total run: ~8.625s (desktop: ~9.25s). */
-      /* line-3: "+ % v0.1.0-beta.21" = 18 chars */
+         faster (16 chars vs 40), and line-5 without its icon is 25 chars
+         vs 27, so every line after line-3 shifts earlier. Every line-3–6
+         typing rate is a uniform 25ms/char; gaps between lines stay a
+         uniform 0.35s. Total run: ~8.575s (desktop: ~9.25s). */
+      /* line-3: "+ v0.1.0-beta.21" = 16 chars */
       .animate .line-3 {
         animation:
-          type-line3 0.45s steps(18) 5.65s forwards,
+          type-line3 0.4s steps(16) 5.65s forwards,
           reveal-line-green 0s 5.65s forwards;
       }
 
       /* line-4: "+ [brew install ⧉]" = 18 chars, unchanged */
       .animate .line-4 {
         animation:
-          type-line4 0.45s steps(18) 6.45s forwards,
-          reveal-line-green 0s 6.45s forwards;
+          type-line4 0.45s steps(18) 6.4s forwards,
+          reveal-line-green 0s 6.4s forwards;
       }
 
       .animate .line-4 .term-btn {
-        animation: reveal-btn 0s 6.45s forwards;
+        animation: reveal-btn 0s 6.4s forwards;
       }
 
       /* line-5: "+ [npx ghostties-install]" = 25 chars (icon dropped) */
       .animate .line-5 {
         animation:
-          type-line5 0.625s steps(25) 7.25s forwards,
-          reveal-line-green 0s 7.25s forwards;
+          type-line5 0.625s steps(25) 7.2s forwards,
+          reveal-line-green 0s 7.2s forwards;
       }
 
       .animate .line-5 .term-btn {
-        animation: reveal-btn 0s 7.25s forwards;
+        animation: reveal-btn 0s 7.2s forwards;
       }
 
       /* line-6: "+ [download now]" = 16 chars, unchanged */
       .animate .line-6 {
         animation:
-          type-line6 0.4s steps(16) 8.225s forwards,
-          reveal-line-green 0s 8.225s forwards;
+          type-line6 0.4s steps(16) 8.175s forwards,
+          reveal-line-green 0s 8.175s forwards;
       }
 
-      @keyframes type-line3 { from { width: 0; } to { width: 18ch; } }
+      @keyframes type-line3 { from { width: 0; } to { width: 16ch; } }
       @keyframes type-line5 { from { width: 0; } to { width: 25ch; } }
 
       footer { padding: 8px 16px; font-size: 0.625rem; } /* 10px; matches the document-page footer padding trim */
@@ -694,10 +716,11 @@
       <!-- line-2: 43 chars: https://github.com/SeanSmithWorks/ghostties -->
       <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithWorks/ghostties</a></div>
       <!-- line-3: 40 chars: + ghostties % v0.1.0-beta.21 · macOS 13+
-           (18 chars on mobile: "ghostties" and " · macOS 13+" are dropped
-           — see the max-width: 480px block. Two spans, not visual-only
-           hiding, so a screen reader never reads the string twice.) -->
-      <div class="line line-3"><span class="line-3-full">+ ghostties % v0.1.0-beta.21 &middot; macOS 13+</span><span class="line-3-short">+ % v0.1.0-beta.21</span></div>
+           (16 chars on mobile: "+ v0.1.0-beta.21" — "ghostties", the bare
+           "%", and " · macOS 13+" are dropped, see the max-width: 480px
+           block. Two spans, not visual-only hiding, so a screen reader
+           never reads the string twice.) -->
+      <div class="line line-3"><span class="line-3-full">+ ghostties % v0.1.0-beta.21 &middot; macOS 13+</span><span class="line-3-short">+ v0.1.0-beta.21</span></div>
       <!-- line-4: 18 chars: + [brew install ⧉] (clickable — copies the command) -->
       <div class="line line-4"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="brew install --cask seansmithworks/tap/ghostties" aria-label="Copy Homebrew install command: brew install --cask seansmithworks/tap/ghostties" title="brew install --cask seansmithworks/tap/ghostties">brew install ⧉</button><span aria-hidden="true">]</span></div>
       <!-- line-5: 27 chars: + [npx ghostties-install ⧉] (clickable — copies the command)
@@ -766,7 +789,7 @@
     // Mobile retimes line-3 (shorter string) and line-5 (icon dropped),
     // which shifts every line after them — see the max-width: 480px block.
     function lockDelayMs() {
-      return window.matchMedia('(max-width: 480px)').matches ? 8625 : 9250;
+      return window.matchMedia('(max-width: 480px)').matches ? 8575 : 9250;
     }
 
     function activateCarets() {

--- a/web/index.html
+++ b/web/index.html
@@ -153,6 +153,35 @@
       text-decoration: underline;
     }
 
+    /* Copy buttons nested in line-4/line-5. Must stay a plain block .line
+       with the button nested inside it — a .line that IS a button breaks
+       stacking (buttons are inline-block), the -2ch hanging indent (doesn't
+       apply to buttons), and the green reveal background (would paint per-
+       button instead of across the line). Hidden via visibility (not
+       opacity/display) so it's never tab-reachable before its line types in;
+       see reveal-btn below. */
+    .term-btn {
+      background: transparent;
+      border: none;
+      padding: 0;
+      margin: 0;
+      font: inherit;
+      color: inherit;
+      cursor: pointer;
+      text-decoration: none;
+      visibility: hidden;
+      user-select: text;
+    }
+
+    .term-btn:hover {
+      text-decoration: underline;
+    }
+
+    /* line-5's copy icon drops on mobile; see the max-width: 480px block. */
+    .btn-icon {
+      display: inline;
+    }
+
     /* Caret blink states */
     .animate .line-1.caret-visible {
       border-right-color: var(--terminal-fg);
@@ -177,47 +206,59 @@
       animation: type-line2 1.1s steps(43) 4.2s forwards;
     }
 
-    /* line-3: "- ghostties % install soon" = 26 chars */
+    /* line-3: "+ ghostties % v0.1.0-beta.21 · macOS 13+" = 40 chars */
     .animate .line-3 {
       animation:
-        type-line3 0.65s steps(26) 5.5s forwards,
-        reveal-line3 0s 5.5s forwards;
+        type-line3 1.0s steps(40) 5.65s forwards,
+        reveal-line-green 0s 5.65s forwards;
     }
 
-    /* line-4: "+ ghostties % v0.1.0-beta.21" = 28 chars */
+    /* line-4: "+ [brew install ⧉]" = 18 chars */
     .animate .line-4 {
       animation:
-        type-line4 0.7s steps(28) 7.0s forwards,
+        type-line4 0.45s steps(18) 7.0s forwards,
         reveal-line-green 0s 7.0s forwards;
     }
 
-    /* line-5: "+ 27Apr2026 · macOS 13+ · Apple Silicon" = 39 chars */
+    .animate .line-4 .term-btn {
+      animation: reveal-btn 0s 7.0s forwards;
+    }
+
+    /* line-5: "+ [npx ghostties-install ⧉]" = 27 chars */
     .animate .line-5 {
       animation:
-        type-line5 1.0s steps(39) 8.2s forwards,
-        reveal-line-green 0s 8.2s forwards;
+        type-line5 0.675s steps(27) 7.825s forwards,
+        reveal-line-green 0s 7.825s forwards;
+    }
+
+    .animate .line-5 .term-btn {
+      animation: reveal-btn 0s 7.825s forwards;
     }
 
     /* line-6: "+ [download now]" = 16 chars */
     .animate .line-6 {
       animation:
-        type-line6 0.4s steps(16) 9.7s forwards,
-        reveal-line-green 0s 9.7s forwards;
+        type-line6 0.4s steps(16) 8.85s forwards,
+        reveal-line-green 0s 8.85s forwards;
     }
 
     @keyframes type-line1 { from { width: 0; } to { width: 14ch; } }
     @keyframes type-line2 { from { width: 0; } to { width: 43ch; } }
-    @keyframes type-line3 { from { width: 0; } to { width: 26ch; } }
-    @keyframes type-line4 { from { width: 0; } to { width: 28ch; } }
-    @keyframes type-line5 { from { width: 0; } to { width: 39ch; } }
+    @keyframes type-line3 { from { width: 0; } to { width: 40ch; } }
+    @keyframes type-line4 { from { width: 0; } to { width: 18ch; } }
+    @keyframes type-line5 { from { width: 0; } to { width: 27ch; } }
     @keyframes type-line6 { from { width: 0; } to { width: 16ch; } }
-
-    @keyframes reveal-line3 {
-      to { color: var(--diff-del-fg); background: var(--diff-del-bg); }
-    }
 
     @keyframes reveal-line-green {
       to { color: var(--diff-add-fg); background: var(--diff-add-bg); }
+    }
+
+    @keyframes reveal-btn {
+      to { visibility: visible; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .term-btn { visibility: visible; animation: none; }
     }
 
     @keyframes blink-caret-green {
@@ -298,19 +339,21 @@
       line-height: 1.25;
     }
 
-    .product h2 span {
-      display: block;
-    }
-
-    /* Window card: glow behind, tilt + video on top */
+    /* Window card: glow behind, tilt + video on top.
+       margin-bottom stays small here — the 56px gap belongs to
+       .product-caption below, so each caption reads as its own window's
+       label instead of the next window's header. */
     .product-window {
       position: relative;
-      margin: 0 auto 56px;
+      margin: 0 auto 12px;
       max-width: 860px;
     }
 
-    .product-window:last-child {
-      margin-bottom: 24px;
+    /* :last-child never matched here — the last child of .product is a
+       .product-caption, not a .product-window. :last-of-type is the
+       selector that actually reaches the flow window. */
+    .product-window:last-of-type {
+      margin-bottom: 12px;
     }
 
     .product-window--sessions .product-card {
@@ -348,11 +391,26 @@
       display: block;
     }
 
+    /* product-flow.mp4 includes its window titlebar and traffic lights;
+       product-sessions.mp4 is already cropped above them. .product-card's
+       overflow: hidden lets a negative top offset crop the flow video to
+       match without a re-capture. */
+    .product-window--flow .product-card video {
+      margin-top: -34px;
+    }
+
+    /* The 56px gap between a window and the next one lives here, not on
+       .product-window, so each caption reads as its own window's label
+       instead of the next window's header. */
     .product-caption {
       font-family: var(--font-mono);
       font-size: 0.75rem; /* 12px */
       color: var(--accent);
-      margin-top: 12px;
+      margin-bottom: 56px;
+    }
+
+    .product-caption:last-of-type {
+      margin-bottom: 0;
     }
 
     /* --- Footer (homepage variant: mono, smaller, pinned to the hero) ---
@@ -451,6 +509,64 @@
       .ghost-row { gap: 10px; }
       .ghosts { gap: 10px; margin-bottom: 28px; }
       .terminal { font-size: 1rem; max-width: calc(100vw - 72px); } /* 16px; .scene 20px + body 16px per side at this width */
+
+      /* line-3 drops "ghostties" and " · macOS 13+" (still on /download) —
+         at this width even the "+ ghostties % v0.1.0-beta.21" wording
+         measures ~277px against a 248px .terminal, ~29px (3 chars) past the
+         budget and invisibly truncated by .terminal's overflow:hidden.
+         "ghostties" is redundant here (line-1 already establishes it) and
+         dropping it is enough to clear the budget with room for a 3-digit
+         beta number. Two spans, not visual-only hiding, so a screen reader
+         never reads the string twice. */
+      .line-3-full { display: none; }
+      .line-3-short { display: inline; }
+
+      /* line-5 drops the ⧉ icon to fit the same budget. */
+      .btn-icon { display: none; }
+
+      /* Retimed so mobile stays coherent: line-3's shorter string types
+         faster (18 chars vs 40), and line-5 without its icon is 25 chars
+         vs 27, so every line after line-3 shifts earlier. Gaps stay a
+         uniform 0.35s. Total run: ~8.625s (desktop: ~9.25s). */
+      /* line-3: "+ % v0.1.0-beta.21" = 18 chars */
+      .animate .line-3 {
+        animation:
+          type-line3 0.45s steps(18) 5.65s forwards,
+          reveal-line-green 0s 5.65s forwards;
+      }
+
+      /* line-4: "+ [brew install ⧉]" = 18 chars, unchanged */
+      .animate .line-4 {
+        animation:
+          type-line4 0.45s steps(18) 6.45s forwards,
+          reveal-line-green 0s 6.45s forwards;
+      }
+
+      .animate .line-4 .term-btn {
+        animation: reveal-btn 0s 6.45s forwards;
+      }
+
+      /* line-5: "+ [npx ghostties-install]" = 25 chars (icon dropped) */
+      .animate .line-5 {
+        animation:
+          type-line5 0.625s steps(25) 7.25s forwards,
+          reveal-line-green 0s 7.25s forwards;
+      }
+
+      .animate .line-5 .term-btn {
+        animation: reveal-btn 0s 7.25s forwards;
+      }
+
+      /* line-6: "+ [download now]" = 16 chars, unchanged */
+      .animate .line-6 {
+        animation:
+          type-line6 0.4s steps(16) 8.225s forwards,
+          reveal-line-green 0s 8.225s forwards;
+      }
+
+      @keyframes type-line3 { from { width: 0; } to { width: 18ch; } }
+      @keyframes type-line5 { from { width: 0; } to { width: 25ch; } }
+
       footer { padding: 8px 16px; font-size: 0.625rem; } /* 10px; matches the document-page footer padding trim */
       /* Bottom padding raised from 72px to clear the fixed footer's own
          height (up to 96px once its icons + link row wrap at this width).
@@ -460,10 +576,11 @@
          footer, so this padding didn't need to reach that far. */
       .product { padding: 16px 20px 112px; }
       .product h2 { font-size: 1.375rem; margin-bottom: 28px; } /* 22px */
-      .product-window { margin-bottom: 28px; }
+      .product-window { margin-bottom: 8px; }
       .product-window--sessions .product-card,
       .product-window--flow .product-card { transform: none; }
-      .product-caption { font-size: 0.6875rem; margin-top: 8px; } /* 11px */
+      .product-caption { font-size: 0.6875rem; margin-bottom: 28px; } /* 11px */
+      .product-caption:last-of-type { margin-bottom: 0; }
       .bg-ghost { width: 22px; height: 22px; }
 
       /* Touch target: the icon stays 14px, the anchor's clickable box
@@ -576,16 +693,16 @@
       <div class="line line-1">cd ~/ghostties</div>
       <!-- line-2: 43 chars: https://github.com/SeanSmithWorks/ghostties -->
       <div class="line line-2"><a class="gh-link" href="https://github.com/SeanSmithWorks/ghostties" target="_blank" rel="noopener">https://github.com/SeanSmithWorks/ghostties</a></div>
-      <!-- line-3: 26 chars: - ghostties % install soon -->
-      <!-- Joke line, not a fact about the product — the only line hidden from
-           assistive tech. Every other line in this terminal states something
-           real (repo URL, version, requirements, download link) and must stay
-           in the accessibility tree. -->
-      <div class="line line-3" aria-hidden="true">- ghostties % install soon</div>
-      <!-- line-4: 28 chars: + ghostties % v0.1.0-beta.21 -->
-      <div class="line line-4">+ ghostties % v0.1.0-beta.21</div>
-      <!-- line-5: 39 chars: + 02Aug2026 · macOS 13+ · Apple Silicon -->
-      <div class="line line-5">+ 02Aug2026 &middot; macOS 13+ &middot; Apple Silicon</div>
+      <!-- line-3: 40 chars: + ghostties % v0.1.0-beta.21 · macOS 13+
+           (18 chars on mobile: "ghostties" and " · macOS 13+" are dropped
+           — see the max-width: 480px block. Two spans, not visual-only
+           hiding, so a screen reader never reads the string twice.) -->
+      <div class="line line-3"><span class="line-3-full">+ ghostties % v0.1.0-beta.21 &middot; macOS 13+</span><span class="line-3-short">+ % v0.1.0-beta.21</span></div>
+      <!-- line-4: 18 chars: + [brew install ⧉] (clickable — copies the command) -->
+      <div class="line line-4"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="brew install --cask seansmithworks/tap/ghostties" aria-label="Copy Homebrew install command: brew install --cask seansmithworks/tap/ghostties" title="brew install --cask seansmithworks/tap/ghostties">brew install ⧉</button><span aria-hidden="true">]</span></div>
+      <!-- line-5: 27 chars: + [npx ghostties-install ⧉] (clickable — copies the command)
+           25 chars on mobile: the icon is dropped, see .btn-icon below. -->
+      <div class="line line-5"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="npx ghostties-install" aria-label="Copy npx install command: npx ghostties-install" title="npx ghostties-install">npx ghostties-install<span class="btn-icon" aria-hidden="true"> ⧉</span></button><span aria-hidden="true">]</span></div>
       <!-- line-6: 16 chars: + [download now] (clickable) -->
       <!-- Hardcoded DMG URL — bump the version tag with each release. Decoration
            ("+ [" / "]") sits outside the link so the accessible name is just
@@ -595,9 +712,11 @@
       </div>
     </div>
 
+    <div class="visually-hidden" role="status" aria-live="polite" id="copy-status"></div>
+
     <section class="product">
       <p class="lead">Ghostties is a multi-agent workspace terminal for macOS &mdash; a fork of <a href="https://github.com/ghostty-org/ghostty" target="_blank" rel="noopener">Ghostty</a>, built by Sean Smith.</p>
-      <h2><span>Multiple agents.</span><span>One window.</span></h2>
+      <h2>Multiple agent terminals, one window</h2>
       <div class="product-window product-window--sessions">
         <div class="product-card">
           <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
@@ -640,7 +759,15 @@
     const scene = document.querySelector('.scene');
     const ghLink = document.querySelector('.gh-link');
     const dlLink = document.querySelector('.line-6 a');
+    const termBtns = document.querySelectorAll('.term-btn');
+    const copyStatus = document.getElementById('copy-status');
     let animating = false;
+
+    // Mobile retimes line-3 (shorter string) and line-5 (icon dropped),
+    // which shifts every line after them — see the max-width: 480px block.
+    function lockDelayMs() {
+      return window.matchMedia('(max-width: 480px)').matches ? 8625 : 9250;
+    }
 
     function activateCarets() {
       const line1 = document.querySelector('.line-1');
@@ -651,17 +778,17 @@
       setTimeout(() => { line1.classList.add('caret-visible'); }, 1000);
       setTimeout(() => { line1.classList.remove('caret-visible'); }, 4200);
 
-      // Line 2: caret appears at 4.2s, disappears when line 3 starts at 5.5s
+      // Line 2: caret appears at 4.2s, disappears when line 3 starts at 5.65s
       setTimeout(() => { line2.classList.add('caret-visible'); }, 4200);
-      setTimeout(() => { line2.classList.remove('caret-visible'); }, 5500);
+      setTimeout(() => { line2.classList.remove('caret-visible'); }, 5650);
 
-      // Line 6: caret + inline locks when typing ends (9.7s delay + 0.4s duration = 10.1s)
+      // Line 6: caret + inline locks when typing ends
       setTimeout(() => {
         line6.classList.add('caret-blink');
         line6.style.width = '16ch';
         line6.style.color = 'rgba(100, 220, 120, 0.9)';
         line6.style.background = 'rgba(80, 210, 100, 0.13)';
-      }, 10100);
+      }, lockDelayMs());
     }
 
     activateCarets();
@@ -697,9 +824,19 @@
       }, 1400); // 0.55s scatter + ~0.85s pause before ghosts fly back in
     });
 
-    // Don't scatter when clicking links
+    // Don't scatter when clicking links or copy buttons
     ghLink.addEventListener('click', (e) => e.stopPropagation());
     dlLink.addEventListener('click', (e) => e.stopPropagation());
+    termBtns.forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const text = btn.dataset.copy;
+        navigator.clipboard.writeText(text).then(() => {
+          copyStatus.textContent = 'Copied';
+          setTimeout(() => { copyStatus.textContent = ''; }, 2000);
+        });
+      });
+    });
   </script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -401,24 +401,6 @@
       display: block;
     }
 
-    /* product-flow.mp4 includes its window titlebar and traffic lights;
-       product-sessions.mp4 is already cropped above them. .product-card's
-       overflow: hidden lets a negative top offset crop the flow video to
-       match without a re-capture.
-
-       The video is 1520x950 intrinsic; the titlebar chrome measures exactly
-       40px in the source frame (pixel-sampled: content pane background
-       starts at row 40, chrome background above it). Expressed as a
-       percentage of the containing block's WIDTH — not a fixed px value —
-       because percentage margins always resolve against container width,
-       and since the video's aspect ratio is fixed, width and height scale
-       together, so 40/1520 = 2.6316% crops the same proportion of the
-       titlebar at every viewport instead of biting a fixed pixel count out
-       of a shrinking frame. */
-    .product-window--flow .product-card video {
-      margin-top: -2.6316%;
-    }
-
     /* The 56px gap between a window and the next one lives here, not on
        .product-window, so each caption reads as its own window's label
        instead of the next window's header. */


### PR DESCRIPTION
## Reversal (2026-08-09, latest commit)

The `product-flow.mp4` crop described below and in "Post-merge review fixes" has been **removed**. On review of the rendered page, the flow video's window titlebar/traffic lights are the correct treatment — they read as a real Mac app. The sessions video *lacking* a titlebar is the actual defect; fixing it requires re-capturing `product-sessions.mp4`, which is blocked for now. Cropping the good capture down to match the bad one was the wrong direction, so it's undone. **The two product videos are inconsistently framed again** (flow shows its titlebar, sessions doesn't) — that's the accepted state until the re-capture happens, not an oversight. Everything else in this PR (hero terminal, caption spacing fix, heading copy, `/download`, `scripts/update-web-version.py`) is unaffected.

## Summary

- Hero terminal's fake "install soon" line (the only red line on the site) is replaced with a real version/OS line plus two copy-to-clipboard buttons — `brew install --cask seansmithworks/tap/ghostties` and `npx ghostties-install` — ahead of the existing DMG download link. Homebrew (#99) and npx have been live installers for a while with nothing on the site pointing at them.
- `/download`'s "Current release" section is restructured to "Install", leading with the same two commands (reusing `pre`, which was styled but unused until now) with the DMG download surviving as the third option.
- Fixes a pre-existing product-section bug: the 56px gap between a product window and its caption sat on the *window's* `margin-bottom` instead of the caption's, so every caption read as the *next* window's header instead of its own. Moved the gap to `.product-caption`.
- ~~Crops `product-flow.mp4` to match `product-sessions.mp4`'s framing~~ **Reverted — see "Reversal" at top.** The crop originally shipped broken on phones (see "Post-merge review fixes" below for that history), but the crop itself was the wrong call: the flow video's titlebar is correct, and it's removed entirely now. The two videos are inconsistently framed as a result.
- Collapses the two-line "Multiple agents. / One window." heading to one line ("Multiple agent terminals, one window") and removes the now-dead CSS that forced the line break.
- Drops "— opens without a Gatekeeper warning" from the download meta line. The DMG ships unstapled (`create-dmg` runs before `stapler staple` in CI) and the cask installs from that same DMG, so the claim isn't reliably true. No new claims added.
- Retimes the hero typewriter to fit the two new lines at the site's existing ~0.025s/char rate: **10.1s → ~9.25s on desktop, ~8.575s on mobile** (mobile is shorter because the version line drops "ghostties" and " · macOS 13+" there — see Notes below).
- Fixes `scripts/update-web-version.py`, which the line restructure broke: **it was only ever bumping `download.html`'s hardcoded DMG URL** — its own comment claimed `index.html` "links to /download" and has no DMG URL of its own, which is false; `index.html`'s hero download link is a second hardcoded DMG URL that has only ever been bumped by hand. Added it to the same rule. Also removed the rule targeting the old `+ <date> · macOS 13+ · Apple Silicon` line (gone) and updated the version-string rule for the merged line.

## Post-merge review fixes (2026-08-09)

An independent render-based review found three real defects in the state above; all three are fixed in this branch now. **Note: item 1 is historical — the crop it fixed has since been removed entirely (see "Reversal" at top).**

1. **Product-flow video crop broke on phones.** The `-34px` crop was a fixed pixel offset on a fluid-height video (`width:100%; height:auto`), so as the video's rendered height shrank at narrower viewports, the constant 34px bite ate a growing share of the frame — down to a **blank white card at 375px, zero task rows visible.** Fixed by measuring the titlebar's true height in the video's own source frame (1520x950 intrinsic, chrome is exactly 40px) and expressing the crop as `-2.6316%` (40/1520) against the container's width instead of a fixed px value — percentage margins always resolve against container width, and since the video's aspect ratio is fixed, width and height scale together, so this stays proportional at every breakpoint. Verified with real screenshots: all task rows fully visible at 320/375/480/700/1280px, and the previously-noted slight top-clutter bleed at 1280px is also gone (34px undershot the true 40px chrome height).

2. **The version string was duplicated in the DOM and accessibility tree.** `.line-3-full`/`.line-3-short` only had a `display` toggle inside the `max-width: 480px` media query — there was no default-state rule, so **both spans rendered above 480px** and screen readers announced the version twice at every non-mobile width. It was invisible on screen only by accident (`.line`'s `overflow:hidden` + typewriter animation happened to clip the second span's pixels). Added the missing default rule. Verified via `ariaSnapshot()`: the version now appears exactly once in the accessibility tree at every width tested (320/600/1280).

3. **Mobile short string, per product decision:** dropped the bare `%` — it had nothing in front of it and read as a rendering bug, not an abbreviation. `+ % v0.1.0-beta.21` (18ch) → **`+ v0.1.0-beta.21` (16ch — not 17 as first drafted; recounted with `len()`).** Re-derived the mobile typing cascade at the site's existing uniform 25ms/char rate for lines 3–6; new mobile settle time is **8.575s** (was 8.625s).

Also corrected in this pass:
- A fabricated measurement in a code comment: the full line-3 string against a 248px `.terminal` was claimed to overflow by ~29px (~277px rendered width). **Measured in-browser, it's ~395.6px — an overflow of ~148px**, nearly 5x the original claim. The conclusion (it overflows, needs truncating) was right; the number was wrong. Fixed in the comment.
- `scripts/update-web-version.py`'s line-3 regex keyed on a literal `"% v"` prefix. The new mobile short-span wording (`"+ v..."`) no longer has a `%` before the version, so the old pattern would silently stop updating that span on future version bumps. Rewrote the regex as a lookbehind for `"+ "` or `"% "` so it still matches all 7 version-string occurrences in the file (was 6, +1 from a new comment added in this pass) without also matching the unrelated DMG-URL version. Verified against a scratch copy with a fake tag (`v0.1.0-beta.22`): all 6 script rules match, 0 "pattern did not match" warnings, all 7+1 occurrences bumped correctly.

**Not changed:** this PR also adds a `prefers-reduced-motion` rule for `.term-btn` (`visibility: visible; animation: none`). That rule is close to a no-op — the parent `.line`'s own typewriter animation (which gates the button's visibility via `overflow: hidden`) has no reduced-motion carve-out, and never has; that's a pre-existing, site-wide gap (17 homepage animations ignore `reduce`, tracked in `web/DESIGN.md` §7 / `BACKLOG.md`) and out of scope here. Nothing in this PR or in `web/DESIGN.md` claims the hero respects reduced motion — flagging only so the next reader doesn't assume this rule did more than it does.

## Contradiction found in the brief (fixed, not silently patched)

The brief specified the mobile line-3 text as `+ ghostties % v0.1.0-beta.21` (28ch) against a stated ~26ch budget. Measured in-browser, that string renders at ~395.6px against the actual 248px terminal width at 320px — it overflows by ~148px and gets invisibly clipped by `.terminal`'s `overflow: hidden`, which is exactly the defect this mobile override was supposed to prevent. Shortened it to `+ v0.1.0-beta.21` (16 chars) — drops the redundant word "ghostties" (already established by `cd ~/ghostties` one line up) and the bare "%" (see "Post-merge review fixes" above), keeps the full version string. Mobile timing was rederived from this: line-3 types faster, so every following line starts earlier. Final mobile total is ~8.575s, not the ~8.875s a literal reading of the brief's cascade would produce.

## Verification (Playwright, fresh `userDataDir`, headless)

- **No horizontal scroll** at 320/375/600/768/1280px on either page (`scrollWidth` vs `clientWidth`, all false).
- **Timestamped hero captures** at 2.0/6.0/7.5/8.5/10.5s — only `cd ~/ghostties` visible at 2.0s (no clip-bug regression); all 6 lines settled and green by 8.5s desktop / earlier on mobile.
- **Clipboard readback** for all copy buttons (2 hero, dispatched real clicks at 320/375/768px, `copy-status` region confirms "Copied") — exact strings confirmed, no stray decoration characters:
  - `brew install --cask seansmithworks/tap/ghostties`
  - `npx ghostties-install`
- **Real dispatched clicks** (not `getBoundingClientRect`) on all 5 CTAs at 320/375/768 — all reachable and functional.
- **Product-flow video (crop removed)**: screenshots of `.product-card` at 320/375/480/700/1280px confirm the video's titlebar and traffic lights are now fully visible at every width, with no content clipped at the top. `margin-top` on the video is `0px` at every tested width (was `-2.6316%`). The sessions video's rendering is unchanged — the two videos are inconsistently framed, as expected.
- **Accessibility tree**: `.line-3`'s `ariaSnapshot()` contains the version string exactly once at 320/600/1280px.
- **`scripts/update-web-version.py` dry-run** against a fake tag (`v0.1.0-beta.22`) on a scratch copy outside the repo — 6/6 rules matched, zero "pattern did not match" warnings; scratch edits discarded, nothing committed from the dry run.

## Visuals

Screenshots were captured and reviewed (hero settled state before/after, product-flow card at all 5 breakpoints, product-caption spacing before/after, `/download` before/after) but this sandbox's action classifier blocks every image-hosting path available (`gh gist create`, `gh api gists`) — same restriction hit in PR #95. Description above is evidence-based on real measurements, not just visual impression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHZBWo4EVejiSHXMBHdNfk
