### PR TITLE
fix(macos): guard shadow-path rebuild against zero-size bounds

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -631,18 +631,31 @@ class WorkspaceViewContainer: NSView {
         // Explicit shadow paths eliminate per-frame offscreen rendering.
         // Without these, Core Animation rasterizes the entire layer to compute
         // the shadow shape every frame — expensive for a terminal that redraws at 60fps.
-        terminalShadowHost.layer?.shadowPath = CGPath(
-            roundedRect: terminalShadowHost.bounds,
-            cornerWidth: WorkspaceLayout.terminalCornerRadius,
-            cornerHeight: WorkspaceLayout.terminalCornerRadius,
-            transform: nil
-        )
-        browserShadowHost.layer?.shadowPath = CGPath(
-            roundedRect: browserShadowHost.bounds,
-            cornerWidth: WorkspaceLayout.terminalCornerRadius,
-            cornerHeight: WorkspaceLayout.terminalCornerRadius,
-            transform: nil
-        )
+        //
+        // `bounds.isEmpty` guard: mirrors the resize reclamp's `bounds.width > 0`
+        // guard above — during animated constraint changes (mode transitions,
+        // teardown, fullscreen intermediates) a shadow host's bounds can
+        // transiently be zero-size. Once an explicit shadowPath is set, Core
+        // Animation uses it exclusively; installing a zero-rect path renders no
+        // shadow at all, silently, until a later layout pass rebuilds it from
+        // settled bounds. Skipping leaves the previously-installed path in
+        // place, which is strictly better than a dead one.
+        if !terminalShadowHost.bounds.isEmpty {
+            terminalShadowHost.layer?.shadowPath = CGPath(
+                roundedRect: terminalShadowHost.bounds,
+                cornerWidth: WorkspaceLayout.terminalCornerRadius,
+                cornerHeight: WorkspaceLayout.terminalCornerRadius,
+                transform: nil
+            )
+        }
+        if !browserShadowHost.bounds.isEmpty {
+            browserShadowHost.layer?.shadowPath = CGPath(
+                roundedRect: browserShadowHost.bounds,
+                cornerWidth: WorkspaceLayout.terminalCornerRadius,
+                cornerHeight: WorkspaceLayout.terminalCornerRadius,
+                transform: nil
+            )
+        }
         sidebarOverlayBackground.layer?.shadowPath = CGPath(
             rect: sidebarOverlayBackground.bounds,
             transform: nil


### PR DESCRIPTION
## What

`layout()` in `WorkspaceViewContainer.swift` rebuilds `terminalShadowHost`/`browserShadowHost`'s `shadowPath` from bounds with no validity guard — unlike the resize reclamp ~20 lines above in the same function, which already guards on `bounds.width > 0`. Once an explicit `shadowPath` is set, Core Animation uses it exclusively; a zero-rect path silently renders no shadow at all. This PR mirrors the existing guard pattern: skip the rebuild when a shadow host's own bounds is empty, leaving the previously-installed path in place (still visible) instead of installing a dead one.

Applied the same guard to `browserShadowHost` since it has the identical unguarded pattern in the same `layout()` call.

## Honest status — unverified

This is **not verified against a live repro**. The trigger for the disappearing terminal-canvas shadow (see `project_canvas-shadow-disappears-during-use` in project memory) was never reproduced — only diagnosed from code inspection. This fix may be a no-op if the real cause lies elsewhere. Shipping in beta.23 so it can be tested against a real build and the shadow-disappears symptom can be watched for recurrence.

## Findings from the investigation

- **Does the animation completion handler reliably trigger a final layout?** Yes. Both places that set `isSidebarTransitionAnimating = true` (`sidebarViewModeChanged()` and `transitionTo()`) have a `completionHandler` that sets `self?.needsLayout = true` after clearing the flag. So if bounds happen to be transiently invalid mid-transition, a settled-bounds layout pass is guaranteed once the transition completes — independent of this fix.
- Because of that, this fix does **not** guard on `isSidebarTransitionAnimating`, only on the shadow host's own `bounds.isEmpty`. The zero-size case this fix targets can happen on any `layout()` call (teardown, tab merge, fullscreen intermediates), not just during an animated sidebar transition, and any later `layout()` call — animated or not — will naturally reinstall a correct path once bounds are non-zero again.

## What I could not verify

- No repro of the actual bug, before or after this change.
- No build — this worktree lacks `GhosttyKit.xcframework`/`zig-out`/`vendor/cef*` (gitignored build inputs), so I could not compile locally. Relying on CI (`build-for-testing`) for compile verification only; CI green does not mean this fixes the symptom.
- No runtime/visual verification (screen capture is broken in this environment; synthetic input is forbidden in this project).

## Diff

```swift
        // Explicit shadow paths eliminate per-frame offscreen rendering.
        // Without these, Core Animation rasterizes the entire layer to compute
        // the shadow shape every frame — expensive for a terminal that redraws at 60fps.
        //
        // `bounds.isEmpty` guard: mirrors the resize reclamp's `bounds.width > 0`
        // guard above — during animated constraint changes (mode transitions,
        // teardown, fullscreen intermediates) a shadow host's bounds can
        // transiently be zero-size. Once an explicit shadowPath is set, Core
        // Animation uses it exclusively; installing a zero-rect path renders no
        // shadow at all, silently, until a later layout pass rebuilds it from
        // settled bounds. Skipping leaves the previously-installed path in
        // place, which is strictly better than a dead one.
        if !terminalShadowHost.bounds.isEmpty {
            terminalShadowHost.layer?.shadowPath = CGPath(
                roundedRect: terminalShadowHost.bounds,
                cornerWidth: WorkspaceLayout.terminalCornerRadius,
                cornerHeight: WorkspaceLayout.terminalCornerRadius,
                transform: nil
            )
        }
        if !browserShadowHost.bounds.isEmpty {
            browserShadowHost.layer?.shadowPath = CGPath(
                roundedRect: browserShadowHost.bounds,
                cornerWidth: WorkspaceLayout.terminalCornerRadius,
                cornerHeight: WorkspaceLayout.terminalCornerRadius,
                transform: nil
            )
        }
```

## Test plan

- [ ] CI compiles clean (`build-for-testing`)
- [ ] Sean runs a Dev build for a while, watches for the shadow to disappear again
- [ ] If it recurs, capture what state the app was in right before (fullscreen, sidebar drag, overlay hover, etc.) to narrow the trigger further

🤖 Generated with Claude Code