### PR TITLE
chore(npm): bump ghostties-install pin to v0.1.0-beta.22

### DIFF
--- a/dist/ghostties/npm/ghostties-install/README.md
+++ b/dist/ghostties/npm/ghostties-install/README.md
@@ -76,9 +76,8 @@ self-heals immediately after install.
 
 **Bumping the pin is currently a manual step**, not automated in CI. The
 Homebrew cask's version bump is automated by a separate CI workflow in this repo;
-the npm package's is not, because this package has never been published to the npm
-registry (publishing needs explicit sign-off first). An auto-bump script that can't
-publish its result would just be dead code, so it wasn't built. If you're bumping
+the npm package's is not, because publishing from CI would need an npm
+automation token that isn't configured. If you're bumping
 this by hand: update `RELEASE.tag`, `RELEASE.assetName` (should stay the same name),
 and `RELEASE.sha256` in `bin/ghostties-install.js`, using the sha256 GitHub reports
 for the release asset.

--- a/dist/ghostties/npm/ghostties-install/bin/ghostties-install.js
+++ b/dist/ghostties/npm/ghostties-install/bin/ghostties-install.js
@@ -23,9 +23,9 @@ const { execFileSync } = require("child_process");
 // Pinned release. Bump manually when a new release ships. See README.md.
 // ---------------------------------------------------------------------------
 const RELEASE = {
-  tag: "v0.1.0-beta.21",
+  tag: "v0.1.0-beta.22",
   assetName: "ghostties-macos-arm64.zip",
-  sha256: "779cb110cc2c3a4cfeb1581601b1f13ed00139dbf5cb039d775b54e625e512ac",
+  sha256: "0542bd3db77ca60048e3f9aba5096c9779037139a52eee2bd82c6c3e1eea98fc",
 };
 const DOWNLOAD_URL = `https://github.com/SeanSmithWorks/ghostties/releases/download/${RELEASE.tag}/${RELEASE.assetName}`;
 const APP_NAME = "Ghostties.app";

--- a/dist/ghostties/npm/ghostties-install/package.json
+++ b/dist/ghostties/npm/ghostties-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostties-install",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Installer shim for Ghostties (macOS, Apple silicon). Downloads and verifies a pinned release build of Ghostties.app.",
   "license": "MIT",
   "os": [


### PR DESCRIPTION
## Summary
- Bumps the `ghostties-install` npm installer's pinned release from `v0.1.0-beta.21` to `v0.1.0-beta.22` (tag + verified sha256 for `ghostties-macos-arm64.zip`)
- Bumps package version `0.1.0` → `0.1.1` (npm won't let us republish `0.1.0`)
- Corrects a now-false README claim that the package "has never been published to the npm registry" — `ghostties-install@0.1.0` is published and live

## Test plan
- [x] Verified sha256 via `gh release view v0.1.0-beta.22 --repo SeanSmithWorks/ghostties` matches what's written into `RELEASE.sha256`
- [x] `git diff --stat` confirms exactly 3 files changed
- [ ] Sean runs `npm publish` from the parent session (out of scope for this PR/agent)