### PR TITLE
chore(homebrew): bump cask to v0.1.0-beta.22

### DIFF
--- a/dist/ghostties/homebrew/ghostties.rb
+++ b/dist/ghostties/homebrew/ghostties.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ghostties" do
-  version "0.1.0-beta.21"
-  sha256 "72a2cafd9b758efb94d7e4b3f8427e7979a44abee13567ff915a059a608f13ea"
+  version "0.1.0-beta.22"
+  sha256 "d98303637d6142af48e165627ca2afb312513610396ca56cda2e781efae780b0"
 
   # Ghostties has not cut a stable release yet — every tag so far, including
   # this one, is a GitHub prerelease. Tracking beta is a deliberate choice,


### PR DESCRIPTION
## Summary
- The `homebrew-cask` release job is inert (gated on the unset `HOMEBREW_TAP_REPO` repo variable), so `ghostties.rb` was still pinned to beta.21 while beta.22 was already tagged and released — the website's `brew install` path was stale.
- Manually reproduces what that job would have done: `bash scripts/update-cask-version.sh v0.1.0-beta.22`, which resolves `version` and `sha256` from the GitHub release itself (downloads `Ghostties.dmg`, computes sha256 locally — never hand-typed).

## Test plan
- [x] Verified only `dist/ghostties/homebrew/ghostties.rb` changed (`git diff --stat`)
- [x] Verified the rewritten cask has valid Ruby syntax (script's built-in `ruby -c` check)
- [x] Companion PR opened against `SeanSmithWorks/homebrew-tap` to sync the bumped cask for end users