### PR TITLE
fix(macos): strip status/spinner glyph from persisted sidebar name

### DIFF
--- a/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
+++ b/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
@@ -21,31 +21,33 @@ enum SessionTitleSanitizer {
         "claude", "claude code", "zsh", "bash", "-zsh", "-bash", "sh", "-sh", "fish", "-fish"
     ]
 
-    /// Fixed status/spinner glyphs Claude Code (and similar CLI agents) prefix
-    /// onto a terminal title while working, e.g. `"✳ Claude Code"`. Distinct
-    /// from the Braille Patterns block (below), which covers the *animated*
-    /// spinner frames (`⠐`, `⠄`, `⠁`, …) rather than a fixed marker character.
-    private static let leadingStatusMarkerCharacters: Set<Character> = ["✳", "✻", "✽", "*", "·", "•"]
-
-    /// Braille Patterns block (U+2800–U+28FF) — Claude Code's terminal spinner
-    /// cycles through glyphs in this range as its status animation. Matched
-    /// as a range rather than an enumerated set since the spinner can use any
-    /// of the 256 codepoints in the block.
-    private static let brailleSpinnerRange: ClosedRange<UInt32> = 0x2800...0x28FF
-
-    /// Strips a single leading status/spinner marker — and any whitespace
-    /// immediately following it — from `segment`, if present. This exists
-    /// only so the bare-program-name and directory-name checks below can see
-    /// past a transient marker like `"✳ "` or `"⠐ "`; it must never be used
-    /// to change what's actually persisted as a session name; the full,
-    /// unstripped title is what gets returned when a title is accepted.
+    /// Strips a leading run of status/spinner marker characters — and any
+    /// whitespace immediately following the run — from `segment`, if
+    /// present. Claude Code (and similar CLI agents) prefix a terminal title
+    /// with a marker while working, either a fixed glyph (e.g. `"✳ Claude
+    /// Code"`) or an animated spinner frame cycling through a symbol block
+    /// (e.g. Braille Patterns `"⠐ "`, or circle-fill frames `"◐ "` / `"◑ "`).
+    ///
+    /// Matched structurally rather than by enumerating known glyphs — a
+    /// leading character is stripped when it's Unicode general category `So`
+    /// (Symbol, other) and does NOT default to emoji presentation. This
+    /// covers every observed marker/spinner style without a hardcoded list
+    /// (enumerating glyphs is exactly what made three previous sanitizer
+    /// patches leak on a new spinner style), while a genuine leading emoji
+    /// (`Emoji_Presentation=Yes`, e.g. 🚀) is left untouched since it's part
+    /// of the title, not a status marker.
+    ///
+    /// This result is what `sanitize(title:currentName:projectDirectoryName:)`
+    /// actually returns — the marker is not persisted into the sidebar name.
     private static func strippingLeadingStatusMarker(from segment: Substring) -> Substring {
         var result = segment
-        guard let first = result.first else { return result }
-        let isBrailleSpinnerFrame = first.unicodeScalars.count == 1
-            && brailleSpinnerRange.contains(first.unicodeScalars[first.unicodeScalars.startIndex].value)
-        guard isBrailleSpinnerFrame || leadingStatusMarkerCharacters.contains(first) else { return result }
-        result.removeFirst()
+        while let first = result.first,
+              first.unicodeScalars.count == 1,
+              let scalar = first.unicodeScalars.first {
+            let properties = scalar.properties
+            guard properties.generalCategory == .otherSymbol, !properties.isEmojiPresentation else { break }
+            result.removeFirst()
+        }
         while let next = result.first, next.isWhitespace {
             result.removeFirst()
         }
@@ -77,13 +79,11 @@ enum SessionTitleSanitizer {
         for rawSegment in replaced.split(separator: placeholder, omittingEmptySubsequences: true) {
             let trimmedSegment = rawSegment.trimmingCharacters(in: .whitespaces)
             guard !trimmedSegment.isEmpty else { continue }
-            // Strip a leading status/spinner marker (e.g. "✳ " or "⠐ ") before
-            // judging whether this segment is informative — a marker prefix
-            // on an otherwise-bare program/directory name must not make it
-            // look informative.
-            let segment = String(strippingLeadingStatusMarker(from: Substring(trimmedSegment)))
-            guard !segment.isEmpty else { continue }
-            let segmentLower = segment.lowercased()
+            // `cleaned` already had its leading status/spinner marker (if
+            // any) stripped before this function is called, so only the
+            // first segment could ever have carried one — no per-segment
+            // stripping needed here.
+            let segmentLower = trimmedSegment.lowercased()
             if segmentLower == dirLower { continue }
             if bareProgramNames.contains(segmentLower) { continue }
             return true
@@ -215,8 +215,17 @@ enum SessionTitleSanitizer {
         // Strip bidi overrides and zero-width obfuscation characters before
         // any shape check below sees the string. Re-trim afterward: removing
         // one of these can expose new leading/trailing whitespace.
-        let cleaned = String(trimmed.unicodeScalars.filter { !disallowedCharacters.contains($0) })
+        let withoutDisallowedCharacters = String(trimmed.unicodeScalars.filter { !disallowedCharacters.contains($0) })
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !withoutDisallowedCharacters.isEmpty else { return nil }
+
+        // Strip a leading status/spinner marker (e.g. "✳ ", "⠐ ", "◐ ") so it
+        // is never persisted into the sidebar name — the row already encodes
+        // session state via the colored status dot, and a stored spinner
+        // frame captures one animation instant and then freezes it forever.
+        // Every check below, and the value returned when a title is
+        // accepted, operates on this already-stripped string.
+        let cleaned = String(strippingLeadingStatusMarker(from: Substring(withoutDisallowedCharacters)))
         guard !cleaned.isEmpty else { return nil }
 
         // Explicit reject for the terminal's own "no title yet" placeholder —
@@ -232,14 +241,6 @@ enum SessionTitleSanitizer {
 
         let lowercased = cleaned.lowercased()
         if bareProgramNames.contains(lowercased) { return nil }
-        // Same check, but past a leading status/spinner marker — Claude Code
-        // prefixes its title with a marker like "✳ " or an animated Braille
-        // spinner frame ("⠐ ") that changes every couple of seconds, so
-        // "✳ Claude Code" must be caught here just like "claude code" is
-        // above. Only the check uses the stripped value; the title returned
-        // below (if accepted) is always the untouched `cleaned` string.
-        let markerStrippedLowercased = strippingLeadingStatusMarker(from: Substring(lowercased))
-        if bareProgramNames.contains(String(markerStrippedLowercased)) { return nil }
         // Reject a title ending in a bare "Claude Code" segment regardless of
         // what precedes it — see `endsWithBareClaudeCodeSegment` doc comment.
         if endsWithBareClaudeCodeSegment(cleaned) { return nil }

--- a/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
+++ b/macos/Sources/Features/Ghostties/Models/SessionTitleSanitizer.swift
@@ -21,6 +21,15 @@ enum SessionTitleSanitizer {
         "claude", "claude code", "zsh", "bash", "-zsh", "-bash", "sh", "-sh", "fish", "-fish"
     ]
 
+    /// Legacy marker characters that predate the structural rule below and
+    /// don't fall under it: `*`, `·`, `•` are Unicode general category `Po`
+    /// (punctuation), not `So` (symbol), so the structural check alone
+    /// wouldn't catch them. Kept as an explicit union rather than folded
+    /// into the structural rule because they're a real, live-observed shape
+    /// — `· Current Apps` was captured verbatim (byte `c2 b7`) from a
+    /// running Claude Code session — not a hypothesis about title format.
+    private static let legacyMarkerCharacters: Set<Character> = ["*", "·", "•"]
+
     /// Strips a leading run of status/spinner marker characters — and any
     /// whitespace immediately following the run — from `segment`, if
     /// present. Claude Code (and similar CLI agents) prefix a terminal title
@@ -28,22 +37,29 @@ enum SessionTitleSanitizer {
     /// Code"`) or an animated spinner frame cycling through a symbol block
     /// (e.g. Braille Patterns `"⠐ "`, or circle-fill frames `"◐ "` / `"◑ "`).
     ///
-    /// Matched structurally rather than by enumerating known glyphs — a
-    /// leading character is stripped when it's Unicode general category `So`
-    /// (Symbol, other) and does NOT default to emoji presentation. This
-    /// covers every observed marker/spinner style without a hardcoded list
-    /// (enumerating glyphs is exactly what made three previous sanitizer
-    /// patches leak on a new spinner style), while a genuine leading emoji
-    /// (`Emoji_Presentation=Yes`, e.g. 🚀) is left untouched since it's part
-    /// of the title, not a status marker.
+    /// Matched structurally where possible rather than by enumerating known
+    /// glyphs — a leading character is stripped when it's Unicode general
+    /// category `So` (Symbol, other) and does NOT default to emoji
+    /// presentation. This covers every observed marker/spinner style
+    /// without a hardcoded list (enumerating glyphs is exactly what made
+    /// three previous sanitizer patches leak on a new spinner style), while
+    /// a genuine leading emoji (`Emoji_Presentation=Yes`, e.g. 🚀) is left
+    /// untouched since it's part of the title, not a status marker.
+    ///
+    /// Unioned with `legacyMarkerCharacters` — see that set's doc comment
+    /// for why those three characters need an explicit carve-out instead of
+    /// falling under the structural rule.
     ///
     /// This result is what `sanitize(title:currentName:projectDirectoryName:)`
     /// actually returns — the marker is not persisted into the sidebar name.
     private static func strippingLeadingStatusMarker(from segment: Substring) -> Substring {
         var result = segment
-        while let first = result.first,
-              first.unicodeScalars.count == 1,
-              let scalar = first.unicodeScalars.first {
+        while let first = result.first {
+            if legacyMarkerCharacters.contains(first) {
+                result.removeFirst()
+                continue
+            }
+            guard first.unicodeScalars.count == 1, let scalar = first.unicodeScalars.first else { break }
             let properties = scalar.properties
             guard properties.generalCategory == .otherSymbol, !properties.isEmojiPresentation else { break }
             result.removeFirst()
@@ -79,11 +95,15 @@ enum SessionTitleSanitizer {
         for rawSegment in replaced.split(separator: placeholder, omittingEmptySubsequences: true) {
             let trimmedSegment = rawSegment.trimmingCharacters(in: .whitespaces)
             guard !trimmedSegment.isEmpty else { continue }
-            // `cleaned` already had its leading status/spinner marker (if
-            // any) stripped before this function is called, so only the
-            // first segment could ever have carried one — no per-segment
-            // stripping needed here.
-            let segmentLower = trimmedSegment.lowercased()
+            // Strip a leading status/spinner marker (e.g. "✳ " or "⠐ ")
+            // before judging whether this segment is informative. `cleaned`
+            // only has its OWN leading marker stripped (by the early strip
+            // in `sanitize`) — a marker can still appear at the start of a
+            // later segment, e.g. "repo | ✳ Claude Code", so every segment
+            // needs its own check here.
+            let segment = String(strippingLeadingStatusMarker(from: Substring(trimmedSegment)))
+            guard !segment.isEmpty else { continue }
+            let segmentLower = segment.lowercased()
             if segmentLower == dirLower { continue }
             if bareProgramNames.contains(segmentLower) { continue }
             return true

--- a/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
+++ b/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
@@ -302,13 +302,6 @@ final class SessionTitleSanitizerTests: XCTestCase {
         ))
     }
 
-    func testMiddleDotMarkerPrefixedShellNameRejected() {
-        XCTAssertNil(SessionTitleSanitizer.sanitize(
-            title: "· zsh",
-            currentName: "Session 1"
-        ))
-    }
-
     func testMarkerPrefixedProjectDirectoryNameRejected() {
         XCTAssertNil(SessionTitleSanitizer.sanitize(
             title: "✳ invented-project",
@@ -317,16 +310,54 @@ final class SessionTitleSanitizerTests: XCTestCase {
         ))
     }
 
-    func testMarkerPrefixedInformativeTitleKept() {
+    func testMarkerPrefixedInformativeTitleStripsMarker() {
         // A marker prefix on a real, informative title must not cause a
-        // rejection — and the accepted value stays the FULL sanitized
-        // title, glyph included. Rewriting the stored name to a de-glyphed
-        // version is a separate product decision, not made here.
+        // rejection — and the leading status/spinner marker must be
+        // stripped from the persisted value. The sidebar row already
+        // encodes session state via the colored status dot, so the glyph
+        // is redundant, and a spinner frame captured at one instant should
+        // never be frozen into a stored name.
         let result = SessionTitleSanitizer.sanitize(
             title: "✳ Refactoring the auth module",
             currentName: "Session 1"
         )
-        XCTAssertEqual(result, "✳ Refactoring the auth module")
+        XCTAssertEqual(result, "Refactoring the auth module")
+    }
+
+    func testHalfCircleSpinnerFramePrefixedTitleStripsMarker() {
+        let resultLeftHalf = SessionTitleSanitizer.sanitize(
+            title: "◐ Refactoring the auth module",
+            currentName: "Session 1"
+        )
+        XCTAssertEqual(resultLeftHalf, "Refactoring the auth module")
+
+        let resultRightHalf = SessionTitleSanitizer.sanitize(
+            title: "◑ Refactoring the auth module",
+            currentName: "Session 1"
+        )
+        XCTAssertEqual(resultRightHalf, "Refactoring the auth module")
+    }
+
+    func testHalfCircleSpinnerFramePrefixedClaudeCodeRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "◐ Claude Code",
+            currentName: "Session 1"
+        ))
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "◑ Claude Code",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testLeadingEmojiPreserved() {
+        // A genuine leading emoji is part of the title, not a status
+        // marker, and must be preserved — this is the guard on the
+        // isEmojiPresentation condition in `strippingLeadingStatusMarker`.
+        let result = SessionTitleSanitizer.sanitize(
+            title: "🚀 Deploy the thing",
+            currentName: "Session 1"
+        )
+        XCTAssertEqual(result, "🚀 Deploy the thing")
     }
 
     func testAsteriskNotAtStartOfTitleDoesNotTriggerRejection() {

--- a/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
+++ b/macos/Tests/Ghostties/SessionTitleSanitizerTests.swift
@@ -302,6 +302,27 @@ final class SessionTitleSanitizerTests: XCTestCase {
         ))
     }
 
+    func testMiddleDotMarkerPrefixedShellNameRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "· zsh",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testAsteriskMarkerPrefixedShellNameRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "* zsh",
+            currentName: "Session 1"
+        ))
+    }
+
+    func testBulletMarkerPrefixedShellNameRejected() {
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "• zsh",
+            currentName: "Session 1"
+        ))
+    }
+
     func testMarkerPrefixedProjectDirectoryNameRejected() {
         XCTAssertNil(SessionTitleSanitizer.sanitize(
             title: "✳ invented-project",
@@ -358,6 +379,33 @@ final class SessionTitleSanitizerTests: XCTestCase {
             currentName: "Session 1"
         )
         XCTAssertEqual(result, "🚀 Deploy the thing")
+    }
+
+    func testDirectorySeparatedMarkerPrefixedClaudeCodeRejected() {
+        // The production shape: `SessionCoordinator.performNameSync` always
+        // supplies `projectDirectoryName`, so a marker prefix glued onto
+        // "Claude Code" after a "<dir> | " separator must still be caught —
+        // the marker doesn't only ever appear at the very start of the raw
+        // title.
+        XCTAssertNil(SessionTitleSanitizer.sanitize(
+            title: "repo | ✳ Claude Code",
+            currentName: "Session 1",
+            projectDirectoryName: "repo"
+        ))
+    }
+
+    func testMigrationPathStripsMarkerFromAlreadyStoredName() {
+        // Existing stored names in workspace.json carry the glyph (from
+        // before this fix). The next terminal-title sync for that same
+        // session re-runs the raw title through `sanitize`, so the glyph
+        // must be stripped from the persisted name even though
+        // `currentName` also still carries it — this is how already-stored
+        // names self-heal without any migration step.
+        let result = SessionTitleSanitizer.sanitize(
+            title: "✳ Child Session",
+            currentName: "✳ Child Session"
+        )
+        XCTAssertEqual(result, "Child Session")
     }
 
     func testAsteriskNotAtStartOfTitleDoesNotTriggerRejection() {


### PR DESCRIPTION
## Summary
- `SessionTitleSanitizer.sanitize` now returns the leading Claude Code status/spinner marker stripped, instead of persisting it into the sidebar name.
- Marker matching is structural (Unicode general category `So`, not emoji-presentation) for the primary rule, unioned with a small legacy set (`*`, `·`, `•`) for markers that are punctuation, not symbols, by Unicode category — this covers all observed shapes (`✳`, `✻`, `✽`, `⠐`, `◐`, `◑`, `·`) plus future spinner styles, and preserves a genuine leading emoji.
- The strip runs once, immediately after control-character/bidi cleanup, so every reject check and the returned value operate on the same already-stripped string. The per-segment strip inside `hasInformativeSegment` is still needed and stays — a marker can appear at the start of a later segment too (e.g. `"repo | ✳ Claude Code"`, the actual production shape since `SessionCoordinator.performNameSync` always supplies `projectDirectoryName`).

## Why
`workspace.json` had 72/416 stored session names carrying a leading glyph (63 `✳`, 6 `⠐`, 2 `◑`, 1 `◐`). The sidebar row already shows session state via the colored status dot, so the glyph in the name is redundant — and for the two animated spinner glyphs, the stored name froze one animation frame into the persisted name forever.

## Accepted trade-off
Adopting a structural (Unicode-category) rule instead of enumerating glyphs means leading non-marker text-presentation symbols (`☀ ⚠ ★ ✓ ♥ © ™ °`) are now stripped from persisted names too, while emoji-presentation characters (`⚡`, `🚀`) are preserved. This is a deliberate trade against re-enumerating glyphs — better surfaced here than discovered later.

## Known pre-existing gap (not touched here)
`endsWithBareClaudeCodeSegment` has the same multi-segment blind spot when `projectDirectoryName` is `nil` — e.g. `"repo | ✳ Claude Code"` with no project directory is accepted on `origin/main` too. Pre-existing, out of scope for this PR.

## Test plan
- [x] `xcodebuild build` — succeeded
- [x] `xcodebuild test` unfiltered — 685 total / 682 passed / 2 failed / 1 skipped. Both failures are pre-existing, unrelated to this change (`ThrottleTrailingEdgeHypothesisTests`, an untracked file in the worktree with intentionally-failing hypothesis tests).
- [x] All 50 `SessionTitleSanitizerTests` pass by name, including `testMiddleDotMarkerPrefixedShellNameRejected`, `testAsteriskMarkerPrefixedShellNameRejected`, `testBulletMarkerPrefixedShellNameRejected`, `testDirectorySeparatedMarkerPrefixedClaudeCodeRejected` (the `"repo | ✳ Claude Code"` production shape), `testMigrationPathStripsMarkerFromAlreadyStoredName`, the inverted `testMarkerPrefixedInformativeTitleStripsMarker`, `testHalfCircleSpinnerFramePrefixedTitleStripsMarker`/`testHalfCircleSpinnerFramePrefixedClaudeCodeRejected` (◐/◑), and `testLeadingEmojiPreserved` (🚀 guard).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wx51S2SaNHRCMcSguafXtK
