### PR TITLE
fix(macos): wire DESIGN.md textSecondary for sidebar low-emphasis text

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,23 @@ Parked items that survive context resets. Prune at `/wrap`.
 
 > Reconciled 2026-07-29: the tracked `main` copy (07-17→07-22) and the untracked working-tree copy (07-26→07-28) had diverged. This file is the union. Only closed items were dropped (PR #48 merged as `3d2cefc57`).
 
+## 2026-08-18 — PR #128 sidebar contrast follow-ups (deferred, not dropped)
+
+`textSecondary` shipped in #128 (`tertiaryLabelColor` → fixed `#636363`/`#9a9a9a` hex for
+low-emphasis sidebar text). Two items surfaced during round-two review, deliberately out of scope
+for that PR — neither blocks merge.
+
+- [ ] **`Color.secondary` is now the worst text in the sidebar.** Independently verified at
+  3.85:1 against chrome — below the 4.5:1 tier #128 just fixed for `tertiaryLabelColor`. Visible
+  side-by-side at `ArchiveZoneView.swift:98-106` (the "Done" lane label reads lighter than the
+  count beside it) and `NeedsYouZoneView.swift:89-91`. #128 didn't cause this, but fixing the
+  tertiary tier made the secondary tier the new visible outlier. | design | new
+- [ ] **Fixed hex text tokens drop Increase Contrast support.** `NSColor.tertiaryLabelColor`
+  ships system high-contrast appearance variants; a literal `Color(red:green:blue:)` (the fix
+  #128 applied) does not respond to `NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast`.
+  Affects exactly the low-vision users #128 targets. Possible follow-up: branch `textSecondary`
+  on that accessibility flag and return a still-higher-contrast value when set. | design | new
+
 ## 2026-08-18 — PR #126 lastOutputAt follow-ups (deferred, not dropped)
 
 `lastOutputAt` (splitting Sessions-row/Archive recency from focus-driven project bucketing) shipped

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,7 +7,7 @@ colors:
   chromeBackground: "#F0E9E6"
   canvasBackground: "#FAF7F3"
   textPrimary: "#1a1a1a"
-  textSecondary: "#6b6b6b"
+  textSecondary: "#636363"
   accent: "#C97350"
   border: "#e5e5e3"
   destructive: "#dc3545"
@@ -93,7 +93,7 @@ The sidebar itself is `.background(.clear)` in both modes — chrome reads throu
 | **Chrome background** | `#F0E9E6` | `#242424` | `chromeBackgroundLight/Dark` |
 | **Canvas background** | `#FAF7F3` | `#2D2D2D` | `canvasBackgroundLight/Dark` |
 | **Text Primary**      | `#1a1a1a` | `#f0efed` | `textPrimary`                |
-| **Text Secondary**    | `#6b6b6b` | `#9a9a9a` | `textSecondary`              |
+| **Text Secondary**    | `#636363` | `#9a9a9a` | `textSecondary`              |
 | **Accent (waiting)**  | `#C97350` | `#C97350` | `waitingTerracotta`          |
 | **Border**            | `#e5e5e3` | `#2a2a2a` | `border`                     |
 | **Destructive**       | `#dc3545` | `#dc3545` | `destructive`                |

--- a/macos/Sources/Features/Ghostties/ActiveZoneView.swift
+++ b/macos/Sources/Features/Ghostties/ActiveZoneView.swift
@@ -23,6 +23,8 @@ struct ActiveZoneView: View {
     /// body call (which previously fired on every user interaction across the sidebar).
     @State private var cachedMergedRows: [ActiveRow] = []
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         let rows = cachedMergedRows
         return VStack(alignment: .leading, spacing: 0) {
@@ -132,17 +134,17 @@ struct ActiveZoneView: View {
             Text("Active".uppercased())
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.8)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Text("· \(rowCount) of ~\(taskStore.machineCap)")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Spacer(minLength: 0)
 
             Text("machine ok")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
         }
         .padding(.horizontal, TaskRowMetrics.horizontalPadding)
         .padding(.vertical, 6)

--- a/macos/Sources/Features/Ghostties/ArchiveZoneView.swift
+++ b/macos/Sources/Features/Ghostties/ArchiveZoneView.swift
@@ -20,6 +20,7 @@ struct GraveyardZoneView: View {
 
     /// Reduced-motion preference for D18 / D19 animation grammar.
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
     /// True when the Done lane is empty. Drives a single muted
     /// "nothing here yet" line so the zone doesn't read as broken.
@@ -62,7 +63,7 @@ struct GraveyardZoneView: View {
             Text("Graveyard".uppercased())
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.8)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Spacer(minLength: 0)
         }
@@ -102,7 +103,7 @@ struct GraveyardZoneView: View {
 
                     Text("\(tasks.count)")
                         .font(.system(size: 10.5, design: .monospaced))
-                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                        .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 }
                 .padding(.horizontal, TaskRowMetrics.horizontalPadding)
                 .frame(height: 32)

--- a/macos/Sources/Features/Ghostties/BacklogZoneView.swift
+++ b/macos/Sources/Features/Ghostties/BacklogZoneView.swift
@@ -19,6 +19,8 @@ struct BacklogZoneView: View {
         taskStore.backlog
     }
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
@@ -52,11 +54,11 @@ struct BacklogZoneView: View {
             Text("Backlog".uppercased())
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.8)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Text("· \(rows.count)")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Spacer(minLength: 0)
         }

--- a/macos/Sources/Features/Ghostties/BuildInfoBadgeView.swift
+++ b/macos/Sources/Features/Ghostties/BuildInfoBadgeView.swift
@@ -116,6 +116,7 @@ struct BuildInfoSnapshot {
 struct BuildInfoBadgeView: View {
     @AppStorage(buildInfoBadgeStorageKey) private var isEnabled: Bool = buildInfoBadgeDefaultEnabled
     @State private var justCopied = false
+    @Environment(\.colorScheme) private var colorScheme
 
     private let info = BuildInfoSnapshot.current
 
@@ -123,7 +124,7 @@ struct BuildInfoBadgeView: View {
         if isEnabled {
             Text(justCopied ? "Copied build info" : info.shortLabel)
                 .font(.system(size: 9))
-                .foregroundColor(Color(nsColor: .tertiaryLabelColor))
+                .foregroundColor(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 2)
                 .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4, style: .continuous))

--- a/macos/Sources/Features/Ghostties/InboxZoneView.swift
+++ b/macos/Sources/Features/Ghostties/InboxZoneView.swift
@@ -49,6 +49,7 @@ struct InboxZoneView: View {
     @AppStorage("ghostties.defaultTaskTemplate") private var defaultTaskTemplate: String = ""
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
 
     /// SEA-215: Read the pre-sorted array from the store instead of sorting
     /// inline. `TaskStore.recomputeLanes()` performs the O(n log n) sort once
@@ -236,7 +237,7 @@ struct InboxZoneView: View {
 
             Text("Click anywhere here to start a new task.")
                 .font(.system(size: 10.5))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 .multilineTextAlignment(.center)
 
             // SG-03: first-run hint — shown only when every lane is empty.
@@ -275,11 +276,11 @@ struct InboxZoneView: View {
             Text("Inbox".uppercased())
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.8)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Text("· \(rows.count)")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Spacer(minLength: 0)
         }

--- a/macos/Sources/Features/Ghostties/NeedsYouZoneView.swift
+++ b/macos/Sources/Features/Ghostties/NeedsYouZoneView.swift
@@ -14,6 +14,8 @@ struct NeedsYouZoneView: View {
     /// hold an independent @ObservedObject on the singleton.
     @ObservedObject private var router = RowClickRouter.shared
 
+    @Environment(\.colorScheme) private var colorScheme
+
     /// Reserved minimum height when the zone is empty. Keeps the divider
     /// below from walking up the sidebar when the list clears out.
     private let emptyHeight: CGFloat = 30
@@ -65,7 +67,7 @@ struct NeedsYouZoneView: View {
 
             Text("\(taskStore.needsYou.count)")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 .fixedSize()
         }
         .padding(.horizontal, TaskRowMetrics.horizontalPadding)

--- a/macos/Sources/Features/Ghostties/NewTaskComposerView.swift
+++ b/macos/Sources/Features/Ghostties/NewTaskComposerView.swift
@@ -126,7 +126,7 @@ struct NewTaskComposerView: View {
             Text("in")
                 .font(.system(size: 10, weight: .semibold))
                 .tracking(0.5)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 .textCase(.uppercase)
                 .frame(width: 20, alignment: .leading)
 
@@ -194,7 +194,7 @@ struct NewTaskComposerView: View {
             Text("via")
                 .font(.system(size: 10, weight: .semibold))
                 .tracking(0.5)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 .textCase(.uppercase)
                 .frame(width: 20, alignment: .leading)
 
@@ -218,7 +218,7 @@ struct NewTaskComposerView: View {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(
                             store.selectedTemplateName == nil
-                                ? Color(nsColor: .tertiaryLabelColor)
+                                ? (colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                                 : Color.primary.opacity(0.85)
                         )
                     Image(systemName: "chevron.down")

--- a/macos/Sources/Features/Ghostties/OnboardingSheet.swift
+++ b/macos/Sources/Features/Ghostties/OnboardingSheet.swift
@@ -8,6 +8,8 @@ import SwiftUI
 struct OnboardingSheet: View {
     let onDismiss: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme
+
     private let buildVersion: String = {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1.0"
     }()
@@ -75,7 +77,7 @@ struct OnboardingSheet: View {
 
                     Text("Version \(buildVersion) (build \(buildNumber)) · Updated \(buildDate)")
                         .font(.system(size: 10))
-                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                        .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                 }
                 .padding(20)
             }

--- a/macos/Sources/Features/Ghostties/OrphanTriageCardView.swift
+++ b/macos/Sources/Features/Ghostties/OrphanTriageCardView.swift
@@ -259,7 +259,7 @@ struct OrphanTriageCardView: View {
         Text(text)
             .font(.system(size: 9.5, weight: .semibold))
             .tracking(0.6)
-            .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+            .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
     }
 
     // MARK: - Background

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -533,6 +533,8 @@ private struct ProjectDisclosureRowContent: View, Equatable {
 private struct SessionGroupHeader: View {
     let bucket: SessionBucket
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         HStack(spacing: 5) {
             Image(systemName: iconName)
@@ -545,7 +547,7 @@ private struct SessionGroupHeader: View {
 
             Spacer(minLength: 0)
         }
-        .foregroundStyle(WorkspaceLayout.sessionGroupHeaderForeground)
+        .foregroundStyle(WorkspaceLayout.sessionGroupHeaderForeground(for: colorScheme))
         .padding(.horizontal, 8)
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -539,15 +539,16 @@ private struct SessionGroupHeader: View {
         HStack(spacing: 5) {
             Image(systemName: iconName)
                 .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(Color(.tertiaryLabelColor))
                 .frame(width: 10, alignment: .center)
 
             Text(label.uppercased())
                 .font(.system(size: 9, weight: .semibold))
                 .tracking(0.5)
+                .foregroundStyle(WorkspaceLayout.sessionGroupHeaderForeground(for: colorScheme))
 
             Spacer(minLength: 0)
         }
-        .foregroundStyle(WorkspaceLayout.sessionGroupHeaderForeground(for: colorScheme))
         .padding(.horizontal, 8)
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -543,6 +543,8 @@ private struct SessionSectionHeader: View {
     /// chevron direction and the accessibility state.
     let isEffectivelyExpanded: Bool
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         Button {
             let animation: Animation? = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
@@ -558,13 +560,13 @@ private struct SessionSectionHeader: View {
                 // directly below it — `PixelChevronView` already pins its own
                 // internal content to a 16pt frame, so the outer frame here
                 // must match that, not shrink it.
-                PixelChevronView(color: WorkspaceLayout.sectionHeaderForeground, isExpanded: isEffectivelyExpanded)
+                PixelChevronView(color: WorkspaceLayout.sectionHeaderForeground(for: colorScheme), isExpanded: isEffectivelyExpanded)
                     .frame(width: WorkspaceLayout.sidebarIconColumnWidth, height: WorkspaceLayout.sidebarIconColumnWidth)
 
                 Text("\(title.uppercased()) \(count)")
                     .font(.system(size: 10, weight: .semibold))
                     .tracking(0.6)
-                    .foregroundStyle(WorkspaceLayout.sectionHeaderForeground)
+                    .foregroundStyle(WorkspaceLayout.sectionHeaderForeground(for: colorScheme))
 
                 Spacer(minLength: 0)
             }

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -560,7 +560,7 @@ private struct SessionSectionHeader: View {
                 // directly below it — `PixelChevronView` already pins its own
                 // internal content to a 16pt frame, so the outer frame here
                 // must match that, not shrink it.
-                PixelChevronView(color: WorkspaceLayout.sectionHeaderForeground(for: colorScheme), isExpanded: isEffectivelyExpanded)
+                PixelChevronView(isExpanded: isEffectivelyExpanded)
                     .frame(width: WorkspaceLayout.sidebarIconColumnWidth, height: WorkspaceLayout.sidebarIconColumnWidth)
 
                 Text("\(title.uppercased()) \(count)")

--- a/macos/Sources/Features/Ghostties/RecentsRowView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsRowView.swift
@@ -83,7 +83,7 @@ struct RecentsRowView: View, Equatable {
 
                 Text(projectName)
                     .font(.system(size: 10))
-                    .foregroundStyle(Color(.tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .lineLimit(1)
             }
 
@@ -95,7 +95,7 @@ struct RecentsRowView: View, Equatable {
             if let ts = session.displayTimestamp {
                 Text(Self.relativeLabel(ts))
                     .font(.system(size: 10))
-                    .foregroundStyle(Color(.tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .monospacedDigit()
             }
         }

--- a/macos/Sources/Features/Ghostties/ReviewZoneView.swift
+++ b/macos/Sources/Features/Ghostties/ReviewZoneView.swift
@@ -19,6 +19,8 @@ struct ReviewZoneView: View {
         taskStore.review
     }
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
@@ -52,11 +54,11 @@ struct ReviewZoneView: View {
             Text("Review".uppercased())
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.8)
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Text("· \(rows.count)")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Spacer(minLength: 0)
         }

--- a/macos/Sources/Features/Ghostties/SessionDetailView.swift
+++ b/macos/Sources/Features/Ghostties/SessionDetailView.swift
@@ -170,7 +170,7 @@ struct SessionRow: View {
         switch indicatorState {
         case .waiting, .needsAttention, .processing, .longRunning: return .primary
         case .idle:     return Color(.secondaryLabelColor)
-        case .inactive: return Color(.tertiaryLabelColor)
+        case .inactive: return colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight
         case .error:    return .primary
         }
     }

--- a/macos/Sources/Features/Ghostties/SessionDraftRowView.swift
+++ b/macos/Sources/Features/Ghostties/SessionDraftRowView.swift
@@ -44,7 +44,7 @@ struct SessionDraftRowView: View {
 
                 Text(metaLine)
                     .font(.system(size: 10.5, design: .monospaced))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -55,7 +55,7 @@ struct SessionDraftRowView: View {
                 // Replaces the + Name affordance while we're editing.
                 Text("↵")
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .padding(.top, 2)
             } else if isHovered {
                 promoteButton
@@ -64,7 +64,7 @@ struct SessionDraftRowView: View {
                 // shift when the hover button appears.
                 Text(trailingTime)
                     .font(.system(size: 10.5, design: .monospaced))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .lineLimit(1)
                     .padding(.top, 2)
             }

--- a/macos/Sources/Features/Ghostties/TaskRowView.swift
+++ b/macos/Sources/Features/Ghostties/TaskRowView.swift
@@ -269,7 +269,7 @@ struct TaskRowView: View {
             TimelineView(.periodic(from: .now, by: 60)) { _ in
                 Text(statusPhrase)
                     .font(.system(size: 11))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .lineLimit(1)
             }
         }
@@ -306,7 +306,7 @@ struct TaskRowView: View {
 
                 Text(compactMetaLine)
                     .font(.system(size: 10.5, design: .monospaced))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -323,7 +323,7 @@ struct TaskRowView: View {
             TimelineView(.periodic(from: .now, by: 60)) { _ in
                 Text(trailingTime)
                     .font(.system(size: 10.5, design: .monospaced))
-                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .lineLimit(1)
                     .padding(.top, 2)
             }

--- a/macos/Sources/Features/Ghostties/TaskSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/TaskSidebarView.swift
@@ -241,7 +241,7 @@ struct TaskSidebarView: View {
         HStack(spacing: 0) {
             Text("tasks · \(taskStore.tasks.count)")
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
 
             Spacer(minLength: 0)
 

--- a/macos/Sources/Features/Ghostties/TemplatePickerView.swift
+++ b/macos/Sources/Features/Ghostties/TemplatePickerView.swift
@@ -20,6 +20,7 @@ struct TemplatePickerView: View {
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var editingTemplate: AgentTemplate?
     @State private var showDeleteConfirmation = false
@@ -155,16 +156,16 @@ struct TemplatePickerView: View {
                     if let description = template.templateDescription {
                         Text(description)
                             .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                             .lineLimit(1)
                     } else if !isPreset, let command = template.command {
                         Text(command)
                             .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     } else if !isPreset {
                         Text("Default shell")
                             .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     }
                 }
                 Spacer()

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -175,15 +175,32 @@ enum WorkspaceLayout {
     /// the long tail" — quietest tier above pure invisible.
     static let activityMutedForeground = Color(.tertiaryLabelColor)
 
+    /// Secondary/muted text foreground (light mode). DESIGN.md `textSecondary`.
+    /// A fixed value, not a system dynamic color — `NSColor.tertiaryLabelColor`
+    /// (25% opacity) fails WCAG 4.5:1 for low-emphasis UI text against both
+    /// chrome and canvas backgrounds; this hex clears it. See
+    /// `docs/audits/sidebar-contrast-audit.md`.
+    static let textSecondaryLight = Color(red: 0x6B / 255.0, green: 0x6B / 255.0, blue: 0x6B / 255.0)
+
+    /// Secondary/muted text foreground (dark mode). See `textSecondaryLight`.
+    static let textSecondaryDark = Color(red: 0x9A / 255.0, green: 0x9A / 255.0, blue: 0x9A / 255.0)
+
     /// Foreground for the small section-header labels in the sidebar
     /// ("Pinned", "Active Now", "Recent", "All Projects"). Muted by design so
-    /// the project rows themselves stay the dominant visual.
-    static let sectionHeaderForeground = Color(.tertiaryLabelColor)
+    /// the project rows themselves stay the dominant visual. Uses the fixed
+    /// `textSecondary` token (not `tertiaryLabelColor`) because this text must
+    /// clear WCAG 4.5:1.
+    static func sectionHeaderForeground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? textSecondaryDark : textSecondaryLight
+    }
 
     /// Foreground for the smaller in-row session group headers ("Active",
     /// "Recent", "Idle") inside an expanded project. One tier quieter than the
-    /// top-level section headers since they're nested.
-    static let sessionGroupHeaderForeground = Color(.tertiaryLabelColor)
+    /// top-level section headers since they're nested. Same `textSecondary`
+    /// token as `sectionHeaderForeground` — both must clear 4.5:1.
+    static func sessionGroupHeaderForeground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? textSecondaryDark : textSecondaryLight
+    }
 
     // MARK: - Sidebar Icon Column
 

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -177,10 +177,13 @@ enum WorkspaceLayout {
 
     /// Secondary/muted text foreground (light mode). DESIGN.md `textSecondary`.
     /// A fixed value, not a system dynamic color — `NSColor.tertiaryLabelColor`
-    /// (25% opacity) fails WCAG 4.5:1 for low-emphasis UI text against both
-    /// chrome and canvas backgrounds; this hex clears it. See
-    /// `docs/audits/sidebar-contrast-audit.md`.
-    static let textSecondaryLight = Color(red: 0x6B / 255.0, green: 0x6B / 255.0, blue: 0x6B / 255.0)
+    /// (25% opacity) fails WCAG 4.5:1 for low-emphasis UI text against every
+    /// backdrop it renders on. `#6b6b6b` (DESIGN.md's original documented
+    /// value) still falls short at 4.44:1 on chrome and 4.08:1 on the
+    /// `activeRowLight` tint — the two backdrops most of this text actually
+    /// sits on. `#636363` clears 4.5:1 on chrome, the active-row tint, and
+    /// canvas. See `docs/audits/sidebar-contrast-audit.md`.
+    static let textSecondaryLight = Color(red: 0x63 / 255.0, green: 0x63 / 255.0, blue: 0x63 / 255.0)
 
     /// Secondary/muted text foreground (dark mode). See `textSecondaryLight`.
     static let textSecondaryDark = Color(red: 0x9A / 255.0, green: 0x9A / 255.0, blue: 0x9A / 255.0)

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -436,15 +436,16 @@ private struct SidebarSectionHeader: View {
         HStack(spacing: WorkspaceLayout.sidebarIconLabelSpacing) {
             Image(systemName: iconName)
                 .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(Color(.tertiaryLabelColor))
                 .frame(width: WorkspaceLayout.sidebarIconColumnWidth, alignment: .center)
 
             Text(label.uppercased())
                 .font(.system(size: 10, weight: .semibold))
                 .tracking(0.6)
+                .foregroundStyle(WorkspaceLayout.sectionHeaderForeground(for: colorScheme))
 
             Spacer(minLength: 0)
         }
-        .foregroundStyle(WorkspaceLayout.sectionHeaderForeground(for: colorScheme))
         .padding(.leading, WorkspaceLayout.sidebarRowLeadingPadding)
         .padding(.trailing, 12)
         .padding(.vertical, 4)

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -427,6 +427,8 @@ private struct PinMigrationNoticeBanner: View {
 private struct SidebarSectionHeader: View {
     let section: SidebarSection
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         // Matches the column structure of `ProjectDisclosureRow` header so
         // section icons vertically center-align with row ghost icons, and
@@ -442,7 +444,7 @@ private struct SidebarSectionHeader: View {
 
             Spacer(minLength: 0)
         }
-        .foregroundStyle(WorkspaceLayout.sectionHeaderForeground)
+        .foregroundStyle(WorkspaceLayout.sectionHeaderForeground(for: colorScheme))
         .padding(.leading, WorkspaceLayout.sidebarRowLeadingPadding)
         .padding(.trailing, 12)
         .padding(.vertical, 4)


### PR DESCRIPTION
## What

Wires DESIGN.md's `textSecondary` token into code, replacing `NSColor.tertiaryLabelColor` (25% opacity) at every call site where it colors real label/body text — section headers, session subtitles/timestamps, task-zone headers, template subtitles, and the build badge. This closes the gap identified in `docs/audits/sidebar-contrast-audit.md`: `tertiaryLabelColor` fails WCAG 4.5:1 in both light and dark mode (worst case 1.81:1 light / 2.28:1 dark).

**Text only.** The status-dot palette (gold/green/orange/blue) also fails contrast in light mode per the audit, but Sean has deliberately deferred that fix. Not touched by this PR — verified in the diff below.

## Revision history

**Round 2** (this push) fixed three defects an independent review found in round 1:

1. **`textSecondary` light value darkened `#6b6b6b` → `#636363`.** `#6b6b6b` (DESIGN.md's original documented value) measured 4.44:1 on chrome and 4.08:1 on the `activeRowLight` tint — the two backdrops most of this text actually renders on, not an edge case. `#636363` clears 4.5:1 on every reachable backdrop. `DESIGN.md`'s `textSecondary` light value updated to match (dark `#9a9a9a` unchanged, already passing).
2. **Fixed a scope leak that darkened chevron/icon tints.** `sectionHeaderForeground`/`sessionGroupHeaderForeground` had been applied to the whole `HStack` in three headers, which also recolored the leading SF Symbol/chevron. Moved the modifier onto the `Text` only in `WorkspaceSidebarView.SidebarSectionHeader` and `ProjectDisclosureRow.SessionGroupHeader` (icon gets its own explicit `tertiaryLabelColor`, matching the existing pattern in `BacklogZoneView`/`ReviewZoneView`/`TaskSidebarView`); dropped the `color:` argument from `PixelChevronView` in `RecentsListView` entirely so it falls back to its own default.
3. **Added the two `TemplatePickerView.swift` sites.** These use SwiftUI's `.tertiary` `HierarchicalShapeStyle`, not `NSColor.tertiaryLabelColor`, so my original grep-scoped pass missed them — but they fail the same way (1.82:1 light / 2.27:1 dark) and pass comfortably with `#636363`.

## Scope

- 46 raw `tertiaryLabelColor` occurrences across 22 files, plus 2 `.tertiary` sites in `TemplatePickerView.swift` added in round 2.
  - **34 changed** (31 `tertiaryLabelColor` + the 2 `TemplatePickerView.swift` `.tertiary` sites + `DESIGN.md` value) — real label/body text that must clear 4.5:1.
  - **13 left alone** — decorative icon tints (including the 2 headers fixed in round 2, which now correctly keep their icon on `tertiaryLabelColor`), status-indicator glyphs/chevrons, ghost-mascot illustrations, and one line of dead/commented code:
    - `BacklogZoneView.swift:52` — tray icon, decorative
    - `NeedsYouZoneView.swift:87` — checkmark icon, decorative
    - `PixelChevronView.swift:9` — chevron default color, decorative (Sean's named example)
    - `ProjectDisclosureRow.swift:415` — `projectHeaderColor`, status-indicator chevron (same family as status dots)
    - `RecentsListView.swift:206` / `WorkspaceSidebarView.swift:182` — `GhostCharacterView` empty-state illustration, decorative
    - `ReviewZoneView.swift:52` — checkmark icon, decorative
    - `SessionDetailView.swift:65` — dead/commented code, no runtime effect
    - `SessionDetailView.swift:164` — `statusColor`, ghost-fill/avatar-initial status marker (status-indicator family)
    - `TaskRowView.swift:468` — `statusSymbolColor` `.done` case, status-indicator family
    - `TaskSidebarView.swift:250` — gearshape icon, decorative
    - `WorkspaceLayout.swift:176` (`activityMutedForeground`) — project-ghost graphic color, decorative
    - `WorkspaceLayout.swift:245` (`sourceDotUnknown`) — source-dot graphic, decorative (status-dot family)
  - **2 off-limits, untouched** — `Command Palette/CommandPalette.swift` and `Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift` are upstream seam files.
- `WorkspaceLayout.textSecondaryLight`/`textSecondaryDark` added following the existing `chromeBackgroundLight`/`chromeBackgroundDark` adaptive-token pattern.
- `sectionHeaderForeground`/`sessionGroupHeaderForeground` are `static func(for colorScheme:)`, applied to `Text` only (not their enclosing `HStack`).

## Contrast table — every backdrop each changed element actually renders on

WCAG 2.1, computed with `python3` (relative luminance + contrast ratio, alpha composited over the real backdrop). `textSecondaryLight = #636363`, `textSecondaryDark = #9a9a9a`. Threshold 4.5:1.

| Backdrop | Mode | Old (`tertiaryLabelColor` 25%) | New (`textSecondary`) | Pass? | Renders under |
|---|---|---|---|---|---|
| chrome `#F0E9E6` / `white:0.14` | Light / Dark | 1.813 / 2.278 | **5.007** / **5.537** | PASS / PASS | Sidebar section headers (`WorkspaceSidebarView`, `RecentsListView`), zone headers (Active/Archive/Backlog/Inbox/NeedsYou/Review), `TaskSidebarView` footer, `NewTaskComposerView` micro-labels + placeholder, `RecentsRowView` subtitle/timestamp (non-active rows) |
| `activeRowLight/Dark` tint composited on chrome | Light / Dark | n/a (old token unaffected by tint) | **4.591** / **4.633** | PASS / PASS | `RecentsRowView` subtitle/timestamp on an *active* session row; `TaskRowView`/`SessionDraftRowView` hover fills |
| canvas `#FAF7F3` / `white:0.18` | Light / Dark | 1.83 / 2.23 | **5.625** / **4.833** | PASS / PASS | `BuildInfoBadgeView` (`.ultraThinMaterial`, approximated as canvas per audit), `OrphanTriageCardView` field labels |
| `expandedContainerLight/Dark` (white / `white:0.16`) | Light / Dark | n/a | **6.008** / **5.184** | PASS / PASS | `ProjectDisclosureRow.SessionGroupHeader` text, `SessionDetailView.sessionTextColor` `.inactive` case |
| `activeRowLight/Dark` tint composited on `expandedContainer` | Light / Dark | n/a | 5.501 / **4.317 FAIL** | PASS / **FAIL** | Computed for completeness — **not reachable in current code**: `SessionDetailView.sessionTextColor` only returns the muted `.inactive` color when `isActive == false`, and `rowBackground` only applies the `activeRow` tint when `isActive == true`. The two conditions are mutually exclusive in the same view, so this composite never actually paints. Flagging rather than hiding it. |
| popover/material (approx, not a Ghostties token) | Light / Dark | 1.82 / 2.27 | **5.085** / **5.239** | PASS / PASS | `TemplatePickerView` template description / command / "Default shell" |

Old-token numbers use the audit's substituted Apple values (`tertiaryLabelColor` composited at 25%); Apple doesn't publish exact resolved RGBA for system dynamic colors.

Status dots (unchanged, deliberately deferred): gold 1.33:1 / green 1.85:1 / orange 2.34:1 / blue 2.69:1 light mode — all still fail 3:1. Not in scope here.

## Verification

- **Build:** `xcodebuild build` — `BUILD SUCCEEDED` (re-run after round 2).
- **Full unfiltered suite** (re-run after round 2): 694 passed / 0 failed / 1 skipped (total 695) — matches baseline exactly.
  ```
  "failedTests" : 0,
  "passedTests" : 694,
  "result" : "Passed",
  "skippedTests" : 1,
  "totalTestCount" : 695
  ```
- `git diff --stat` (round 2 delta): 7 files changed, 35 insertions(+), 12 deletions(-) — `DESIGN.md`, `BACKLOG.md`, and 5 Swift files, all within stated scope. No status-dot diff.

## Follow-ups filed, not fixed here (`BACKLOG.md`, 2026-08-18)

1. `Color.secondary` is now the sidebar's worst-contrast text at 3.85:1 on chrome (independently verified) — below the tier this PR just fixed. Visible at `ArchiveZoneView.swift:98-106` and `NeedsYouZoneView.swift:89-91`.
2. Swapping `tertiaryLabelColor` for a fixed hex drops macOS's Increase Contrast support (the system color ships high-contrast variants; a literal RGB doesn't). Possible follow-up: branch on `NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast`.

## Visual evidence

Screen-recording permission for this terminal denies `screencapture` (the known recurring TCC gotcha in this repo). Numeric table above stands in for screenshots — grab before/after screenshots at your desk (light + dark, Sessions tab section headers are the clearest before/after) before merging if you want the visual record in this PR.

Do not merge — leaving open for review.