### PR TITLE
fix(web): clipped bracket on hero copy buttons + undercounted session caption

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -182,6 +182,20 @@
       display: inline;
     }
 
+    /* Forces the copy icon (U+29C9) to an exact 1ch advance. The glyph's
+       natural advance in the resolved mono stack measures ~1.29ch (see PR
+       description) -- not 1ch like every other character in these lines --
+       so it silently pushed the typewriter's hard-coded ch widths past the
+       actual rendered width and .line's overflow: hidden ate the trailing
+       "]". margin-left supplies the 1ch gap the source string's literal
+       space used to provide. */
+    .copy-icon {
+      display: inline-block;
+      width: 1ch;
+      margin-left: 1ch;
+      text-align: center;
+    }
+
     /* Default (>480px): show the full line-3 string, hide the mobile-short
        one. Without this rule both spans render above 480px — the
        max-width: 480px block below only sets the mobile state, there was
@@ -704,10 +718,10 @@
            never reads the string twice.) -->
       <div class="line line-3"><span class="line-3-full">+ ghostties % v0.1.0-beta.22 &middot; macOS 13+</span><span class="line-3-short">+ v0.1.0-beta.22</span></div>
       <!-- line-4: 18 chars: + [brew install ⧉] (clickable — copies the command) -->
-      <div class="line line-4"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="brew install --cask seansmithworks/tap/ghostties" aria-label="Copy Homebrew install command: brew install --cask seansmithworks/tap/ghostties" title="brew install --cask seansmithworks/tap/ghostties">brew install ⧉</button><span aria-hidden="true">]</span></div>
+      <div class="line line-4"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="brew install --cask seansmithworks/tap/ghostties" aria-label="Copy Homebrew install command: brew install --cask seansmithworks/tap/ghostties" title="brew install --cask seansmithworks/tap/ghostties">brew install<span class="copy-icon" aria-hidden="true">⧉</span></button><span aria-hidden="true">]</span></div>
       <!-- line-5: 27 chars: + [npx ghostties-install ⧉] (clickable — copies the command)
            25 chars on mobile: the icon is dropped, see .btn-icon below. -->
-      <div class="line line-5"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="npx ghostties-install" aria-label="Copy npx install command: npx ghostties-install" title="npx ghostties-install">npx ghostties-install<span class="btn-icon" aria-hidden="true"> ⧉</span></button><span aria-hidden="true">]</span></div>
+      <div class="line line-5"><span aria-hidden="true">+ [</span><button type="button" class="term-btn" data-copy="npx ghostties-install" aria-label="Copy npx install command: npx ghostties-install" title="npx ghostties-install">npx ghostties-install<span class="btn-icon copy-icon" aria-hidden="true">⧉</span></button><span aria-hidden="true">]</span></div>
       <!-- line-6: 16 chars: + [download now] (clickable) -->
       <!-- Hardcoded DMG URL — bump the version tag with each release. Decoration
            ("+ [" / "]") sits outside the link so the accessible name is just
@@ -724,10 +738,10 @@
       <h2>Multiple agent terminals, one window</h2>
       <div class="product-window product-window--sessions">
         <div class="product-card">
-          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing four parallel Claude Code agent sessions running in one window"></video>
+          <video src="/assets/product-sessions.mp4" poster="/assets/product-sessions-poster.jpg" autoplay muted loop playsinline aria-label="Ghostties sidebar showing multiple parallel Claude Code agent sessions running in one window"></video>
         </div>
       </div>
-      <div class="product-caption">four sessions, one window</div>
+      <div class="product-caption">every session, one window</div>
 
       <div class="product-window product-window--flow">
         <div class="product-card">

--- a/web/index.html
+++ b/web/index.html
@@ -177,10 +177,6 @@
       text-decoration: underline;
     }
 
-    .term-btn:hover .copy-icon {
-      text-decoration: underline;
-    }
-
     /* line-5's copy icon drops on mobile; see the max-width: 480px block. */
     .btn-icon {
       display: inline;
@@ -195,9 +191,8 @@
        space used to provide. */
     .copy-icon {
       display: inline-block;
-      width: 1ch;
-      margin-left: 1ch;
-      text-align: right;
+      width: 2ch;
+      text-align: center;
     }
 
     /* Default (>480px): show the full line-3 string, hide the mobile-short

--- a/web/index.html
+++ b/web/index.html
@@ -177,6 +177,10 @@
       text-decoration: underline;
     }
 
+    .term-btn:hover .copy-icon {
+      text-decoration: underline;
+    }
+
     /* line-5's copy icon drops on mobile; see the max-width: 480px block. */
     .btn-icon {
       display: inline;
@@ -193,7 +197,7 @@
       display: inline-block;
       width: 1ch;
       margin-left: 1ch;
-      text-align: center;
+      text-align: right;
     }
 
     /* Default (>480px): show the full line-3 string, hide the mobile-short


### PR DESCRIPTION
Two homepage fixes, both in `web/index.html`.

## 1. Trailing `]` clipped on the hero copy buttons

The `]` was being eaten on the two hero lines containing the `⧉` glyph. Line 6 (`+ [download now]`, no icon) rendered fine — the control was already on the page.

**Measured cause, not inferred.** At the terminal's computed 18px, `1ch = 11.140625px`, but `⧉` (U+29C9) advances **14.328125px = 1.286ch**, because it falls off the mono stack. The typewriter keyframes animate `width` to hard-coded `18ch`/`27ch` and `.line` has `overflow: hidden`, so the real content (18.265ch / 27.255ch) overflowed its box and the bracket fell outside the clip.

Line 4 was clipping at **every** width, not just desktop — its icon had no wrapper at all.

**The fix forces the glyph into an exact 1ch box** rather than bumping the `ch` values. The `ch` numbers, the `steps(N)` counts and the code comments all encode "this line is N characters"; patching the numbers would make every one of those a lie and re-break at the next copy edit. `margin-left: 1ch` replaces the literal space that preceded the glyph, so the arithmetic stays additive. No `steps()`, keyframe width, or timing value changed.

## 2. Caption said four sessions; the clip shows five

The video shows five Claude Code sessions — one under `fieldwork`, four under `switchboard` — across two projects. Both the visible caption and the `aria-label` said four.

Changed to `every session, one window`, which parallels the sibling caption (`gt list — every task, one lane`) and cannot go stale at the next re-shoot, which is how it broke.

## Verified

- Trailing `]` whole on lines 4, 5 and 6 at 320 / 375 / 480 / 700 / 1280
- Captured mid-type-in, not just settled: no stray `+` or bracket escapes its line box
- Mobile unchanged at 375px — line 5's icon still hides, line 4's still shows, both brackets whole
- Both copy buttons write the correct string to the clipboard; neither is tab-reachable before its line reveals
- No version regression: 0 occurrences of `beta.21`, 7 of `beta.22`, matching `main`

Screenshots were reviewed in-thread rather than embedded — `gh gist create` is classifier-blocked in this environment.
