### PR TITLE
test(macos): add synthetic load harness for session-name-sync cache

### DIFF
--- a/docs/perf/session-name-sync-cache-load.md
+++ b/docs/perf/session-name-sync-cache-load.md
@@ -1,0 +1,231 @@
+# Session Name Sync — Cache Invalidation Load Measurement
+
+**Status:** measured, not fixed. This is a measurement-only harness (task
+scope excluded fixing the `didSet`). No production behavior was changed.
+
+**Harness:** `macos/Tests/Workspace/SessionNameSyncCacheLoadTests.swift`
+**Bug under measurement:** PR #54 (`0ad1e05d3`) syncs the Claude Code window
+title into the sidebar session name via
+`WorkspaceStore.syncSessionNameFromTitle`. That write path mutates
+`sessions`, whose `didSet` clears `sessionGroupsCache` for **every**
+project, not just the one whose session was renamed
+(`WorkspaceStore.swift`, `sessions` property, ~line 32).
+
+## Headline number
+
+**Excess wall-clock cost attributable to the over-broad invalidation: ~181ms
+over 50 minutes of simulated continuous 6-agent load — about 60
+microseconds of extra CPU work per second of load, or ~50µs per title-sync
+write.**
+
+**Is it a real problem at 5–7 agents? No — not as a CPU/recompute cost.**
+The store-wide clear does measurably more work than necessary (3x the
+recompute count: 21,600 vs. 7,200 over the run), but `computeSessionGroups`
+itself is cheap (a handful of sessions per project, O(n) filter+sort), so
+even 3x too much of a cheap operation is still cheap in absolute terms.
+This harness does NOT show a "third instance of the activity-invalidation
+storm" in the sense of unbounded work — the earlier storm incidents
+(`project_perf-activity-invalidation-storm.md`, SEA-214) were expensive
+because of `objectWillChange`-driven **SwiftUI view-tree re-renders**
+cascading across the sidebar, not because the underlying computation itself
+was slow. This harness deliberately measures only the store's own
+recompute cost, not the downstream render cost — see **Scope & limits**
+below for why that matters and what it doesn't tell you.
+
+## Method
+
+### Fixture
+
+6 projects (matching the "5–7 concurrent agents" cadence basis in the task
+brief), sized 3–8 sessions each (8, 7, 6, 5, 4, 3 — 33 sessions total),
+matching the observed shape of a handful of concurrently-worked projects
+with several accumulated sessions each. One session per project (6 total)
+is the "active agent" whose title gets synced on the real cadence.
+
+### Cadence
+
+The real-world cadence from the task brief: ~1 title write per session
+every 5 seconds. The harness ticks every `5.0/6.0`s (≈0.833s) and, on each
+tick, one of the 6 active sessions (round-robin) gets a fresh,
+sanitizer-passing title via `syncSessionNameFromTitle` — the exact PR #54
+write path. Round-robining 6 sessions at this tick rate means each
+INDIVIDUAL session's title syncs exactly once every 5 simulated seconds,
+and the AGGREGATE write rate across all 6 is 1.2 writes/sec — matching the
+brief's "~1–1.4 store-wide invalidations/sec at 5–7 agents" estimate.
+
+### Read pattern (redraw simulation)
+
+After each write, the harness simulates a sidebar redraw by calling
+`sessionGroups(forProject:)` for **every** project — the worst-realistic
+case where all 6 projects are pinned/expanded simultaneously. This is a
+documented assumption, not a measurement: if fewer projects are expanded at
+once, both models' costs scale down proportionally with the number of
+expanded projects actually read, and the excess (the store-wide vs.
+per-project delta) scales down with them too, since it is driven by reads,
+not by the write itself.
+
+### Two models, same data
+
+1. **Store-wide (real).** The real `WorkspaceStore`, the real
+   `sessionGroupsCache`, exercised through the real write → read path.
+2. **Per-project (counterfactual, MEASURED not derived).** A local shadow
+   cache in the test file, keyed by project id and TTL'd identically to the
+   real cache (2s — duplicated from `WorkspaceStore.cacheTTL`, which is
+   private), but invalidated only for the ONE project whose session was
+   just renamed. Cache misses call the store's own pure, exported
+   `WorkspaceStore.computeSessionGroups` static function over the exact
+   same live `store.sessions` / `store.globalIndicatorStates` data the real
+   model saw at that tick. Because this reuses the real computation
+   function over real data, this is a genuine measurement of the
+   counterfactual, not an estimate multiplied out from a single-project
+   cost (the task's fallback method for cases where per-project
+   invalidation "is not trivially simulable" — it was trivially simulable
+   here, so the fallback wasn't needed).
+
+An important, expected wrinkle: because the cache TTL (2s) is shorter than
+the per-session write interval (5s), the per-project counterfactual is NOT
+zero-cost — every project's shadow entry also goes stale from **pure time
+elapsing** roughly every ~2.5 ticks, independent of any write. This is
+correct and intentional: the delta between the two models isolates exactly
+the cost caused by the over-broad `didSet`, with the unavoidable
+TTL-driven baseline churn (present in both models) subtracted out.
+
+### Time compression
+
+Ticks are driven by `WorkspaceStore._setTestClock` (a `#if DEBUG` test-only
+hook that already existed in `WorkspaceStore.swift` before this task) with
+NO real `Task.sleep` / wall-clock wait between ticks. The work performed
+per tick — one sanitized title write plus a full 6-project redraw read
+against both models — is byte-for-byte identical to what the real cadence
+would run; only the *wait* between ticks was removed.
+
+**Compression factor:** 3,000 simulated seconds (50 minutes of continuous
+6-agent load) were represented in a real xcodebuild-measured test run of
+**0.51 seconds** of wall-clock time — a compression factor of ≈5,880x. Of
+that 0.51s, ~369ms was the actual instrumented work (`storeWideElapsed` +
+`perProjectElapsed` below); the remainder is fixture setup and per-tick
+Swift/XCTest overhead not part of the measured recompute cost.
+
+## Raw numbers (one real run, unfiltered)
+
+```
+=== Session Name Sync Cache Load — Results ===
+Simulated duration: 3000.0s over 3600 ticks (compressed — no real sleep between ticks)
+Writes (title syncs): 3600
+Store-wide model  — recomputes: 21600, elapsed: 275.41565895080566ms
+Per-project model — recomputes: 7200, elapsed: 93.99950504302979ms
+Excess recomputes attributable to store-wide invalidation: 14400
+Excess wall-clock attributable to store-wide invalidation: 181.41615390777588ms
+Excess recomputes per write: 4.0
+Excess elapsed per write: 50.393376085493294µs
+Excess elapsed per simulated second of load: 0.060472051302591964ms/s
+===============================================
+```
+
+| Metric | Store-wide (real) | Per-project (counterfactual) | Excess (delta) |
+|---|---|---|---|
+| Recomputes over 3,600 writes | 21,600 | 7,200 | **14,400** (3.0x) |
+| Wall-clock (compressed run) | 275.4ms | 94.0ms | **181.4ms** |
+| Per write | 6.0 recomputes | 2.0 recomputes | 4.0 recomputes / **50.4µs** |
+| Per simulated second of load | — | — | **0.060ms/s** (≈0.006% of one core) |
+
+`21,600 = 3,600 ticks × 6 projects` — every read after every write
+recomputes ALL 6 projects, because the store-wide clear invalidates the
+entire `sessionGroupsCache` dictionary on every single write, and every
+tick performs exactly one write. `7,200 = 3,600 × 2.0` — the per-project
+model still recomputes ~2 of 6 projects per tick, almost entirely from the
+2s TTL naturally expiring faster than the 5s per-project write interval
+(not from write-triggered invalidation, which fires for only 1 of 6
+projects per write).
+
+## Full test suite (unfiltered)
+
+```
+xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties \
+  -derivedDataPath macos/build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES \
+  -only-testing:GhosttyTests test-without-building
+```
+
+Exit code: 65 (non-zero — see below). `xcresulttool get test-results
+summary` for the run:
+
+```
+totalTestCount: 627
+passedTests: 625
+failedTests: 1
+skippedTests: 1
+```
+
+- **Failing test:** `UpdateViewModelTests.testNotFoundText()` — the ONE
+  pre-existing failure the task brief called out on clean main. Confirmed
+  no other test failed.
+- **Skipped test:** `BenchmarkTests.example()` — pre-existing, unrelated to
+  this change (a placeholder/example benchmark suite entry).
+- Both new tests in this harness (`SessionNameSyncCacheLoadTests`) passed:
+  `testSessionNameSyncCadence_StoreWideVsPerProjectInvalidation()` and
+  `testSessionGroupsRedrawCost_AfterStoreWideInvalidation()`.
+- `xcodebuild test` (not `test-without-building`) was also run standalone
+  for `SessionNameSyncCacheLoadTests` alone and passed with exit code 0 —
+  confirmed the app-hosted test target runs to completion locally, not just
+  `build-for-testing`.
+
+## Scope & limits — what this measurement does NOT tell you
+
+- **This is a store-recompute-cost measurement, not a render-cost
+  measurement.** The prior "storm" incidents in this repo
+  (`project_perf-activity-invalidation-storm.md`, SEA-214 coordinator tick)
+  were expensive because `objectWillChange` cascaded into full SwiftUI
+  view-tree re-evaluation across the sidebar — a cost this harness
+  deliberately does not model, because doing so would require driving real
+  `WorkspaceSidebarView`/`ProjectDisclosureRow` SwiftUI bodies under test,
+  which is a materially different (and much heavier) harness. If Sean wants
+  that number, it needs a UI-level or `XCTMetric`-based measurement of an
+  actual sidebar re-render, not this store-level harness.
+- **`sectionedProjectsCache` is also cleared store-wide by the same
+  `didSet`** (`invalidateSectionedProjectsCache()` runs alongside
+  `sessionGroupsCache.removeAll()`). This harness does not instrument that
+  cache — it targets `sessionGroupsCache` specifically because that's the
+  cache the task brief named. `computeSectionedProjects` is O(projects +
+  sessions) and already single-slot (not keyed per-project), so its
+  store-wide clear is *inherent* to its design, not a bug — there was
+  nothing narrower to compare it against.
+- **All-projects-expanded is a worst-case assumption**, not a measurement
+  of real usage. If fewer projects are typically pinned/expanded at once,
+  the absolute costs (both models) and the excess scale down together.
+- **Single machine, single run.** This is a sanity-scale measurement (~180ms
+  of excess CPU work spread across 50 minutes of load), not a statistically
+  rigorous multi-run benchmark — the number is small enough that run-to-run
+  noise could move it by a factor of 2 without changing the conclusion.
+
+## Production-code footprint
+
+One `#if DEBUG`-gated, read-only counter was added to
+`WorkspaceStore.swift` so the harness could distinguish a cache hit from a
+miss without reaching into the (rightly) private `sessionGroupsCache`
+dictionary — the same pattern already used by the existing `persistCallCount`
+test hook in that file:
+
+```swift
+#if DEBUG
+private(set) var _sessionGroupsRecomputeCount = 0
+#endif
+```
+
+incremented on the existing cache-miss path inside `sessionGroups(forProject:)`.
+Compiled out of release builds entirely; no other production code was
+touched, and the `didSet` under test was NOT modified.
+
+## What a fix would involve (not implemented — Sean's call)
+
+The mechanical fix is straightforward: on the `sessions` `didSet`, instead
+of `sessionGroupsCache.removeAll()`, diff the old and new `sessions` arrays
+for which `projectId`s actually changed (added/removed/mutated session) and
+remove only those entries from `sessionGroupsCache`. `syncSessionNameFromTitle`
+already knows the exact session (and therefore project) being written —
+the simplest version would let mutating methods report which project id(s)
+they touched rather than relying purely on `didSet` diffing the whole
+array. Given the measured cost here is small, this is a "worth doing for
+correctness/design-cleanliness" fix, not an urgent perf fix — worth
+weighing against the `didSet`-invalidation design's stated benefit (a
+future mutation site can never forget to bust the cache) before touching
+it.

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -418,6 +418,16 @@ final class WorkspaceStore: ObservableObject {
         flatProjectsInVisualOrder.map(\.id)
     }
 
+    #if DEBUG
+    /// Test-only counter — increments every time `sessionGroups(forProject:)`
+    /// actually recomputes (cache miss or TTL expiry), never on a cache hit.
+    /// Added solely for the `docs/perf/session-name-sync-cache-load.md`
+    /// measurement harness (`SessionNameSyncCacheLoadTests`) — read-only,
+    /// DEBUG-gated, and touched by no production path. Compiled out of
+    /// release builds entirely.
+    private(set) var _sessionGroupsRecomputeCount = 0
+    #endif
+
     /// Memoized `sessionGroups(forProject:)` results, keyed by project id,
     /// each paired with the wall-clock time it was computed at. `computeSessionGroups`
     /// buckets by `lastActiveAt` recency too, so — same as `sectionedProjectsCache`
@@ -446,6 +456,9 @@ final class WorkspaceStore: ObservableObject {
             now: { now }
         )
         sessionGroupsCache[projectId] = (computed, now)
+        #if DEBUG
+        _sessionGroupsRecomputeCount += 1
+        #endif
         return computed
     }
 

--- a/macos/Tests/Workspace/SessionNameSyncCacheLoadTests.swift
+++ b/macos/Tests/Workspace/SessionNameSyncCacheLoadTests.swift
@@ -1,0 +1,289 @@
+import Foundation
+import XCTest
+@testable import Ghostty
+
+/// Synthetic load harness measuring the cost of PR #54's session-name-sync
+/// cache-invalidation path. Results, method, and headline numbers live in
+/// `docs/perf/session-name-sync-cache-load.md` — this file is the harness
+/// itself, not the report.
+///
+/// The suspected shape: `WorkspaceStore.sessions`'s `didSet` clears
+/// `sessionGroupsCache` for **every** project on every mutation — including
+/// `syncSessionNameFromTitle`, the write path PR #54 added to sync the
+/// Claude Code terminal title into the sidebar session name, called on a
+/// real per-session cadence of roughly once every 5 seconds. This harness
+/// reproduces that cadence against a realistic multi-project fixture and
+/// measures two things against each other:
+///
+///   1. The STORE-WIDE model — the real `WorkspaceStore`, its real
+///      `sessionGroupsCache`, exercised through the real
+///      `syncSessionNameFromTitle` → `sessionGroups(forProject:)` path.
+///   2. A PER-PROJECT counterfactual — built from the exact same pure
+///      `WorkspaceStore.computeSessionGroups` static function the store
+///      itself calls on a cache miss, but invalidated only for the ONE
+///      project whose session was renamed, never the others. This is a real
+///      measurement (not an estimate): it runs the identical work over the
+///      identical mutated state, just gated by a different invalidation
+///      rule implemented locally in this test file.
+///
+/// The delta between the two is the wall-clock and recompute-count cost
+/// directly attributable to the over-broad `didSet`, isolated from the
+/// (unavoidable, correct) cost of recomputing the one project that actually
+/// changed.
+///
+/// TIME COMPRESSION: ticks are driven by `WorkspaceStore._setTestClock`
+/// (`#if DEBUG` test hook), advanced in software with no real
+/// `Task.sleep`/wall clock wait between ticks. The WORK performed per tick
+/// (one sanitized title write + a full-sidebar redraw read against both
+/// models) is byte-for-byte identical to what the real cadence would do —
+/// only the wait between ticks is removed. See the results doc for the
+/// exact compression factor (simulated seconds represented vs. real xctest
+/// wall-clock time to run the test).
+///
+/// Production-code footprint: ONE new `#if DEBUG`-gated, read-only counter
+/// (`WorkspaceStore._sessionGroupsRecomputeCount`) was added to
+/// `WorkspaceStore.swift` so this harness can distinguish a cache hit from a
+/// miss without reaching into the (rightly) private `sessionGroupsCache`
+/// dictionary. It increments on the existing cache-miss path and is
+/// compiled out of release builds entirely — no behavior change, no
+/// non-DEBUG diff. No other production code was touched. The `didSet` under
+/// test is NOT modified — this harness measures, it does not fix.
+@MainActor
+final class SessionNameSyncCacheLoadTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    private let template = AgentTemplate.shell
+
+    /// 6 projects, sized 3–8 sessions each — matches the task brief's "5–7
+    /// projects, each with 3–8 sessions" and the observed shape of
+    /// `.ghostties/tasks/` (a handful of concurrently-worked projects, each
+    /// having accumulated several sessions over time).
+    private let projectSessionCounts = [8, 7, 6, 5, 4, 3]
+
+    private struct Fixture {
+        var projects: [Project]
+        var sessions: [AgentSession]
+        /// One "active agent" session per project — the one the harness
+        /// renames on the real cadence. 6 total, matching the "5–7
+        /// concurrent agents" basis the real-world cadence estimate in the
+        /// task brief is built on.
+        var activeSessionIds: [UUID]
+        var projectIds: [UUID]
+    }
+
+    private func makeFixture() -> Fixture {
+        var projects: [Project] = []
+        var sessions: [AgentSession] = []
+        var activeSessionIds: [UUID] = []
+
+        for (i, count) in projectSessionCounts.enumerated() {
+            let project = Project(name: "Project \(i)", rootPath: "/tmp/project-\(i)", isPinned: true)
+            projects.append(project)
+            for j in 0..<count {
+                let session = AgentSession(
+                    name: "Session \(i)-\(j)",
+                    templateId: template.id,
+                    projectId: project.id,
+                    sortOrder: j
+                )
+                sessions.append(session)
+                if j == 0 {
+                    // The first session in each project is the "live agent"
+                    // that gets its title synced on the real cadence.
+                    activeSessionIds.append(session.id)
+                }
+            }
+        }
+        return Fixture(
+            projects: projects,
+            sessions: sessions,
+            activeSessionIds: activeSessionIds,
+            projectIds: projects.map(\.id)
+        )
+    }
+
+    // MARK: - Harness core
+
+    struct RunResult {
+        var ticks: Int
+        var writes: Int
+        var simulatedSeconds: TimeInterval
+        var storeWideRecomputes: Int
+        var storeWideElapsed: TimeInterval
+        var perProjectRecomputes: Int
+        var perProjectElapsed: TimeInterval
+    }
+
+    /// Mirrors `WorkspaceStore.cacheTTL` (private in the production type) so
+    /// the counterfactual model applies the identical TTL rule. If the real
+    /// constant ever changes, `sessionGroupsCacheExpiresAfterTTLWithNoMutation`
+    /// in `WorkspaceStoreSectionsTests.swift` will still pin the real value —
+    /// this harness's TTL is a deliberate, documented duplicate, not a
+    /// silent drift risk.
+    private let cacheTTL: TimeInterval = 2.0
+
+    /// Runs the synthetic name-sync cadence for `ticks` ticks. Each tick:
+    ///
+    ///   1. Advances the fake clock by `tickInterval` — `5.0/6.0`s, so with 6
+    ///      round-robined active sessions, EACH individual session gets its
+    ///      title synced exactly once every 5 simulated seconds (the real
+    ///      per-session cadence from the task brief), and the aggregate
+    ///      write rate across all 6 is 1.2 writes/sec (also matching the
+    ///      brief's "~1–1.4 store-wide invalidations/sec at 5–7 agents").
+    ///   2. One active session (round-robin) gets a fresh, sanitizer-passing
+    ///      title via `syncSessionNameFromTitle` — the exact PR #54 write
+    ///      path, which trips `sessions`'s `didSet` and clears
+    ///      `sessionGroupsCache` for every project, not just the written one.
+    ///   3. Simulates a sidebar redraw against the STORE-WIDE model: reads
+    ///      `sessionGroups(forProject:)` for every project. Worst-realistic-
+    ///      case assumption: all 6 projects are pinned/expanded at once (see
+    ///      results doc for why this is the right assumption to report,
+    ///      and what changes if fewer are expanded).
+    ///   4. Simulates the identical redraw against the PER-PROJECT
+    ///      counterfactual: a local shadow cache keyed by project id, TTL'd
+    ///      exactly like the real one, but invalidated ONLY for the project
+    ///      whose session was just renamed. Cache misses call the store's
+    ///      own pure `computeSessionGroups` over the SAME live
+    ///      `store.sessions` / `store.globalIndicatorStates` data.
+    func runCadence(ticks: Int) -> RunResult {
+        let fixture = makeFixture()
+        let store = WorkspaceStore(testingProjects: fixture.projects, testingSessions: fixture.sessions)
+
+        let tickInterval: TimeInterval = 5.0 / 6.0
+        var simulatedTime = Date(timeIntervalSince1970: 1_700_000_000)
+        store._setTestClock { simulatedTime }
+
+        // Prime both caches once before measuring so tick 0 doesn't pay a
+        // one-time cold-start cost neither model would pay in steady state.
+        for id in fixture.projectIds {
+            _ = store.sessionGroups(forProject: id)
+        }
+        var shadowCachedAt: [UUID: Date] = Dictionary(
+            uniqueKeysWithValues: fixture.projectIds.map { ($0, simulatedTime) }
+        )
+
+        var writes = 0
+        var storeWideRecomputes = 0
+        var storeWideElapsed: TimeInterval = 0
+        var perProjectRecomputes = 0
+        var perProjectElapsed: TimeInterval = 0
+
+        for tick in 0..<ticks {
+            simulatedTime = simulatedTime.addingTimeInterval(tickInterval)
+
+            let writerIndex = tick % fixture.activeSessionIds.count
+            let sessionId = fixture.activeSessionIds[writerIndex]
+            let writtenProjectId = fixture.projectIds[writerIndex]
+            let title = "Working on migration step \(tick) of the request pipeline"
+            store.syncSessionNameFromTitle(id: sessionId, title: title)
+            writes += 1
+
+            // --- Store-wide model: the real store, the real cache. ---
+            let beforeCount = store._sessionGroupsRecomputeCount
+            let storeWideStart = CFAbsoluteTimeGetCurrent()
+            for id in fixture.projectIds {
+                _ = store.sessionGroups(forProject: id)
+            }
+            storeWideElapsed += CFAbsoluteTimeGetCurrent() - storeWideStart
+            storeWideRecomputes += store._sessionGroupsRecomputeCount - beforeCount
+
+            // --- Per-project counterfactual: invalidate ONLY the written project. ---
+            shadowCachedAt.removeValue(forKey: writtenProjectId)
+            let perProjectStart = CFAbsoluteTimeGetCurrent()
+            for id in fixture.projectIds {
+                let isStale = shadowCachedAt[id].map { simulatedTime.timeIntervalSince($0) >= cacheTTL } ?? true
+                if isStale {
+                    _ = WorkspaceStore.computeSessionGroups(
+                        projectId: id,
+                        sessions: store.sessions,
+                        indicatorStates: store.globalIndicatorStates,
+                        now: { simulatedTime }
+                    )
+                    shadowCachedAt[id] = simulatedTime
+                    perProjectRecomputes += 1
+                }
+            }
+            perProjectElapsed += CFAbsoluteTimeGetCurrent() - perProjectStart
+        }
+
+        return RunResult(
+            ticks: ticks,
+            writes: writes,
+            simulatedSeconds: Double(ticks) * tickInterval,
+            storeWideRecomputes: storeWideRecomputes,
+            storeWideElapsed: storeWideElapsed,
+            perProjectRecomputes: perProjectRecomputes,
+            perProjectElapsed: perProjectElapsed
+        )
+    }
+
+    // MARK: - Tests
+
+    /// The headline measurement. 3600 ticks × 5/6s = 3000 simulated seconds
+    /// (50 minutes of continuous 6-agent load) run back-to-back with no real
+    /// sleep — see the class doc comment for the compression rationale.
+    func testSessionNameSyncCadence_StoreWideVsPerProjectInvalidation() {
+        let ticks = 3600
+        let result = runCadence(ticks: ticks)
+
+        let excessRecomputes = result.storeWideRecomputes - result.perProjectRecomputes
+        let excessElapsed = result.storeWideElapsed - result.perProjectElapsed
+
+        // swiftlint:disable:next line_length
+        let report = """
+        === Session Name Sync Cache Load — Results ===
+        Simulated duration: \(result.simulatedSeconds)s over \(result.ticks) ticks (compressed — no real sleep between ticks)
+        Writes (title syncs): \(result.writes)
+        Store-wide model  — recomputes: \(result.storeWideRecomputes), elapsed: \(result.storeWideElapsed * 1000)ms
+        Per-project model — recomputes: \(result.perProjectRecomputes), elapsed: \(result.perProjectElapsed * 1000)ms
+        Excess recomputes attributable to store-wide invalidation: \(excessRecomputes)
+        Excess wall-clock attributable to store-wide invalidation: \(excessElapsed * 1000)ms
+        Excess recomputes per write: \(Double(excessRecomputes) / Double(result.writes))
+        Excess elapsed per write: \(excessElapsed / Double(result.writes) * 1_000_000)µs
+        Excess elapsed per simulated second of load: \(excessElapsed / result.simulatedSeconds * 1000)ms/s
+        ===============================================
+        """
+        print(report)
+
+        // `print()` output from app-hosted GhosttyTests isn't reliably captured by
+        // `xcodebuild test`'s console in this environment (see
+        // `general-agent-context.md` — "app-hosted GhosttyTests execution stays
+        // local-Cmd+U-only"). Also write the report to a fixed, well-known path
+        // so a CLI run can recover the exact numbers this run produced for
+        // `docs/perf/session-name-sync-cache-load.md`. Harmless side effect —
+        // this is test code, not production code, and every run simply
+        // overwrites the same file with its own fresh numbers.
+        let reportPath = NSTemporaryDirectory() + "session-name-sync-cache-load-results.txt"
+        try? report.write(toFile: reportPath, atomically: true, encoding: .utf8)
+
+        // Sanity floor: store-wide invalidation can never do LESS work than
+        // per-project invalidation over the same mutation sequence.
+        XCTAssertGreaterThanOrEqual(result.storeWideRecomputes, result.perProjectRecomputes)
+        XCTAssertEqual(result.writes, ticks)
+    }
+
+    /// Official XCTest performance baseline: the cost of ONE full-sidebar
+    /// redraw (all 6 projects) immediately following one store-wide-
+    /// invalidating title sync, at the fixture's realistic session-per-
+    /// project shape. Xcode records this baseline automatically; a future
+    /// regression (e.g. a bigger fixture, or the invalidation getting even
+    /// broader) shows up as a measurable timing increase here.
+    func testSessionGroupsRedrawCost_AfterStoreWideInvalidation() {
+        let fixture = makeFixture()
+        let store = WorkspaceStore(testingProjects: fixture.projects, testingSessions: fixture.sessions)
+        var now = Date(timeIntervalSince1970: 1_700_000_000)
+        store._setTestClock { now }
+
+        measure {
+            now = now.addingTimeInterval(5)
+            store.syncSessionNameFromTitle(
+                id: fixture.activeSessionIds[0],
+                title: "Rotating measured title \(now.timeIntervalSince1970)"
+            )
+            for id in fixture.projectIds {
+                _ = store.sessionGroups(forProject: id)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a synthetic, measurement-only load harness (`SessionNameSyncCacheLoadTests.swift`) for the `sessionGroupsCache` invalidation in `WorkspaceStore` that PR #54's session-name-sync write path triggers.

## What it measures

`WorkspaceStore.syncSessionNameFromTitle` (from PR #54) mutates `sessions`, whose `didSet` clears `sessionGroupsCache` store-wide instead of per-project. The harness simulates 6 projects / 33 sessions under the real observed cadence (~1 title write per session per 5s, 6 concurrent agents) over 50 simulated minutes, and reads back through `sessionGroups(forProject:)` on every tick to approximate a full sidebar redraw.

**Result:** the over-broad invalidation does ~3x the recompute work it needs to (21,600 vs. 7,200 recomputes), but the excess wall-clock cost is only ~181ms over the 50-minute run (~50µs per write) — real, but small in absolute terms. `computeSessionGroups` itself is cheap. The bigger unmeasured risk is the downstream SwiftUI re-render fan-out, which this store-level harness deliberately does not cover.

Adds one `#if DEBUG`-gated, read-only recompute counter to `WorkspaceStore` (mirrors the existing `persistCallCount` hook) so the harness can distinguish cache hits from misses without reaching into the private cache dict. No behavior change, compiled out of release builds. The `didSet` under measurement is untouched — this is measurement only, not a fix.

Full method and results: `docs/perf/session-name-sync-cache-load.md`.

---

**Reviewer question — is this already obsolete?** This harness targets Ghostties' session-name-sync cache. Claude Code now writes `~/.claude/sessions/<pid>.json` carrying a `nameSource` field (e.g. `"derived"`), meaning session naming may be moving to a read-from-source model rather than one Ghostties infers and caches. Judge this harness in that light rather than in isolation: does it still test something Ghostties will own?

## Test plan
- [x] `xcodebuild test` — harness runs and reproduces the measured numbers above