### PR TITLE
fix(sidebar): rename session context-menu "Remove" to "Delete"

### DIFF
--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -222,7 +222,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
                 Button("Relaunch") {
                     relaunchSession(session)
                 }
-                Button("Remove", role: .destructive) {
+                Button("Delete", role: .destructive) {
                     coordinator.clearRuntime(id: session.id)
                     store.removeSession(id: session.id)
                 }

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -158,7 +158,7 @@ struct RecentsListView: View {
                 Button("Relaunch") {
                     relaunchSession(session, project: project)
                 }
-                Button("Remove", role: .destructive) {
+                Button("Delete", role: .destructive) {
                     coordinator.clearRuntime(id: session.id)
                     store.removeSession(id: session.id)
                 }


### PR DESCRIPTION
## Summary
- `removeSession(id:)` is a permanent delete (`sessions.removeAll` + `persist()`, no undo/tombstone). "Remove" sat one menu item away from the Archive zone in the same sidebar, reading as though it routed there — it doesn't, Archive is a derived zone.
- Renamed the label to "Delete" in both session context-menu call sites. No behavior change: `role: .destructive` and closure bodies (`coordinator.clearRuntime` + `store.removeSession`) untouched.

## Scope
- `macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift`
- `macos/Sources/Features/Ghostties/RecentsListView.swift`

Out of scope (unchanged, confirmed separate surfaces): project-level "Remove" in `ProjectDisclosureRow.swift:366` (`store.removeProject`, deletes a whole project row) and `MCPSourceSettingsView.swift:61` (MCP source removal).

## Test plan
- [ ] CI build/test
- [ ] Manual: right-click a session in Projects tab and in Recents — context menu reads "Delete", destructive styling intact, deletion still works