### PR TITLE
Phase 1: one template resolver, name-first template creation (D4/D5/D6)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -919,3 +919,10 @@ Sidebar/UX wave night. Ten PRs merged: the six-PR overnight wave (#96, #100, #10
 **Parked — design, Sean's call:**
 
 - [ ] **Status representation vs. per-session ghost icons** — half of this resolved itself: #122 removed the `✳` glyph from names, so the row no longer carries two competing status channels. The remaining question is whether the ghost icon is the right status channel at all. Design decision. Captured in `tease-capture.md`. | design | parked
+
+## 2026-08-19 — Phase 1 review spillover (deferred, not dropped)
+
+- [ ] **Third copy of the template-scoping predicate.** `WorkspaceStore.templates(for projectId:)` duplicates `isGlobal || projectId == id`, consumed by `NewTaskComposerView.swift:240`. Phase 1 unified the other two into `SessionTemplateResolver`. Deliberately out of scope then; converge or delete it. | app | new
+- [ ] **`duplicateTemplate` drops `mcpConfigPath`.** The memberwise copy in `WorkspaceStore.duplicateTemplate` omits `mcpConfigPath`, directly beneath its own `NOTE: Update this if AgentTemplate gains new stored properties.` Duplicating a folder-format preset silently loses its MCP config. Pre-existing on `main`, not introduced by Phase 1. | app | new
+- [ ] **Name-collision rename has no user feedback.** Typing an existing template name now silently yields "X 2", and correcting it back in the edit sheet silently keeps "X 2". Correct per the locked spec, but it dead-ends with no message. Wants one line under the name field: "A template named X already exists." | app | new
+- [ ] **Untracked `ThrottleTrailingEdgeHypothesisTests.swift` pollutes every local test run.** It sits untracked in the shared worktree, Xcode's synchronized groups compile it anyway, and 2 of its 4 tests fail by design — so a local unfiltered run reads 696/2/1 instead of the committed tree's 694/0/1. Decide whether it lands, moves, or goes. | build | new

--- a/docs/plans/session-creation-unified.html
+++ b/docs/plans/session-creation-unified.html
@@ -528,7 +528,7 @@ project ▾ open:                      ┌────────────�
       </li>
       <li>
         <strong>Repoint both callers.</strong> Delete
-        <code>RecentsListView.availableTemplates(for:store:)</code>
+        <code>SessionTemplateResolver.templates(for:store:)</code>
         (<code>:152–160</code>, including the invalid sort at <code>:156</code>)
         and the three computed filters in
         <code>TemplatePickerView</code> (<code>:32–43</code>). Both call the

--- a/docs/plans/session-creation-unified.html
+++ b/docs/plans/session-creation-unified.html
@@ -528,7 +528,7 @@ project ▾ open:                      ┌────────────�
       </li>
       <li>
         <strong>Repoint both callers.</strong> Delete
-        <code>SessionTemplateResolver.templates(for:store:)</code>
+        <code>the old RecentsListView.availableTemplates(for:store:)</code>
         (<code>:152–160</code>, including the invalid sort at <code>:156</code>)
         and the three computed filters in
         <code>TemplatePickerView</code> (<code>:32–43</code>). Both call the

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -143,22 +143,6 @@ struct RecentsListView: View {
         .background(.clear)
     }
 
-    // MARK: - New Session (project-picker templates)
-
-    /// Returns templates available for a given project: global templates plus
-    /// any templates scoped to that project, with the project's default first.
-    /// Static so `NewSessionToolbarButton` (titlebar toolbar) can share the
-    /// exact same resolution logic without instantiating this view.
-    static func availableTemplates(for project: Project, store: WorkspaceStore) -> [AgentTemplate] {
-        let candidates = store.templates.filter { $0.isGlobal || $0.projectId == project.id }
-        // Lift the default template to the top of the list.
-        if let defaultId = project.defaultTemplateId {
-            let sorted = candidates.sorted { a, _ in a.id == defaultId }
-            return sorted
-        }
-        return candidates
-    }
-
     // MARK: - Session Row
 
     private func sessionRow(for session: AgentSession) -> some View {
@@ -260,7 +244,7 @@ struct RecentsListView: View {
     // MARK: - Actions
 
     /// Static so `NewSessionToolbarButton` shares this exactly — see
-    /// `availableTemplates(for:store:)` above.
+    /// `SessionTemplateResolver.templates(for:store:)`.
     static func startNewSession(in project: Project, template: AgentTemplate?, store: WorkspaceStore, coordinator: SessionCoordinator) {
         let resolved: AgentTemplate = template ?? {
             if let defaultId = project.defaultTemplateId,
@@ -477,7 +461,7 @@ struct RecentsListView: View {
 /// Labelled toolbar button for the Sessions tab, presented in
 /// `WorkspaceSidebarView.titlebarToolbar` right-aligned on the traffic-light
 /// row. Opens the same project-picker flyout menu the former `newSessionRow`
-/// showed inline in the list — see `RecentsListView.availableTemplates(for:store:)`
+/// showed inline in the list — see `SessionTemplateResolver.templates(for:store:)`
 /// and `RecentsListView.startNewSession(in:template:store:coordinator:)`, which
 /// this calls directly so the menu logic is never duplicated.
 struct NewSessionToolbarButton: View {
@@ -489,7 +473,7 @@ struct NewSessionToolbarButton: View {
     var body: some View {
         Menu {
             ForEach(store.projects) { project in
-                let templates = RecentsListView.availableTemplates(for: project, store: store)
+                let templates = SessionTemplateResolver.templates(for: project, store: store)
                 if templates.count <= 1 {
                     // Single template — tap creates directly, no submenu needed.
                     Button(project.name) {

--- a/macos/Sources/Features/Ghostties/SessionTemplateResolver.swift
+++ b/macos/Sources/Features/Ghostties/SessionTemplateResolver.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The single source of truth for "which templates are available to a
+/// project, in what order" — replaces two divergent implementations that
+/// used to live in `RecentsListView.availableTemplates(for:store:)` and the
+/// three computed properties on `TemplatePickerView` (`presetTemplates`,
+/// `builtinTemplates`, `customTemplates`). Both callers now route through
+/// this type so the scoping predicate and the ordering rule exist in exactly
+/// one place.
+@MainActor
+enum SessionTemplateResolver {
+
+    /// The three sections the template picker renders, in display order.
+    enum Group {
+        case preset
+        case builtin
+        case user
+    }
+
+    /// Classifies a template into a picker section.
+    ///
+    /// Switches on `isDefault` first so the function is total: a non-default
+    /// template is always user-created (`.user`), regardless of its other
+    /// fields. Among default templates, one with a `templateDescription` is
+    /// a file-based preset (`.preset`); one without is a built-in
+    /// (`.builtin`, e.g. Shell, Claude Code).
+    static func group(for template: AgentTemplate) -> Group {
+        guard template.isDefault else { return .user }
+        return template.templateDescription != nil ? .preset : .builtin
+    }
+
+    /// Returns the templates available to `project`, in the order both the
+    /// flat "New Session" menu and the sectioned template picker should
+    /// present them.
+    ///
+    /// Scope: a template is a candidate if it's global (`isGlobal`) or
+    /// scoped to this exact project (`projectId == project.id`).
+    ///
+    /// Order:
+    /// 1. The project's `defaultTemplateId` template, if present in the
+    ///    candidate set, always comes first — regardless of its group.
+    /// 2. The remaining candidates, grouped `.preset`, then `.builtin`, then
+    ///    `.user`, with insertion order preserved within each group (a
+    ///    stable partition, not a `sort` — the predicate this replaces,
+    ///    `candidates.sorted { a, _ in a.id == defaultId }`, is not a strict
+    ///    weak ordering and leaves everything past "the default sorts
+    ///    early" unspecified across repeated calls).
+    ///
+    /// Default-first, ahead of group order, is a deliberate ordering
+    /// decision: because a stable partition preserves each group's relative
+    /// order, putting the default first in this flat list also puts it
+    /// first within whichever section it belongs to once `TemplatePickerView`
+    /// filters this same list by `group(for:)` — so the sectioned picker's
+    /// "default appears first in its own section" behavior falls out of one
+    /// resolved list for free, instead of needing a second, separate sort.
+    static func templates(for project: Project, store: WorkspaceStore) -> [AgentTemplate] {
+        let candidates = store.templates.filter { $0.isGlobal || $0.projectId == project.id }
+
+        let defaultId = project.defaultTemplateId
+        var defaultTemplate: AgentTemplate?
+        var rest: [AgentTemplate] = []
+        rest.reserveCapacity(candidates.count)
+        for candidate in candidates {
+            if defaultTemplate == nil, let defaultId, candidate.id == defaultId {
+                defaultTemplate = candidate
+            } else {
+                rest.append(candidate)
+            }
+        }
+
+        var presets: [AgentTemplate] = []
+        var builtins: [AgentTemplate] = []
+        var users: [AgentTemplate] = []
+        for candidate in rest {
+            switch group(for: candidate) {
+            case .preset: presets.append(candidate)
+            case .builtin: builtins.append(candidate)
+            case .user: users.append(candidate)
+            }
+        }
+
+        var result: [AgentTemplate] = []
+        result.reserveCapacity(candidates.count)
+        if let defaultTemplate { result.append(defaultTemplate) }
+        result.append(contentsOf: presets)
+        result.append(contentsOf: builtins)
+        result.append(contentsOf: users)
+        return result
+    }
+}

--- a/macos/Sources/Features/Ghostties/SessionTemplateResolver.swift
+++ b/macos/Sources/Features/Ghostties/SessionTemplateResolver.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 /// The single source of truth for "which templates are available to a
-/// project, in what order" — replaces two divergent implementations that
-/// used to live in `RecentsListView.availableTemplates(for:store:)` and the
-/// three computed properties on `TemplatePickerView` (`presetTemplates`,
-/// `builtinTemplates`, `customTemplates`). Both callers now route through
-/// this type so the scoping predicate and the ordering rule exist in exactly
-/// one place.
+/// project, in what order" for the session-creation surfaces (the New
+/// Session menu and the template picker) — replaces two divergent
+/// implementations that used to live in
+/// `RecentsListView.availableTemplates(for:store:)` and the three computed
+/// properties on `TemplatePickerView` (`presetTemplates`, `builtinTemplates`,
+/// `customTemplates`). Both those callers now route through this type.
+///
+/// `WorkspaceStore.templates(for projectId:)` is a third, knowingly-separate
+/// copy of the scoping predicate consumed by `NewTaskComposerView` — it does
+/// not route through here. Do not assume this is the only scoping/ordering
+/// implementation left in the codebase before adding a new caller.
 @MainActor
 enum SessionTemplateResolver {
 

--- a/macos/Sources/Features/Ghostties/TemplatePickerView.swift
+++ b/macos/Sources/Features/Ghostties/TemplatePickerView.swift
@@ -383,9 +383,9 @@ struct TemplatePickerView: View {
     /// and opens the existing edit sheet on it — preserving the follow-on
     /// behavior `addCustomTemplate()` used to provide immediately.
     ///
-    /// Guarded on `isAddingCustomTemplate` so a commit racing a prior
-    /// cancel/commit (see the deferred dispatch in `addCustomRow`) is a
-    /// no-op instead of creating a second template.
+    /// Guarded on `isAddingCustomTemplate` as belt-and-braces against a
+    /// double-commit — calling this twice in a row is a no-op instead of
+    /// creating a second template.
     private func commitNewCustomTemplate() {
         guard isAddingCustomTemplate else { return }
         isAddingCustomTemplate = false

--- a/macos/Sources/Features/Ghostties/TemplatePickerView.swift
+++ b/macos/Sources/Features/Ghostties/TemplatePickerView.swift
@@ -114,7 +114,7 @@ struct TemplatePickerView: View {
             if userTemplates.isEmpty {
                 Text("Presets above cover most cases.")
                     .font(.system(size: 10))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)
                     .padding(.horizontal, 12)
                     .padding(.bottom, 4)
             } else {
@@ -311,21 +311,13 @@ struct TemplatePickerView: View {
                     .focused($newCustomTemplateNameFocused)
                     .onSubmit { commitNewCustomTemplate() }
                     .onExitCommand { cancelNewCustomTemplate() }
-                    .onChange(of: newCustomTemplateNameFocused) { focused in
-                        // Deferred: Esc can drop focus (firing this) before
-                        // SwiftUI's onExitCommand runs cancelNewCustomTemplate().
-                        // Dispatching async lets the cancel clear
-                        // isAddingCustomTemplate first, so the guard in
-                        // commitNewCustomTemplate() rejects this call instead
-                        // of persisting a stale/unwanted template.
-                        if !focused, isAddingCustomTemplate {
-                            DispatchQueue.main.async { commitNewCustomTemplate() }
-                        }
-                    }
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
-            .onAppear { newCustomTemplateNameFocused = true }
+            .onAppear {
+                // Focus after the popover lays out so the TextField is actually in the hierarchy.
+                DispatchQueue.main.async { newCustomTemplateNameFocused = true }
+            }
         } else {
             addCustomButton
         }

--- a/macos/Sources/Features/Ghostties/TemplatePickerView.swift
+++ b/macos/Sources/Features/Ghostties/TemplatePickerView.swift
@@ -27,22 +27,13 @@ struct TemplatePickerView: View {
     @State private var templateToDelete: AgentTemplate?
     @State private var previewingTemplate: AgentTemplate?
 
+    /// Whether the inline "name the new template" field is showing in place
+    /// of `addCustomButton` — see `addCustomRow`.
+    @State private var isAddingCustomTemplate = false
+    @State private var newCustomTemplateName = ""
+    @FocusState private var newCustomTemplateNameFocused: Bool
+
     @AppStorage("ghostties.skipPresetPreview") private var skipPresetPreview = false
-
-    /// Preset templates loaded from `~/.ghostties/presets/` (have a `templateDescription`).
-    private var presetTemplates: [AgentTemplate] {
-        store.templates.filter { $0.templateDescription != nil && $0.isDefault }
-    }
-
-    /// Built-in templates (Shell, Claude Code, etc.) — no preset description.
-    private var builtinTemplates: [AgentTemplate] {
-        store.templates.filter { $0.templateDescription == nil && $0.isDefault }
-    }
-
-    /// User-created custom templates.
-    private var customTemplates: [AgentTemplate] {
-        store.templates.filter { !$0.isDefault }
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -77,7 +68,15 @@ struct TemplatePickerView: View {
     // MARK: - Template List
 
     private var templateList: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        // Resolved once per body evaluation, then split by group — the
+        // single source of ordering truth for this project's templates.
+        // See `SessionTemplateResolver`.
+        let resolved = SessionTemplateResolver.templates(for: project, store: store)
+        let presetTemplates = resolved.filter { SessionTemplateResolver.group(for: $0) == .preset }
+        let builtinTemplates = resolved.filter { SessionTemplateResolver.group(for: $0) == .builtin }
+        let userTemplates = resolved.filter { SessionTemplateResolver.group(for: $0) == .user }
+
+        return VStack(alignment: .leading, spacing: 2) {
             // Presets section
             if !presetTemplates.isEmpty {
                 sectionHeader("PRESETS")
@@ -101,15 +100,25 @@ struct TemplatePickerView: View {
                 }
             }
 
-            // Custom templates section
-            if !customTemplates.isEmpty {
+            // Your Templates section — header always shows once there's at
+            // least one other section above it, even with zero user
+            // templates, so the empty state below has somewhere to live.
+            if !presetTemplates.isEmpty || !builtinTemplates.isEmpty {
                 Divider()
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
+            }
 
-                sectionHeader("YOUR TEMPLATES")
+            sectionHeader("YOUR TEMPLATES")
 
-                ForEach(customTemplates) { template in
+            if userTemplates.isEmpty {
+                Text("Presets above cover most cases.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 4)
+            } else {
+                ForEach(userTemplates) { template in
                     templateRow(template)
                 }
             }
@@ -118,7 +127,7 @@ struct TemplatePickerView: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
 
-            addCustomButton
+            addCustomRow
 
             Spacer()
                 .frame(height: 8)
@@ -285,8 +294,45 @@ struct TemplatePickerView: View {
 
     // MARK: - Add Custom Template
 
+    /// Shows `addCustomButton` normally; swaps in an inline name field, in
+    /// the same row position, once the user starts adding a template — see
+    /// `beginAddCustomTemplate()`. Nothing is persisted until the name is
+    /// committed (Return) with non-empty trimmed text; Esc discards.
+    @ViewBuilder
+    private var addCustomRow: some View {
+        if isAddingCustomTemplate {
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11))
+                    .frame(width: 16)
+                TextField("Template name", text: $newCustomTemplateName)
+                    .font(.system(size: 12, weight: .medium))
+                    .textFieldStyle(.plain)
+                    .focused($newCustomTemplateNameFocused)
+                    .onSubmit { commitNewCustomTemplate() }
+                    .onExitCommand { cancelNewCustomTemplate() }
+                    .onChange(of: newCustomTemplateNameFocused) { focused in
+                        // Deferred: Esc can drop focus (firing this) before
+                        // SwiftUI's onExitCommand runs cancelNewCustomTemplate().
+                        // Dispatching async lets the cancel clear
+                        // isAddingCustomTemplate first, so the guard in
+                        // commitNewCustomTemplate() rejects this call instead
+                        // of persisting a stale/unwanted template.
+                        if !focused, isAddingCustomTemplate {
+                            DispatchQueue.main.async { commitNewCustomTemplate() }
+                        }
+                    }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .onAppear { newCustomTemplateNameFocused = true }
+        } else {
+            addCustomButton
+        }
+    }
+
     private var addCustomButton: some View {
-        Button(action: addCustomTemplate) {
+        Button(action: beginAddCustomTemplate) {
             HStack(spacing: 8) {
                 Image(systemName: "plus")
                     .font(.system(size: 11))
@@ -335,9 +381,32 @@ struct TemplatePickerView: View {
         dismiss()
     }
 
-    private func addCustomTemplate() {
-        let newTemplate = store.addTemplate(AgentTemplate(name: "New Template", kind: .custom))
+    private func beginAddCustomTemplate() {
+        newCustomTemplateName = ""
+        isAddingCustomTemplate = true
+    }
+
+    /// Commits the inline name field: trims, discards silently if empty
+    /// (never persists an unnamed template), otherwise creates the template
+    /// and opens the existing edit sheet on it — preserving the follow-on
+    /// behavior `addCustomTemplate()` used to provide immediately.
+    ///
+    /// Guarded on `isAddingCustomTemplate` so a commit racing a prior
+    /// cancel/commit (see the deferred dispatch in `addCustomRow`) is a
+    /// no-op instead of creating a second template.
+    private func commitNewCustomTemplate() {
+        guard isAddingCustomTemplate else { return }
+        isAddingCustomTemplate = false
+        let trimmed = newCustomTemplateName.trimmingCharacters(in: .whitespacesAndNewlines)
+        newCustomTemplateName = ""
+        guard !trimmed.isEmpty else { return }
+        let newTemplate = store.addTemplate(AgentTemplate(name: trimmed, kind: .custom))
         editingTemplate = newTemplate
+    }
+
+    private func cancelNewCustomTemplate() {
+        isAddingCustomTemplate = false
+        newCustomTemplateName = ""
     }
 
     private func openPresetInEditor(_ template: AgentTemplate) {

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -851,7 +851,20 @@ final class WorkspaceStore: ObservableObject {
 
     @discardableResult
     func addTemplate(_ template: AgentTemplate) -> AgentTemplate {
-        let sanitized = WorkspacePersistence.sanitizeTemplate(template)
+        var sanitized = WorkspacePersistence.sanitizeTemplate(template)
+
+        // Dedupe an exact name collision against an existing template — a
+        // backstop for a user typing the same name twice, appending " 2",
+        // " 3", etc. until the name is free.
+        let existingNames = Set(templates.map(\.name))
+        if existingNames.contains(sanitized.name) {
+            var suffix = 2
+            while existingNames.contains("\(sanitized.name) \(suffix)") {
+                suffix += 1
+            }
+            sanitized.name = "\(sanitized.name) \(suffix)"
+        }
+
         templates.append(sanitized)
         persist()
         return sanitized

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -849,6 +849,19 @@ final class WorkspaceStore: ObservableObject {
 
     // MARK: - Template Actions
 
+    /// Returns `candidate` if free, else `candidate` with " 2", " 3", … appended
+    /// until it is. `excluding` is the id of the template being renamed, so
+    /// renaming a template to the name it already has is not a collision.
+    private func uniqueName(_ candidate: String, excluding id: UUID?) -> String {
+        let existingNames = Set(templates.filter { $0.id != id }.map(\.name))
+        guard existingNames.contains(candidate) else { return candidate }
+        var suffix = 2
+        while existingNames.contains("\(candidate) \(suffix)") {
+            suffix += 1
+        }
+        return "\(candidate) \(suffix)"
+    }
+
     @discardableResult
     func addTemplate(_ template: AgentTemplate) -> AgentTemplate {
         var sanitized = WorkspacePersistence.sanitizeTemplate(template)
@@ -856,14 +869,7 @@ final class WorkspaceStore: ObservableObject {
         // Dedupe an exact name collision against an existing template — a
         // backstop for a user typing the same name twice, appending " 2",
         // " 3", etc. until the name is free.
-        let existingNames = Set(templates.map(\.name))
-        if existingNames.contains(sanitized.name) {
-            var suffix = 2
-            while existingNames.contains("\(sanitized.name) \(suffix)") {
-                suffix += 1
-            }
-            sanitized.name = "\(sanitized.name) \(suffix)"
-        }
+        sanitized.name = uniqueName(sanitized.name, excluding: nil)
 
         templates.append(sanitized)
         persist()
@@ -883,7 +889,7 @@ final class WorkspaceStore: ObservableObject {
     ) {
         guard let index = templates.firstIndex(where: { $0.id == id }) else { return }
         guard !templates[index].isDefault else { return }
-        if let name { templates[index].name = name }
+        if let name { templates[index].name = uniqueName(name, excluding: id) }
         if let kind { templates[index].kind = kind }
         if let command { templates[index].command = command }
         if let environmentVariables { templates[index].environmentVariables = environmentVariables }
@@ -913,10 +919,7 @@ final class WorkspaceStore: ObservableObject {
             icon: original.icon,
             accessLabel: original.accessLabel
         )
-        let sanitized = WorkspacePersistence.sanitizeTemplate(copy)
-        templates.append(sanitized)
-        persist()
-        return sanitized
+        return addTemplate(copy)
     }
 
     func removeTemplate(id: UUID) {

--- a/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
+++ b/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
@@ -123,7 +123,7 @@ final class SessionTemplateResolverTests: XCTestCase {
     /// surfaces a preset after a builtin — this assertion catches that.
     /// `testOrderingIsDeterministicAcrossRepeatedCalls` below does not: at
     /// this fixture size the old predicate is deterministic in practice
-    /// (Swift's insertion sort below the introsort threshold), so it passes
+    /// (Swift's sort insertion-sorts short runs), so it passes
     /// against both implementations.
     func testGroupOrderIsPresetThenBuiltinThenUser() {
         let fixture = makeFixture()
@@ -167,8 +167,8 @@ final class SessionTemplateResolverTests: XCTestCase {
     /// The predicate this replaces (`candidates.sorted { a, _ in a.id ==
     /// defaultId }`) is not a strict weak ordering, so `sorted` was free to
     /// permute everything past "the default sorts early" differently across
-    /// calls — but at this fixture size Swift's insertion sort (used below
-    /// the introsort threshold) happens to be deterministic anyway, so this
+    /// calls — but at this fixture size Swift's sort insertion-sorts short
+    /// runs, which happens to be deterministic anyway, so this
     /// test passes against both the old and new implementations.
     func testOrderingIsDeterministicAcrossRepeatedCalls() {
         let fixture = makeFixture()

--- a/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
+++ b/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import Ghostty
+
+/// Tests for `SessionTemplateResolver` — the single template scoping +
+/// ordering implementation that replaced `RecentsListView.availableTemplates`
+/// and the three computed properties on `TemplatePickerView`.
+@MainActor
+final class SessionTemplateResolverTests: XCTestCase {
+
+    // MARK: - group(for:)
+
+    func testGroupClassifiesNonDefaultAsUser() {
+        let template = AgentTemplate(name: "Mine", kind: .custom, isDefault: false)
+        XCTAssertEqual(SessionTemplateResolver.group(for: template), .user)
+    }
+
+    func testGroupClassifiesNonDefaultAsUserEvenWithADescription() {
+        // isDefault is switched on FIRST — a non-default template is always
+        // `.user`, regardless of templateDescription.
+        let template = AgentTemplate(name: "Mine", kind: .custom, isDefault: false, templateDescription: "desc")
+        XCTAssertEqual(SessionTemplateResolver.group(for: template), .user)
+    }
+
+    func testGroupClassifiesDefaultWithDescriptionAsPreset() {
+        let template = AgentTemplate(name: "Preset", kind: .custom, isDefault: true, templateDescription: "A preset")
+        XCTAssertEqual(SessionTemplateResolver.group(for: template), .preset)
+    }
+
+    func testGroupClassifiesDefaultWithoutDescriptionAsBuiltin() {
+        let template = AgentTemplate(name: "Shell", kind: .shell, isDefault: true)
+        XCTAssertEqual(SessionTemplateResolver.group(for: template), .builtin)
+    }
+
+    // MARK: - templates(for:store:) — fixture
+
+    /// Two projects sharing one store, seeded with the 5 built-in defaults
+    /// (all global) plus a mixed set of global/scoped custom templates.
+    private struct Fixture {
+        let store: WorkspaceStore
+        let projectA: Project
+        let projectB: Project
+        let scopedToA: AgentTemplate
+        let globalUser1: AgentTemplate
+        let globalUser2: AgentTemplate
+        let globalPreset: AgentTemplate
+    }
+
+    private func makeFixture() -> Fixture {
+        let projectA = Project(name: "A", rootPath: "/a")
+        let projectB = Project(name: "B", rootPath: "/b")
+        let store = WorkspaceStore(testingProjects: [projectA, projectB])
+
+        // A project-scoped template — must appear only in projectA's list.
+        let scopedToA = store.addTemplate(
+            AgentTemplate(name: "ScopedToA", kind: .custom, isGlobal: false, projectId: projectA.id)
+        )
+
+        // Two global user templates, added in this order to verify
+        // insertion order is preserved within the `.user` group.
+        let globalUser1 = store.addTemplate(AgentTemplate(name: "GlobalUserFirst", kind: .custom, isGlobal: true))
+        let globalUser2 = store.addTemplate(AgentTemplate(name: "GlobalUserSecond", kind: .custom, isGlobal: true))
+
+        // A global default-with-description template — classifies as
+        // `.preset` and must sort ahead of the built-in defaults.
+        let globalPreset = store.addTemplate(
+            AgentTemplate(
+                name: "GlobalPreset",
+                kind: .custom,
+                isDefault: true,
+                isGlobal: true,
+                templateDescription: "A fixture preset"
+            )
+        )
+
+        return Fixture(
+            store: store,
+            projectA: projectA,
+            projectB: projectB,
+            scopedToA: scopedToA,
+            globalUser1: globalUser1,
+            globalUser2: globalUser2,
+            globalPreset: globalPreset
+        )
+    }
+
+    /// D5 regression guard: a project-scoped template appears in exactly one
+    /// project's list.
+    func testProjectScopedTemplateAppearsInOnlyItsOwnProject() {
+        let fixture = makeFixture()
+
+        let listA = SessionTemplateResolver.templates(for: fixture.projectA, store: fixture.store)
+        let listB = SessionTemplateResolver.templates(for: fixture.projectB, store: fixture.store)
+
+        XCTAssertTrue(listA.contains { $0.id == fixture.scopedToA.id })
+        XCTAssertFalse(listB.contains { $0.id == fixture.scopedToA.id })
+    }
+
+    func testGlobalTemplatesAppearInEveryProject() {
+        let fixture = makeFixture()
+
+        let listA = SessionTemplateResolver.templates(for: fixture.projectA, store: fixture.store)
+        let listB = SessionTemplateResolver.templates(for: fixture.projectB, store: fixture.store)
+
+        for global in [fixture.globalUser1, fixture.globalUser2, fixture.globalPreset] {
+            XCTAssertTrue(listA.contains { $0.id == global.id })
+            XCTAssertTrue(listB.contains { $0.id == global.id })
+        }
+    }
+
+    func testDefaultTemplateIdIsAtIndexZero() {
+        let fixture = makeFixture()
+        fixture.store.updateProject(id: fixture.projectA.id, defaultTemplateId: fixture.globalUser2.id)
+        let updatedProjectA = fixture.store.projects.first { $0.id == fixture.projectA.id }!
+
+        let list = SessionTemplateResolver.templates(for: updatedProjectA, store: fixture.store)
+
+        XCTAssertEqual(list.first?.id, fixture.globalUser2.id)
+    }
+
+    func testGroupOrderIsPresetThenBuiltinThenUser() {
+        let fixture = makeFixture()
+
+        let list = SessionTemplateResolver.templates(for: fixture.projectA, store: fixture.store)
+        let groups = list.map { SessionTemplateResolver.group(for: $0) }
+
+        // No `.user` entry appears before any `.preset` or `.builtin` entry,
+        // and no `.builtin` entry appears before any `.preset` entry.
+        var sawBuiltin = false
+        var sawUser = false
+        for group in groups {
+            switch group {
+            case .preset:
+                XCTAssertFalse(sawBuiltin, "preset found after a builtin")
+                XCTAssertFalse(sawUser, "preset found after a user template")
+            case .builtin:
+                XCTAssertFalse(sawUser, "builtin found after a user template")
+                sawBuiltin = true
+            case .user:
+                sawUser = true
+            }
+        }
+    }
+
+    func testInsertionOrderIsPreservedWithinAGroup() {
+        let fixture = makeFixture()
+
+        let list = SessionTemplateResolver.templates(for: fixture.projectA, store: fixture.store)
+        let userNames = list
+            .filter { SessionTemplateResolver.group(for: $0) == .user }
+            .map(\.name)
+
+        // Added in this order: ScopedToA, GlobalUserFirst, GlobalUserSecond.
+        XCTAssertEqual(userNames, ["ScopedToA", "GlobalUserFirst", "GlobalUserSecond"])
+    }
+
+    /// D6 regression guard: with more than two candidates, repeated calls
+    /// must return the identical order every time. The predicate this
+    /// replaces (`candidates.sorted { a, _ in a.id == defaultId }`) is not a
+    /// strict weak ordering, so `sorted` was free to permute everything past
+    /// "the default sorts early" differently across calls.
+    func testOrderingIsDeterministicAcrossRepeatedCalls() {
+        let fixture = makeFixture()
+        fixture.store.updateProject(id: fixture.projectA.id, defaultTemplateId: fixture.globalUser2.id)
+        let updatedProjectA = fixture.store.projects.first { $0.id == fixture.projectA.id }!
+
+        let first = SessionTemplateResolver.templates(for: updatedProjectA, store: fixture.store).map(\.id)
+        for _ in 0..<10 {
+            let next = SessionTemplateResolver.templates(for: updatedProjectA, store: fixture.store).map(\.id)
+            XCTAssertEqual(first, next)
+        }
+    }
+
+    // MARK: - WorkspaceStore.addTemplate dedupe-on-write
+
+    func testAddTemplateDedupesExactNameCollision() {
+        let store = WorkspaceStore(testingProjects: [])
+
+        let first = store.addTemplate(AgentTemplate(name: "X", kind: .custom))
+        let second = store.addTemplate(AgentTemplate(name: "X", kind: .custom))
+
+        XCTAssertEqual(first.name, "X")
+        XCTAssertEqual(second.name, "X 2")
+    }
+}

--- a/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
+++ b/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
@@ -117,6 +117,14 @@ final class SessionTemplateResolverTests: XCTestCase {
         XCTAssertEqual(list.first?.id, fixture.globalUser2.id)
     }
 
+    /// D6 regression guard: this is the test that genuinely fails against the
+    /// old implementation. The fixture appends `GlobalPreset` after the user
+    /// templates (see `makeFixture()`), so a non-grouping implementation
+    /// surfaces a preset after a builtin — this assertion catches that.
+    /// `testOrderingIsDeterministicAcrossRepeatedCalls` below does not: at
+    /// this fixture size the old predicate is deterministic in practice
+    /// (Swift's insertion sort below the introsort threshold), so it passes
+    /// against both implementations.
     func testGroupOrderIsPresetThenBuiltinThenUser() {
         let fixture = makeFixture()
 
@@ -153,11 +161,15 @@ final class SessionTemplateResolverTests: XCTestCase {
         XCTAssertEqual(userNames, ["ScopedToA", "GlobalUserFirst", "GlobalUserSecond"])
     }
 
-    /// D6 regression guard: with more than two candidates, repeated calls
-    /// must return the identical order every time. The predicate this
-    /// replaces (`candidates.sorted { a, _ in a.id == defaultId }`) is not a
-    /// strict weak ordering, so `sorted` was free to permute everything past
-    /// "the default sorts early" differently across calls.
+    /// Call-stability guard, NOT the D6 regression guard (that is
+    /// `testGroupOrderIsPresetThenBuiltinThenUser` above). With more than two
+    /// candidates, repeated calls must return the identical order every time.
+    /// The predicate this replaces (`candidates.sorted { a, _ in a.id ==
+    /// defaultId }`) is not a strict weak ordering, so `sorted` was free to
+    /// permute everything past "the default sorts early" differently across
+    /// calls — but at this fixture size Swift's insertion sort (used below
+    /// the introsort threshold) happens to be deterministic anyway, so this
+    /// test passes against both the old and new implementations.
     func testOrderingIsDeterministicAcrossRepeatedCalls() {
         let fixture = makeFixture()
         fixture.store.updateProject(id: fixture.projectA.id, defaultTemplateId: fixture.globalUser2.id)

--- a/macos/Tests/Ghostties/WorkspaceStoreTemplateDedupeTests.swift
+++ b/macos/Tests/Ghostties/WorkspaceStoreTemplateDedupeTests.swift
@@ -1,0 +1,72 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+// See .github/workflows/test-ghostties.yml — macos-app job is build-only due to
+// XCTest host app hang in headless GH Actions runners.
+import XCTest
+@testable import Ghostty
+
+/// Tests for `WorkspaceStore`'s name-uniqueness invariant across all three
+/// template write paths (`addTemplate`, `updateTemplate`, `duplicateTemplate`).
+/// Phase 1 review found the dedupe covered only `addTemplate` — a subsequent
+/// `updateTemplate` (e.g. correcting a name back after dedupe renamed it) or
+/// `duplicateTemplate` could still produce two templates sharing a name.
+@MainActor
+final class WorkspaceStoreTemplateDedupeTests: XCTestCase {
+
+    private func makeStore() -> WorkspaceStore {
+        WorkspaceStore(testingProjects: [])
+    }
+
+    private func makeTemplate(name: String) -> AgentTemplate {
+        AgentTemplate(name: name, kind: .shell)
+    }
+
+    /// Adding "X" three times in a row must yield "X", "X 2", "X 3" — the
+    /// existing `addTemplate` dedupe behavior, now routed through `uniqueName`.
+    func testAddTemplate_repeatedName_appendsIncrementingSuffix() {
+        let store = makeStore()
+
+        let first = store.addTemplate(makeTemplate(name: "X"))
+        let second = store.addTemplate(makeTemplate(name: "X"))
+        let third = store.addTemplate(makeTemplate(name: "X"))
+
+        XCTAssertEqual(first.name, "X")
+        XCTAssertEqual(second.name, "X 2")
+        XCTAssertEqual(third.name, "X 3")
+    }
+
+    /// Renaming an unrelated template to a name already in use must dedupe
+    /// exactly like `addTemplate` — the collision check is not add-only.
+    func testUpdateTemplate_renameToExistingName_appendsSuffix() {
+        let store = makeStore()
+
+        store.addTemplate(makeTemplate(name: "X"))
+        store.addTemplate(makeTemplate(name: "X 2"))
+        store.addTemplate(makeTemplate(name: "X 3"))
+        let other = store.addTemplate(makeTemplate(name: "Other"))
+
+        store.updateTemplate(id: other.id, name: "X")
+
+        guard let updated = store.templates.first(where: { $0.id == other.id }) else {
+            return XCTFail("updated template missing")
+        }
+        XCTAssertEqual(updated.name, "X 4", "must dedupe against all three existing X templates, not collide")
+        XCTAssertEqual(store.templates.filter { $0.name == "X" }.count, 1, "the original X must remain the only X")
+    }
+
+    /// Renaming a template to the name it already holds is a no-op rename,
+    /// not a self-collision — the `excluding:` guard must prevent it from
+    /// becoming "X 2".
+    func testUpdateTemplate_renameToOwnCurrentName_isUnchanged() {
+        let store = makeStore()
+
+        let template = store.addTemplate(makeTemplate(name: "X"))
+
+        store.updateTemplate(id: template.id, name: "X")
+
+        guard let updated = store.templates.first(where: { $0.id == template.id }) else {
+            return XCTFail("updated template missing")
+        }
+        XCTAssertEqual(updated.name, "X", "renaming to the same name must not append a suffix")
+    }
+}


### PR DESCRIPTION
Phase 1 of the session-composer work from `docs/plans/session-creation-unified.html`. Replaces two
divergent template-resolution implementations with one resolver, and makes template creation
name-first. Fixes defects **D4**, **D5**, **D6**.

## What changed

**New `SessionTemplateResolver`** — one place that answers "which templates are available to this
project, in what order." Filters on `isGlobal || projectId == project.id`, then orders: the
project's `defaultTemplateId` first, then presets, then built-ins, then user templates, with
insertion order preserved inside each group. It is a stable partition, not a sort.

**Two implementations deleted.** `RecentsListView.availableTemplates(for:store:)` and the three
computed filters on `TemplatePickerView`. Both callers now route through the resolver.

- **D5** — `TemplatePickerView` ignored project scoping entirely, so a project-scoped template
  appeared in *every* project's picker. It now scopes correctly.
- **D6** — the old sort predicate was `candidates.sorted { a, _ in a.id == defaultId }`, which
  ignores its second argument and is therefore not a strict weak ordering: everything past "the
  default sorts early" was unspecified. Replaced with an explicit partition.
- **D4** — three rows all named "New Template" were reachable because the name was hardcoded and
  the record persisted before the user ever named it. Creation is now name-first: an inline field
  replaces the `+ Custom Template…` row, Return commits, Esc discards, and nothing unnamed is ever
  written.

**Name uniqueness now actually holds.** A `uniqueName(_:excluding:)` helper on `WorkspaceStore` is
called from all three write paths — `addTemplate`, `updateTemplate`, and `duplicateTemplate`. See
the review section below for why one path was not enough.

**Empty state** in YOUR TEMPLATES, using the file's existing subtitle treatment.

## Ordering decision worth flagging

The plan's Phase 1 spec is ambiguous where the project's default template is *also* a user
template: "partition the default to the front" and "presets group before built-ins before user
templates" can't both be first. I ruled **default-first wins in the flat list.**

That choice pays for itself: because a stable partition preserves each group's relative order,
putting the default first in the flat list also puts it first *within its own section* once the
picker filters that same list by group — so the sectioned picker's behaviour falls out of one
resolved list instead of needing a second sort. Easy to flip if you disagree.

## Review

Three rounds. The first two both returned DO-NOT-SHIP.

Round 1 and round 2 independently found the same two defects in the new inline field, and cited the
same precedent for both — the blur-commit handler had been copied from the *rename* flows
(`RecentsRowView`, `SessionDetailView`), where commit-on-blur is correct because the row stays on
screen. For a *creation* flow it means clicking away silently persists a template the user never
confirmed, and since the view is torn down by then, the follow-on edit sheet never opens. The
repo's own creation-flow precedent, `SessionDraftRowView.nameField`, has no blur handler at all.
Deleted. Focus assignment was also made deferred, matching three in-repo precedents.

Round 2 then found the one that mattered most: **the dedupe was defeated by its own happy path.**
Type a name that already exists, `addTemplate` silently renames it to "X 2", the edit sheet opens
prefilled with "X 2", the user corrects it back to "X" — and `updateTemplate` had no collision
check at all. Two identical names, via the primary path. `duplicateTemplate` bypassed dedupe too.
Hence the shared helper across all three writers.

Round 3 verified the fixes and caught one more — in the fix pass itself. Correcting a stale
reference in the plan document had substituted the *new* resolver's name into a sentence that was a
historical instruction to delete the *old* function, so the run-book briefly told the next phase to
delete the file this branch creates. Reverted.

## Tests

**710 passed / 2 failed / 1 skipped** (713 total), read from the result bundle rather than log
lines — raw `xcodebuild` output carries a constant −49 offset in this repo.

The 2 failures are **pre-existing and not from this branch**: both are
`ThrottleTrailingEdgeHypothesisTests`, an *untracked* file another session left in the shared
worktree, which Xcode's synchronized groups compile anyway. Its 4 tests split 2 pass / 2 fail on
`main` too. Subtracting them, `main`'s committed baseline is 694/0/1 as recorded, and this branch
adds 14 tests: 11 for the resolver, 3 for name uniqueness.

## No visual evidence

`screencapture` is TCC-denied for this terminal — it returns "could not create image from display" —
so there are no before/after stills. Saying so explicitly rather than omitting them quietly.

One consequence: the deferred-focus fix is inferred from three in-repo precedents and **cannot be
closed by reading code**. Worth a ten-second smoke test when you open this — click
`+ Custom Template…` and check the field takes keystrokes immediately.

## Merging

This is the base of a stacked series. **Merge bottom-up and rebase each later branch after its base
lands** — squash-merge plus stacked PRs conflict in this repo
(`reference_stacked-pr-squash-merge-conflict.md`).

## Known, deliberately out of scope — all filed to `BACKLOG.md`

- `WorkspaceStore.templates(for projectId:)` is a *third* copy of the scoping predicate, consumed by
  `NewTaskComposerView`. The plan named two callers; this is a third.
- `duplicateTemplate`'s memberwise copy omits `mcpConfigPath`, directly beneath its own
  "update this if `AgentTemplate` gains new stored properties" note — so duplicating a folder-format
  preset silently loses its MCP config. Pre-existing on `main`, not introduced here.
- The collision rename has no user-facing feedback. Typing an existing name yields "X 2" silently,
  and correcting it back in the edit sheet silently keeps "X 2". Correct per the locked spec, but it
  wants one line under the name field. Phase 2 material.
