### PR TITLE
fix(macos): sidebar Sessions tab shows stale name after terminal title sync

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -619,3 +619,22 @@ Sidebar/UX wave night. Ten PRs merged: the six-PR overnight wave (#96, #100, #10
 - [ ] **PR #105** (`docs/npm-published`) — owned by another session, worktree `session-2` is locked. Not this thread's to merge. | dist | other-session
 - [ ] **PR #56** (idle-fallback) — open since July, correctly excluded from beta.22. | app | deferred
 - [ ] **`test/session-cache-load-harness`** — branch on origin, no PR ever opened, genuinely unmerged. Confirm whether it's dead. | build | deferred
+
+## 2026-08-14
+
+**Carried — sidebar row staleness (branch `fix/sidebar-name-stale-sessions-tab`, PR #121, `d3f85b08f`):**
+
+- [ ] **Verify the `.equatable()` fix at runtime** — built but UNVERIFIED. Relaunch `Ghostties Dev.app`, rename a session, confirm the SIDEBARDIAG log shows the row rendering the new name with an unchanged `id=` prefix. | app | carried
+- [ ] **Strip temporary SIDEBARDIAG os_log instrumentation** from `RecentsListView.swift` + `RecentsRowView.swift` before merge. Commit `d3f85b08f` is explicitly labelled not-shippable. | app | carried
+- [ ] **Run the full suite + reshape PR #121** — its description still describes the abandoned `.onReceive` attempt, which was disproven. | app | carried
+- [ ] **`ThrottleTrailingEdgeHypothesisTests.swift`** (untracked) — DECIDE OR KILL: keep the trailing-edge test as a regression test and delete the two diagnostic ones (one calls `XCTFail` unconditionally, so it fails every local run), or drop the file. Strawman: keep the trailing-edge test only. | app | carried
+
+**New, found while debugging the above:**
+
+- [ ] **`.workspaceSidebarTabChanged` is a dead notification** — declared `WorkspaceLayout.swift:338`, posted twice from `TerminalController.swift:1361,1368`, zero observers anywhere. The sidebar tab switch actually works by riding the `.workspaceSidebarViewModeChanged` post on the following line, usually setting the mode to the value it already held. | app | new
+- [ ] **`SessionTitleSanitizer` doesn't strip `◐`/`◑` (U+25D0/U+25D1)** — it covers `✳ ✻ ✽ * · •` and the Braille block, but the circle-quadrant spinner frames persist into session names and rewrite `workspace.json` every few seconds. | app | new
+- [ ] **Re-test two conclusions measured through the broken row** — the invisible-session bug (2026-08-10) and the blue-ghost indicator readings in `project_switchboard-phase0-verdict.md`. Both were observed via a row that could not update its `indicatorState`, so they may not hold. | app | new
+
+**Parked — off-objective (next thread's scope, not this one's):**
+
+- [ ] **Status representation vs. per-session ghost icons** — Sean: "The ghost icons were supposed to represent status. If we have a new status representation then the ghost icons are redundant." The row now carries two status channels (ghost color + Claude's own `✳` glyph baked into the name) plus a timestamp. Design decision, Sean's call. Captured in `tease-capture.md`. | design | parked

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -71,7 +71,7 @@ struct RecentsListView: View {
                 )
 
                 ScrollView {
-                    LazyVStack(spacing: 2) {
+                    VStack(spacing: 2) {
                         // All three headers always render (when there's at
                         // least one session anywhere) — membership adapts,
                         // but the ACTIVE/INACTIVE/ARCHIVE headers themselves

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -1,4 +1,9 @@
 import SwiftUI
+import os
+
+/// TEMPORARY diagnostic logger — see `SIDEBARDIAG` tag. To be reverted.
+private let sidebarDiagLogger = Logger(subsystem: "com.seansmithdesign.ghostties", category: "sidebardiag")
+private var sidebarDiagBodyCounter = 0
 
 /// The Sessions tab content: a flat, time-sorted list of all sessions across projects.
 ///
@@ -15,10 +20,6 @@ struct RecentsListView: View {
     @State private var editingSessionId: UUID?
     @State private var editingName: String = ""
     @FocusState private var renameFieldFocused: Bool
-    /// Bumped on every `store.objectWillChange` so SwiftUI has a dependency
-    /// that actually changes on name edits — see the `.onReceive` below and
-    /// the `_ = storeRevision` read in `body`.
-    @State private var storeRevision = 0
 
     /// Section-collapse state, persisted across launches. Active and
     /// Inactive default open (sessions the user is working with today, or
@@ -36,12 +37,14 @@ struct RecentsListView: View {
         let inactive = inactiveSessions
         let archive = archiveSessions
         let selectedId = coordinator.activeSessionId
-        // Reads storeRevision so the compiler can't strip it as an unused
-        // dependency — see the `.onReceive` below for why it's needed. Uses
-        // `let _ =` (not a bare `_ =`) because `body` is a @ViewBuilder
-        // closure, which parses a bare discard expression as an attempted
-        // View and fails to build.
-        let _ = storeRevision
+
+        // TEMPORARY diagnostic — see SIDEBARDIAG in the boundaries note; to be reverted.
+        let _ = {
+            sidebarDiagBodyCounter &+= 1
+            sidebarDiagLogger.debug("SIDEBARDIAG body pass=\(sidebarDiagBodyCounter, privacy: .public) activeCount=\(active.count, privacy: .public)")
+            let activeSummary = active.map { "\(String($0.id.uuidString.prefix(8)))=\($0.name)" }.joined(separator: ", ")
+            sidebarDiagLogger.debug("SIDEBARDIAG active sessions: \(activeSummary, privacy: .public)")
+        }()
 
         VStack(spacing: 0) {
             if store.sessions.isEmpty {
@@ -81,6 +84,18 @@ struct RecentsListView: View {
                             isEffectivelyExpanded: activeExpanded
                         )
                         if activeExpanded {
+                            // Keyed on the stable `\.id` (default Identifiable) —
+                            // NOT `\.self`. `\.self` was tried and reverted: it makes
+                            // row identity churn on every `lastActiveAt` write (see
+                            // `AgentSession.lastActiveAt`, rewritten every few seconds
+                            // for running sessions), which tears down and rebuilds the
+                            // row — resetting `RecentsRowView`'s hover state and
+                            // killing the inline-rename `TextField`/`FocusState`
+                            // mid-edit. Freshness on a stable identity is instead
+                            // guaranteed by `.equatable()` on `RecentsRowView` in
+                            // `sessionRow(for:)`, which forces a body re-render
+                            // whenever the row's own inputs change, without touching
+                            // identity.
                             ForEach(active) { session in
                                 sessionRow(for: session)
                             }
@@ -93,6 +108,8 @@ struct RecentsListView: View {
                             isEffectivelyExpanded: inactiveExpanded
                         )
                         if inactiveExpanded {
+                            // See the identity/`.equatable()` comment on the Active
+                            // ForEach above — same fix applies here.
                             ForEach(inactive) { session in
                                 sessionRow(for: session)
                             }
@@ -105,6 +122,8 @@ struct RecentsListView: View {
                             isEffectivelyExpanded: archiveExpanded
                         )
                         if archiveExpanded {
+                            // See the identity/`.equatable()` comment on the Active
+                            // ForEach above — same fix applies here.
                             ForEach(archive) { session in
                                 sessionRow(for: session)
                             }
@@ -119,10 +138,6 @@ struct RecentsListView: View {
             Spacer(minLength: 0)
         }
         .background(.clear)
-        // Session rows don't otherwise re-render when only `session.name`
-        // changes (e.g. terminal title sync) — see ActiveZoneView's
-        // identical pattern for `sessionDraftStore`.
-        .onReceive(store.objectWillChange) { _ in storeRevision &+= 1 }
     }
 
     // MARK: - New Session (project-picker templates)
@@ -159,6 +174,7 @@ struct RecentsListView: View {
             onCommitRename: { commitRename(session: session) },
             onCancelRename: { cancelRename() }
         )
+        .equatable()
         .contextMenu {
             Button("Rename") {
                 beginRename(session: session)

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -15,6 +15,10 @@ struct RecentsListView: View {
     @State private var editingSessionId: UUID?
     @State private var editingName: String = ""
     @FocusState private var renameFieldFocused: Bool
+    /// Bumped on every `store.objectWillChange` so SwiftUI has a dependency
+    /// that actually changes on name edits — see the `.onReceive` below and
+    /// the `_ = storeRevision` read in `body`.
+    @State private var storeRevision = 0
 
     /// Section-collapse state, persisted across launches. Active and
     /// Inactive default open (sessions the user is working with today, or
@@ -32,6 +36,12 @@ struct RecentsListView: View {
         let inactive = inactiveSessions
         let archive = archiveSessions
         let selectedId = coordinator.activeSessionId
+        // Reads storeRevision so the compiler can't strip it as an unused
+        // dependency — see the `.onReceive` below for why it's needed. Uses
+        // `let _ =` (not a bare `_ =`) because `body` is a @ViewBuilder
+        // closure, which parses a bare discard expression as an attempted
+        // View and fails to build.
+        let _ = storeRevision
 
         VStack(spacing: 0) {
             if store.sessions.isEmpty {
@@ -109,6 +119,10 @@ struct RecentsListView: View {
             Spacer(minLength: 0)
         }
         .background(.clear)
+        // Session rows don't otherwise re-render when only `session.name`
+        // changes (e.g. terminal title sync) — see ActiveZoneView's
+        // identical pattern for `sessionDraftStore`.
+        .onReceive(store.objectWillChange) { _ in storeRevision &+= 1 }
     }
 
     // MARK: - New Session (project-picker templates)

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -159,6 +159,8 @@ struct RecentsListView: View {
     // MARK: - Session Row
 
     private func sessionRow(for session: AgentSession) -> some View {
+        // TEMPORARY diagnostic — see SIDEBARDIAG in the boundaries note; to be reverted.
+        sidebarDiagLogger.debug("SIDEBARDIAG construct id=\(session.id.uuidString.prefix(8), privacy: .public) name=\(session.name, privacy: .public)")
         let project = store.projects.first { $0.id == session.projectId }
         let projectName = project?.name ?? "Unknown"
         let indicatorState = store.globalIndicatorStates[session.id] ?? .inactive

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -1,9 +1,4 @@
 import SwiftUI
-import os
-
-/// TEMPORARY diagnostic logger — see `SIDEBARDIAG` tag. To be reverted.
-private let sidebarDiagLogger = Logger(subsystem: "com.seansmithdesign.ghostties", category: "sidebardiag")
-private var sidebarDiagBodyCounter = 0
 
 /// The Sessions tab content: a flat, time-sorted list of all sessions across projects.
 ///
@@ -38,14 +33,6 @@ struct RecentsListView: View {
         let archive = archiveSessions
         let selectedId = coordinator.activeSessionId
 
-        // TEMPORARY diagnostic — see SIDEBARDIAG in the boundaries note; to be reverted.
-        let _ = {
-            sidebarDiagBodyCounter &+= 1
-            sidebarDiagLogger.debug("SIDEBARDIAG body pass=\(sidebarDiagBodyCounter, privacy: .public) activeCount=\(active.count, privacy: .public)")
-            let activeSummary = active.map { "\(String($0.id.uuidString.prefix(8)))=\($0.name)" }.joined(separator: ", ")
-            sidebarDiagLogger.debug("SIDEBARDIAG active sessions: \(activeSummary, privacy: .public)")
-        }()
-
         VStack(spacing: 0) {
             if store.sessions.isEmpty {
                 emptyState
@@ -71,6 +58,22 @@ struct RecentsListView: View {
                 )
 
                 ScrollView {
+                    // Deliberately a plain VStack, NOT `LazyVStack`. A lazy
+                    // container realizes each row once and retains it — when
+                    // a session's fields (e.g. name) change but its `\.id`
+                    // identity doesn't, `ForEach`'s content closure is never
+                    // re-invoked for that row, so it renders the value it was
+                    // first constructed with forever (proven by
+                    // instrumentation: `sessionRow(for:)` fired only at
+                    // creation, never on rename). Switching this back to
+                    // `LazyVStack` reintroduces the frozen-name bug — rows
+                    // will stop picking up renames, activity changes, and
+                    // timestamp updates. If eager rendering of ~37 archive
+                    // rows (each carrying a `.contextMenu`) ever becomes a
+                    // measured perf problem, the fix is a lazy container that
+                    // still re-invokes its content closure on element change
+                    // (e.g. `LazyVStack` keyed with `.id` forced to include a
+                    // content hash), not a plain revert.
                     VStack(spacing: 2) {
                         // All three headers always render (when there's at
                         // least one session anywhere) — membership adapts,
@@ -91,11 +94,11 @@ struct RecentsListView: View {
                             // for running sessions), which tears down and rebuilds the
                             // row — resetting `RecentsRowView`'s hover state and
                             // killing the inline-rename `TextField`/`FocusState`
-                            // mid-edit. Freshness on a stable identity is instead
-                            // guaranteed by `.equatable()` on `RecentsRowView` in
-                            // `sessionRow(for:)`, which forces a body re-render
-                            // whenever the row's own inputs change, without touching
-                            // identity.
+                            // mid-edit. Freshness on that stable identity comes from
+                            // this container being a non-lazy `VStack` (see the
+                            // comment above it) — `.equatable()` on `RecentsRowView`
+                            // in `sessionRow(for:)` is a body-re-execution perf gate
+                            // layered on top, not what makes rows fresh.
                             ForEach(active) { session in
                                 sessionRow(for: session)
                             }
@@ -108,8 +111,8 @@ struct RecentsListView: View {
                             isEffectivelyExpanded: inactiveExpanded
                         )
                         if inactiveExpanded {
-                            // See the identity/`.equatable()` comment on the Active
-                            // ForEach above — same fix applies here.
+                            // See the identity comment on the Active ForEach
+                            // above — same reasoning applies here.
                             ForEach(inactive) { session in
                                 sessionRow(for: session)
                             }
@@ -122,8 +125,8 @@ struct RecentsListView: View {
                             isEffectivelyExpanded: archiveExpanded
                         )
                         if archiveExpanded {
-                            // See the identity/`.equatable()` comment on the Active
-                            // ForEach above — same fix applies here.
+                            // See the identity comment on the Active ForEach
+                            // above — same reasoning applies here.
                             ForEach(archive) { session in
                                 sessionRow(for: session)
                             }
@@ -159,8 +162,6 @@ struct RecentsListView: View {
     // MARK: - Session Row
 
     private func sessionRow(for session: AgentSession) -> some View {
-        // TEMPORARY diagnostic — see SIDEBARDIAG in the boundaries note; to be reverted.
-        sidebarDiagLogger.debug("SIDEBARDIAG construct id=\(session.id.uuidString.prefix(8), privacy: .public) name=\(session.name, privacy: .public)")
         let project = store.projects.first { $0.id == session.projectId }
         let projectName = project?.name ?? "Unknown"
         let indicatorState = store.globalIndicatorStates[session.id] ?? .inactive

--- a/macos/Sources/Features/Ghostties/RecentsRowView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsRowView.swift
@@ -1,11 +1,25 @@
 import SwiftUI
+import os
+
+/// TEMPORARY diagnostic logger — see `SIDEBARDIAG` tag. To be reverted.
+private let sidebarDiagRowLogger = Logger(subsystem: "com.seansmithdesign.ghostties", category: "sidebardiag")
 
 /// A single row in the Sessions recents list.
 ///
 /// Displays a status dot (colored by `SessionIndicatorState`), the session name,
 /// the owning project name in muted text, and a right-aligned relative timestamp.
 /// Tapping focuses the session in the terminal area.
-struct RecentsRowView: View {
+///
+/// `Equatable` (manual, not synthesized — several stored properties are
+/// closures/bindings and can't derive `==`) so the caller can apply
+/// `.equatable()` and gate `body` re-execution on this row's own inputs.
+/// This is the same pattern as `ProjectDisclosureRowContent` (PR #40): it lets
+/// `RecentsListView` key its `ForEach` on the stable `\.id` — required so
+/// hover state and an in-progress inline rename survive `WorkspaceStore`
+/// writes that don't touch this row (e.g. another session's
+/// `lastActiveAt`) — while still refreshing this row's own rendered content
+/// (name, indicator, timestamp) without a full teardown/rebuild.
+struct RecentsRowView: View, Equatable {
     let session: AgentSession
     let projectName: String
     let indicatorState: SessionIndicatorState
@@ -20,7 +34,22 @@ struct RecentsRowView: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
 
+    /// Every field that affects rendered output. Deliberately excludes
+    /// `editingName`/`isRenameFocused`/the closures — those are live
+    /// bindings the `TextField` reads directly, not values `body` needs to
+    /// re-run for.
+    static func == (lhs: RecentsRowView, rhs: RecentsRowView) -> Bool {
+        lhs.session == rhs.session
+            && lhs.projectName == rhs.projectName
+            && lhs.indicatorState == rhs.indicatorState
+            && lhs.isActive == rhs.isActive
+            && lhs.isEditing == rhs.isEditing
+    }
+
     var body: some View {
+        // TEMPORARY diagnostic — see SIDEBARDIAG in the boundaries note; to be reverted.
+        let _ = sidebarDiagRowLogger.debug("SIDEBARDIAG row id=\(String(session.id.uuidString.prefix(8)), privacy: .public) name=\(session.name, privacy: .public)")
+
         HStack(spacing: WorkspaceLayout.sidebarIconLabelSpacing) {
             // Per-session ghost character, tinted by status — same color mapping
             // as MenuBarDropdownView.

--- a/macos/Sources/Features/Ghostties/RecentsRowView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsRowView.swift
@@ -1,8 +1,4 @@
 import SwiftUI
-import os
-
-/// TEMPORARY diagnostic logger — see `SIDEBARDIAG` tag. To be reverted.
-private let sidebarDiagRowLogger = Logger(subsystem: "com.seansmithdesign.ghostties", category: "sidebardiag")
 
 /// A single row in the Sessions recents list.
 ///
@@ -12,13 +8,18 @@ private let sidebarDiagRowLogger = Logger(subsystem: "com.seansmithdesign.ghostt
 ///
 /// `Equatable` (manual, not synthesized — several stored properties are
 /// closures/bindings and can't derive `==`) so the caller can apply
-/// `.equatable()` and gate `body` re-execution on this row's own inputs.
-/// This is the same pattern as `ProjectDisclosureRowContent` (PR #40): it lets
-/// `RecentsListView` key its `ForEach` on the stable `\.id` — required so
-/// hover state and an in-progress inline rename survive `WorkspaceStore`
-/// writes that don't touch this row (e.g. another session's
-/// `lastActiveAt`) — while still refreshing this row's own rendered content
-/// (name, indicator, timestamp) without a full teardown/rebuild.
+/// `.equatable()` and skip re-executing `body` when none of this row's own
+/// inputs changed. This is the same pattern as `ProjectDisclosureRowContent`
+/// (PR #40) and is a body-re-execution **perf gate**, not what makes a row
+/// pick up new values — `RecentsListView` keys its `ForEach` on the stable
+/// `\.id` (required so hover state and an in-progress inline rename survive
+/// `WorkspaceStore` writes that don't touch this row, e.g. another session's
+/// `lastActiveAt`), and freshness on that stable identity comes from the
+/// caller using a non-lazy `VStack` rather than `LazyVStack` — a lazy
+/// container retains a realized row and never re-invokes the `ForEach`
+/// content closure when only the element changes, so `.equatable()` alone
+/// cannot fix a frozen row (there is no new value to compare against).
+/// See the `VStack` comment in `RecentsListView.body`.
 struct RecentsRowView: View, Equatable {
     let session: AgentSession
     let projectName: String
@@ -47,9 +48,6 @@ struct RecentsRowView: View, Equatable {
     }
 
     var body: some View {
-        // TEMPORARY diagnostic — see SIDEBARDIAG in the boundaries note; to be reverted.
-        let _ = sidebarDiagRowLogger.debug("SIDEBARDIAG row id=\(String(session.id.uuidString.prefix(8)), privacy: .public) name=\(session.name, privacy: .public)")
-
         HStack(spacing: WorkspaceLayout.sidebarIconLabelSpacing) {
             // Per-session ghost character, tinted by status — same color mapping
             // as MenuBarDropdownView.


### PR DESCRIPTION
## Summary
- Sessions-tab rows rendered a permanently frozen session name: once a row was constructed, renaming the session (via inline rename or terminal-title sync) never updated the visible text — the row kept showing whatever name it was first built with, for the life of the app.
- Root cause: `RecentsListView`'s row container was a `LazyVStack`. A lazy container realizes each child once and retains it; when a session's fields changed but its `\.id` identity did not, `ForEach`'s content closure was never re-invoked for that row, so the row's `body` kept re-running against the same stale `AgentSession` value forever.
- Confirmed by instrumentation (since removed): with `LazyVStack`, `sessionRow(for:)` (the `ForEach` content closure) fired only at session construction — 6 calls vs. 31 parent `body` passes and 26 row `body` re-runs — and each row id rendered exactly one name for its whole lifetime. Swapping to a plain `VStack` made `sessionRow(for:)` fire on every rename, and all three layers (parent body / construct / row body) agreed.
- Fix: `LazyVStack(spacing: 2)` → `VStack(spacing: 2)` in `RecentsListView.body`. One-word change; `.equatable()` on `RecentsRowView` is unrelated to the bug and is retained as a body-re-execution perf gate, not the freshness mechanism — comments that previously claimed `.equatable()` was what made rows fresh were wrong and have been corrected.

## Known follow-up (not fixed here)
`VStack` renders eagerly. `isArchiveExpanded` defaults to `false`, so the ~37 archive rows are normally absent from the tree — but if a user expands Archive, all of them render eagerly, each carrying a `.contextMenu`. This repo has documented history of sidebar beachballs from per-row `.contextMenu` cost (`project_perf-contextmenu-render-cost.md`), which is a known, unfixed bottleneck independent of this PR. Flagging for a decision on whether it needs a follow-up (e.g. a lazy container that still re-invokes its content closure on element change) rather than fixing here.

## Test plan
- [x] `xcodebuild ... build` — BUILD SUCCEEDED
- [x] `xcodebuild test` — 682/685 pass, 1 skip; the 2 failures are `ThrottleTrailingEdgeHypothesisTests` (pre-existing, untracked investigation file, unrelated to this change)
- [ ] Manual: rename a session via terminal title sync, confirm the sidebar Sessions tab row updates without switching tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
