### PR TITLE
fix(ci): staple app before packaging DMG, not after

### DIFF
--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -347,6 +347,45 @@ jobs:
             ./
           mv ./Ghostties*.dmg ./Ghostties.dmg
 
+      # create-dmg signs the DMG itself with a separate code signature/CDHash
+      # from the app inside it, so the app's notarization ticket (stapled
+      # above) does not cover the DMG. Without this second round trip, a
+      # direct DMG download needs an online Gatekeeper check just to mount —
+      # the same class of bug this PR set out to fix, just moved to a
+      # different artifact. The app packaged inside is already stapled at
+      # this point, so this covers the "double-click the DMG" install path
+      # on top of the "copy the app out" path handled above.
+      - name: Notarize DMG
+        env:
+          APPLE_NOTARIZATION_ISSUER: ${{ secrets.APPLE_NOTARIZATION_ISSUER }}
+          APPLE_NOTARIZATION_KEY_ID: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
+          APPLE_NOTARIZATION_KEY: ${{ secrets.APPLE_NOTARIZATION_KEY }}
+        run: |
+          # Credentials were already stored under this profile name by the
+          # "Notarize app" step above; reuse it.
+          set -o pipefail
+          xcrun notarytool submit "Ghostties.dmg" \
+            --keychain-profile "notarytool-profile" \
+            --wait | tee notarytool-submit-dmg.log
+          NOTARIZE_EXIT=${PIPESTATUS[0]}
+
+          # Always fetch the detailed log — Apple's per-file rejection reasons
+          # only appear via `notarytool log`, never in the submit output.
+          SUBMISSION_ID=$(grep -m1 "id:" notarytool-submit-dmg.log | head -1 | awk '{print $2}')
+          if [ -n "$SUBMISSION_ID" ]; then
+            echo "::group::DMG notarization detailed log (submission $SUBMISSION_ID)"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --keychain-profile "notarytool-profile" || true
+            echo "::endgroup::"
+          fi
+
+          if [ "$NOTARIZE_EXIT" != "0" ]; then
+            echo "::error::DMG notarization failed (exit $NOTARIZE_EXIT). See log above."
+            exit "$NOTARIZE_EXIT"
+          fi
+
+          xcrun stapler staple "Ghostties.dmg"
+
       - name: Zip app
         run: |
           cd macos/build/Release

--- a/.github/workflows/ghostties-release.yml
+++ b/.github/workflows/ghostties-release.yml
@@ -280,18 +280,20 @@ jobs:
           /usr/bin/codesign --verbose -f -s "$MACOS_CERTIFICATE_NAME" -o runtime \
             --entitlements "macos/Ghostties.entitlements" "$APP"
 
-      - name: Create DMG
-        env:
-          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+      # Notarization must run — and staple succeed — on the app bundle BEFORE
+      # it gets packaged into the DMG or the release zip, otherwise whichever
+      # artifact is built first ships an unstapled app (see BACKLOG.md history:
+      # create-dmg used to run before stapling, so the DMG's copy of the app
+      # never received the notarization ticket while the zip's copy did).
+      - name: Zip app for notarization submission
         run: |
-          npm install --global create-dmg@8.1.0
-          create-dmg \
-            --identity="$MACOS_CERTIFICATE_NAME" \
-            ./macos/build/Release/Ghostties.app \
-            ./
-          mv ./Ghostties*.dmg ./Ghostties.dmg
+          cd macos/build/Release
+          # ditto (not zip) preserves the code signature exactly as notarytool
+          # expects for submission. This zip is a transient submission vehicle
+          # only — the release zip is built fresh from the stapled app below.
+          ditto -c -k --keepParent Ghostties.app ../../../notarization-submission.zip
 
-      - name: Notarize DMG
+      - name: Notarize app
         env:
           APPLE_NOTARIZATION_ISSUER: ${{ secrets.APPLE_NOTARIZATION_ISSUER }}
           APPLE_NOTARIZATION_KEY_ID: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
@@ -309,7 +311,7 @@ jobs:
           # Capture submission ID so we can fetch the detailed log if it fails.
           # --wait exits non-zero on Invalid, so we tee output and parse the ID.
           set -o pipefail
-          xcrun notarytool submit "Ghostties.dmg" \
+          xcrun notarytool submit "notarization-submission.zip" \
             --keychain-profile "notarytool-profile" \
             --wait | tee notarytool-submit.log
           NOTARIZE_EXIT=${PIPESTATUS[0]}
@@ -329,9 +331,21 @@ jobs:
             exit "$NOTARIZE_EXIT"
           fi
 
-          # Staple the ticket so Gatekeeper validates the app offline
-          xcrun stapler staple "Ghostties.dmg"
+          # Staple the ticket so Gatekeeper validates the app offline. This
+          # must happen before Create DMG and Zip app below, so both
+          # packaged artifacts ship the stapled app, not just one of them.
           xcrun stapler staple "macos/build/Release/Ghostties.app"
+
+      - name: Create DMG
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        run: |
+          npm install --global create-dmg@8.1.0
+          create-dmg \
+            --identity="$MACOS_CERTIFICATE_NAME" \
+            ./macos/build/Release/Ghostties.app \
+            ./
+          mv ./Ghostties*.dmg ./Ghostties.dmg
 
       - name: Zip app
         run: |


### PR DESCRIPTION
## Summary

`create-dmg` ran before `xcrun stapler staple`, so `Ghostties.dmg` packaged the pre-staple app while `ghostties-macos-arm64.zip` (zipped after staple) got the notarization ticket. A Homebrew cask install — which copies the app out of the DMG — needed an online Gatekeeper check on first launch as a result, and failed that check offline or on a restrictive network.

## Fix

`.github/workflows/ghostties-release.yml`, `build-macos` job. Two artifacts need two separate notarization tickets, because `create-dmg` signs the DMG with its own code signature/CDHash, distinct from the app's — stapling the app does not cover the DMG.

1. Zip the signed app (`ditto`) into a transient `notarization-submission.zip` — notarytool can't take a raw `.app`.
2. Submit that zip, wait, staple the on-disk app bundle.
3. Create the DMG — packages the now-**stapled** app.
4. Submit the built `Ghostties.dmg` itself, wait, staple the DMG.
5. Zip the app (release artifact) — already stapled from step 2.

Both the app-inside-DMG and the DMG container itself now carry valid tickets, so both the "copy the app out of the DMG" (Homebrew cask) and "double-click the DMG to mount" (direct download) install paths work fully offline.

### Before

1. Create DMG (packages the **unstapled** app)
2. Notarize DMG (submit `Ghostties.dmg`, wait, staple `Ghostties.dmg`, staple the on-disk app)
3. Zip app (packages the now-stapled on-disk app)

### After

1. Zip app for notarization submission (`notarization-submission.zip`)
2. Notarize app (submit the zip, wait, staple the on-disk app)
3. Create DMG (packages the **stapled** app)
4. Notarize DMG (submit `Ghostties.dmg`, wait, staple `Ghostties.dmg`)
5. Zip app (packages the stapled app — release artifact)

Line numbers in the final file:
- App staple (`xcrun stapler staple "macos/build/Release/Ghostties.app"`) — line 337, after the app notarization wait (lines 312–315).
- Create DMG — line 339 (after the app staple).
- DMG notarization submit + wait — lines 358–370.
- DMG staple (`xcrun stapler staple "Ghostties.dmg"`) — line 387, after the DMG notarization wait.
- Zip app (release artifact) — line 389, after both staples.
- Upload artifacts — line 394, lists exactly `Ghostties.dmg` and `ghostties-macos-arm64.zip` (verified neither the transient `notarization-submission.zip` nor either `notarytool-submit*.log` is uploaded).

## YAML validation

```
$ python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ghostties-release.yml')); print('YAML OK')"
YAML OK
```

## Cost / trade-off

This adds a second `notarytool submit --wait` round trip to every release — releases will take longer by roughly one notarization wait (Apple's notarization typically takes a few minutes, occasionally longer). That's the correct trade: it's the only way to get both artifacts a valid, offline-checkable ticket, since they have distinct code signatures.

## Risk

The two notarization submissions reuse the same `notarytool-profile` keychain credential (stored once, in the app-notarization step) and the same `--wait` + tee-to-log + fetch-detailed-log-on-failure pattern, with a distinct log filename (`notarytool-submit-dmg.log`) so the DMG submission's log doesn't clobber the app submission's. A DMG notarization failure now fails the job exactly as loudly as an app notarization failure does.

**This has not been verified end-to-end — that requires cutting a real release**, which is out of scope for this PR (CI-workflow change only, no releases triggered). Recommend a `workflow_dispatch` dry run before the next real tag, then installing from the resulting DMG both via direct mount and via a Homebrew cask install, confirming `stapler validate` succeeds and no `com.apple.quarantine` friction on either path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSN1pyhdLgpxt4n9Lrzm7x