### PR TITLE
feat(macos): dev build-info badge, bottom-left, click to copy

### DIFF
--- a/macos/Sources/Features/Ghostties/BuildInfoBadgeView.swift
+++ b/macos/Sources/Features/Ghostties/BuildInfoBadgeView.swift
@@ -1,0 +1,147 @@
+import AppKit
+import Darwin
+import SwiftUI
+
+/// `@AppStorage` key gating the dev build-info badge. Default ON in Debug
+/// builds, OFF in Release. Toggle manually with:
+///
+///   defaults write com.seansmithdesign.ghostties.dev ghostties.devBuildInfoBadge.enabled -bool true
+///   defaults write com.seansmithdesign.ghostties.dev ghostties.devBuildInfoBadge.enabled -bool false
+///   defaults write com.seansmithdesign.ghostties ghostties.devBuildInfoBadge.enabled -bool true
+///   defaults write com.seansmithdesign.ghostties ghostties.devBuildInfoBadge.enabled -bool false
+private let buildInfoBadgeStorageKey = "ghostties.devBuildInfoBadge.enabled"
+
+#if DEBUG
+    private let buildInfoBadgeDefaultEnabled = true
+#else
+    private let buildInfoBadgeDefaultEnabled = false
+#endif
+
+/// One-time snapshot of build and launch facts, resolved at runtime from the
+/// bundle and the process table — no baked-in git SHA, no Xcode build phase.
+/// See `reference_stale-dev-instance-serves-old-code.md`: a running instance
+/// keeps serving the binary it launched with, so "is this the latest build"
+/// requires comparing binary mtime against process launch time.
+struct BuildInfoSnapshot {
+    let shortVersion: String
+    let buildNumber: String
+    let bundleIdentifier: String
+    let buildDate: Date?
+    let launchDate: Date
+
+    /// Resolved once per process.
+    static let current: BuildInfoSnapshot = {
+        let bundle = Bundle.main
+        let shortVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let buildNumber = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let bundleIdentifier = bundle.bundleIdentifier ?? "?"
+
+        var buildDate: Date?
+        if let execURL = bundle.executableURL,
+            let attrs = try? FileManager.default.attributesOfItem(atPath: execURL.path),
+            let modDate = attrs[.modificationDate] as? Date
+        {
+            buildDate = modDate
+        }
+
+        return BuildInfoSnapshot(
+            shortVersion: shortVersion,
+            buildNumber: buildNumber,
+            bundleIdentifier: bundleIdentifier,
+            buildDate: buildDate,
+            launchDate: BuildInfoSnapshot.currentProcessStartDate()
+        )
+    }()
+
+    /// Exact process launch time via `sysctl(KERN_PROC_PID)` — the same value
+    /// `ps -o lstart` reports. Falls back to "now" if the sysctl call fails.
+    private static func currentProcessStartDate() -> Date {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        let result = sysctl(&mib, u_int(mib.count), &info, &size, nil, 0)
+        guard result == 0 else { return Date() }
+        let ts = info.kp_proc.p_starttime
+        let seconds = TimeInterval(ts.tv_sec) + TimeInterval(ts.tv_usec) / 1_000_000
+        return Date(timeIntervalSince1970: seconds)
+    }
+
+    private static let shortTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    private static let fullTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.unitsStyle = .abbreviated
+        formatter.maximumUnitCount = 2
+        return formatter
+    }()
+
+    /// Glanceable one-liner for the always-visible label.
+    var shortLabel: String {
+        let builtText = buildDate.map { Self.shortTimeFormatter.string(from: $0) } ?? "?"
+        let upText = Self.durationFormatter.string(from: launchDate, to: Date()) ?? "0m"
+        return "\(shortVersion) (\(buildNumber)) · built \(builtText) · up \(upText)"
+    }
+
+    /// Full multi-line detail copied to the pasteboard on click.
+    var fullDetail: String {
+        let builtText = buildDate.map { Self.fullTimeFormatter.string(from: $0) } ?? "unknown"
+        let launchText = Self.fullTimeFormatter.string(from: launchDate)
+        let upText = Self.durationFormatter.string(from: launchDate, to: Date()) ?? "0m"
+        return """
+            Ghostties build info
+            Version: \(shortVersion) (\(buildNumber))
+            Bundle: \(bundleIdentifier)
+            Built: \(builtText)
+            Launched: \(launchText) (running \(upText))
+            """
+    }
+}
+
+/// Tiny diagnostic label pinned to the bottom-left corner of the window.
+/// Answers "is this the latest build, and when did this instance start" at a
+/// glance; click copies the full detail to the pasteboard. Sizes itself to
+/// its content (`.fixedSize()`) so it never intercepts clicks outside its
+/// own bounds — it must not swallow terminal clicks.
+struct BuildInfoBadgeView: View {
+    @AppStorage(buildInfoBadgeStorageKey) private var isEnabled: Bool = buildInfoBadgeDefaultEnabled
+    @State private var justCopied = false
+
+    private let info = BuildInfoSnapshot.current
+
+    var body: some View {
+        if isEnabled {
+            Text(justCopied ? "Copied build info" : info.shortLabel)
+                .font(.system(size: 9))
+                .foregroundColor(Color(nsColor: .tertiaryLabelColor))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+                .contentShape(Rectangle())
+                .onTapGesture(perform: copyToPasteboard)
+                .help(info.fullDetail)
+                .fixedSize()
+        }
+    }
+
+    private func copyToPasteboard() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(info.fullDetail, forType: .string)
+
+        justCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            justCopied = false
+        }
+    }
+}

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -159,6 +159,15 @@ class WorkspaceViewContainer: NSView {
     /// The browser panel content (navigation bar + content area placeholder).
     private let browserPanelView = BrowserPanelView()
 
+    /// Diagnostic build/launch info badge — bottom-left corner of the window,
+    /// click-to-copy. `@AppStorage`-gated; sizes itself to its content so it
+    /// never intercepts clicks outside its own bounds. See `BuildInfoBadgeView.swift`.
+    private let buildInfoBadgeHostingView: NSHostingView<BuildInfoBadgeView> = {
+        let view = NSHostingView(rootView: BuildInfoBadgeView())
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     /// Sidebar material backing for overlay mode. In pinned mode the shared
     /// `backgroundEffectView` already covers the sidebar area, so this is hidden.
     /// In overlay mode it provides the .sidebar material behind the hosting view
@@ -1313,7 +1322,7 @@ class WorkspaceViewContainer: NSView {
         // Canvas layer — the warm background visible behind the floating card.
         wantsLayer = true
 
-        // Z-order: background material → overlay background → sidebar → sidebar drag handle → terminal → browser drag handle → browser.
+        // Z-order: background material → overlay background → sidebar → sidebar drag handle → terminal → browser drag handle → browser → build-info badge (topmost).
         addSubview(backgroundEffectView)
         addSubview(sidebarOverlayBackground)
         addSubview(sidebarHostingView)
@@ -1321,6 +1330,7 @@ class WorkspaceViewContainer: NSView {
         addSubview(terminalShadowHost)
         addSubview(browserDragHandle)
         addSubview(browserShadowHost)
+        addSubview(buildInfoBadgeHostingView)
 
         sidebarHostingView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -1477,6 +1487,12 @@ class WorkspaceViewContainer: NSView {
             sidebarDragHandle.bottomAnchor.constraint(equalTo: sidebarHostingView.bottomAnchor),
             sidebarDragHandle.leadingAnchor.constraint(equalTo: sidebarHostingView.trailingAnchor),
             sidebarDragHandle.trailingAnchor.constraint(equalTo: terminalShadowHost.leadingAnchor),
+
+            // Build-info badge: bottom-left corner of the whole window, on top
+            // of sidebar and terminal alike. Unconstrained width/height — the
+            // hosting view sizes to its SwiftUI content (`.fixedSize()`).
+            buildInfoBadgeHostingView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            buildInfoBadgeHostingView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
         ])
 
         // Terminal floating card: top corners rounded when in card mode (pinned/closed).


### PR DESCRIPTION
## Summary
- Adds a small diagnostic label pinned to the bottom-left corner of the window that answers "is this the latest build, and when did this instance start" — short version + build number, the main-bundle executable's file mtime as build time, and the process's exact launch time (via `sysctl(KERN_PROC_PID)`, the same value `ps -o lstart` reports).
- Click copies the full multi-line detail (version, bundle ID, build time, launch time, uptime) to the pasteboard; the label briefly reads "Copied build info" as confirmation.
- `@AppStorage`-gated (`ghostties.devBuildInfoBadge.enabled`) — default ON in Debug builds, OFF in Release.
- No Xcode build-phase change, no baked-in git SHA — everything is resolved at runtime from `Bundle.main` and the process table, so this doesn't touch the `.xcodeproj` and won't churn across branches.
- The hosting view sizes to its SwiftUI content only (`.fixedSize()`), so it never intercepts clicks outside its own tiny footprint — it sits over a terminal and must not swallow clicks.

## Toggle (defaults write)
```
# Dev build
defaults write com.seansmithdesign.ghostties.dev ghostties.devBuildInfoBadge.enabled -bool true
defaults write com.seansmithdesign.ghostties.dev ghostties.devBuildInfoBadge.enabled -bool false

# Release build
defaults write com.seansmithdesign.ghostties ghostties.devBuildInfoBadge.enabled -bool true
defaults write com.seansmithdesign.ghostties ghostties.devBuildInfoBadge.enabled -bool false
```

## Test plan
- [x] `xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Debug -derivedDataPath macos/build ONLY_ACTIVE_ARCH=YES ARCHS=arm64 build` — BUILD SUCCEEDED
- [x] `xcodebuild test ... -only-testing:GhosttyTests` — 682 passed / 2 failed / 1 skipped (685 total). Both failures are pre-existing noise in `ThrottleTrailingEdgeHypothesisTests` (unrelated to this change, by design per that file).
- [ ] Screenshot of the running Dev app — **not captured**: Screen Recording permission isn't granted to this session (`screencapture` returned "could not create image from display"). Verified instead via `ps -o pid,lstart` against the binary mtime that the launched Dev instance is on the fresh build, and via `defaults read` that the flag correctly defaults ON in Debug with no explicit key set.