### PR TITLE
Phase 2: SessionComposer in the sidebar popover (D3/D11)

### DIFF
--- a/docs/plans/session-creation-unified.html
+++ b/docs/plans/session-creation-unified.html
@@ -224,7 +224,7 @@
 │  ──────────────────────────────────    │
 │   + New template…                      │
 └────────────────────────────────────────┘
-     ↵ start    ⌥↵ start + reveal    esc cancel
+     ↵ start    esc cancel
 
 project ▾ open:                      ┌────────────────┐
                                      │ Ghostties      │
@@ -651,11 +651,11 @@ project ▾ open:                      ┌────────────�
         parameterized; <code>DESIGN.md:116</code> specifies 11&nbsp;pt sidebar
         UI and <code>:202</code> says resist upsizing, so the fork must
         parameterize width and type scale, fixing D11.
-        <code>.onSubmit</code> (<code>:271</code>) carries no modifier
-        information, so ⌥↵ (start + reveal) needs
         <code>Backport.onKeyPress</code>
         (<code>Helpers/Backport.swift:53</code>; precedent at
-        <code>SurfaceView.swift:416</code>).
+        <code>SurfaceView.swift:416</code>) is the macOS 14+ Return path;
+        <code>.onSubmit</code> (<code>:271</code>) is what makes Return work
+        on the 13.0 deployment target.
       </li>
       <li>
         <strong>Commit</strong> calls

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -450,16 +450,22 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         .padding(.vertical, 4)
         .onHover { isNewSessionHovered = $0 }
         .popover(isPresented: $showingTemplatePicker) {
-            TemplatePickerView(project: project)
+            SessionComposerPalette(
+                isPresented: $showingTemplatePicker,
+                request: SessionComposerRequest(presentation: .anchored, projectBinding: .locked(project))
+            )
         }
     }
 
     // MARK: - Actions
 
+    /// D3: the modifier is the shortcut, not the escape hatch. A plain click
+    /// opens the session composer; Option-click keeps the old instant-create
+    /// behavior when the project has a default template.
     private func handleNewSession() {
         selectedProjectId = project.id
-        if let defaultId = project.defaultTemplateId,
-           !NSEvent.modifierFlags.contains(.option),
+        if NSEvent.modifierFlags.contains(.option),
+           let defaultId = project.defaultTemplateId,
            let template = store.templates.first(where: { $0.id == defaultId }) {
             Task {
                 await coordinator.createQuickSession(for: project, template: template)

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -452,7 +452,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         .popover(isPresented: $showingTemplatePicker) {
             SessionComposerPalette(
                 isPresented: $showingTemplatePicker,
-                request: SessionComposerRequest(presentation: .anchored, projectBinding: .locked(project))
+                request: SessionComposerRequest(presentation: .anchored, projectBinding: .prefilled(project))
             )
         }
     }

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -9,14 +9,16 @@ import SwiftUI
 /// `reference_command-palette-reuse` for the gotchas this fork works around.
 ///
 /// Differences from the system palette, each tied to a specific defect:
-/// - Sectioned RECENT / TEMPLATES results instead of one flat list.
+/// - Sectioned RECENT / TEMPLATES / PROJECTS results instead of one flat
+///   list — the search field filters both templates and projects.
 /// - A trailing divided project control (Treatment 2) instead of a
 ///   project-chip row — Spotlight direction, project selector on the right.
 /// - Prefix-first relevance ranking (`SessionComposerRanking`) instead of
 ///   boolean-match + color scoring.
 /// - Focus-loss auto-dismiss removed: the project dropdown and
 ///   `+ Add project…`'s `NSOpenPanel` both take first responder, and either
-///   would otherwise kill the composer mid-interaction (ship gate 2).
+///   would otherwise kill the composer mid-interaction (ship gate 2). This
+///   is UNVERIFIED beyond source reading — see `ProjectDropdownView` below.
 /// - `ComposerOption.id` is injectable (derived from the underlying
 ///   template/project id) instead of a fresh `UUID()` per recompute, so
 ///   options don't churn hover/scroll-to-selection on every keystroke.
@@ -40,13 +42,18 @@ struct SessionComposerPalette: View {
     @State private var isAddingTemplate = false
     @State private var newTemplateName = ""
     @State private var newTemplateToEdit: AgentTemplate?
+    @State private var showDeleteConfirmation = false
+    @State private var templateToDelete: AgentTemplate?
     @FocusState private var newTemplateNameFocused: Bool
 
     // MARK: - DESIGN.md scale (D11) — see `TemplatePickerView` for precedent.
+    // `paletteWidth` pulls from `WorkspaceLayout.sidebarWidth` (DESIGN.md §2
+    // forbids hardcoded pt values where an equivalent token exists); the
+    // other constants have no `WorkspaceLayout` equivalent.
 
-    private static let paletteWidth: CGFloat = 320
+    private static let paletteWidth: CGFloat = WorkspaceLayout.sidebarWidth
     private static let fieldHeight: CGFloat = 30
-    private static let fieldFontSize: CGFloat = 13
+    private static let fieldFontSize: CGFloat = 11
     private static let rowFontSize: CGFloat = 12
     private static let subtitleFontSize: CGFloat = 10
     private static let sectionHeaderFontSize: CGFloat = 10
@@ -68,12 +75,38 @@ struct SessionComposerPalette: View {
     // MARK: - Options
 
     private func makeOption(for template: AgentTemplate) -> ComposerOption {
-        ComposerOption(
+        let group = SessionTemplateResolver.group(for: template)
+        let isPreset = group == .preset
+
+        // Restores the "Default shell" subtitle fallback `TemplatePickerView`
+        // ships: description first, then command (non-presets only), then
+        // "Default shell" (non-presets only). Presets with no description
+        // render no subtitle, matching the original.
+        let subtitle: String? = {
+            if let description = template.templateDescription { return description }
+            if !isPreset, let command = template.command { return command }
+            if !isPreset { return "Default shell" }
+            return nil
+        }()
+
+        return ComposerOption(
             id: template.id,
             title: template.name,
-            subtitle: template.templateDescription ?? template.command,
+            subtitle: subtitle,
             leadingIcon: template.icon ?? iconName(for: template),
-            action: { commit(template: template) }
+            action: { commit(template: template) },
+            template: template,
+            templateGroup: group
+        )
+    }
+
+    private func makeOption(for project: Project) -> ComposerOption {
+        ComposerOption(
+            id: project.id,
+            title: project.name,
+            subtitle: nil,
+            leadingIcon: "folder",
+            action: { composerStore.selectedProjectId = project.id }
         )
     }
 
@@ -110,7 +143,7 @@ struct SessionComposerPalette: View {
     }
 
     private var filteredRecentOptions: [ComposerOption] {
-        SessionComposerRanking.sorted(recentOptions, query: query, title: { $0.title })
+        SessionComposerRanking.sorted(recentOptions, query: query, title: { $0.title }, subtitle: { $0.subtitle })
     }
 
     private var filteredTemplateOptions: [ComposerOption] {
@@ -118,13 +151,24 @@ struct SessionComposerPalette: View {
         let base = availableTemplates
             .map(makeOption)
             .filter { !recentIds.contains($0.id) }
-        return SessionComposerRanking.sorted(base, query: query, title: { $0.title })
+        return SessionComposerRanking.sorted(base, query: query, title: { $0.title }, subtitle: { $0.subtitle })
+    }
+
+    /// Query-matching projects (S2, locked decision: "the search field
+    /// filters BOTH templates and projects"). Empty when the query is
+    /// blank — the trailing dropdown already covers browsing every project
+    /// unfiltered. Selecting a row here sets the composer's selected
+    /// project; it does not start a session.
+    private var filteredProjectOptions: [ComposerOption] {
+        guard !query.isEmpty else { return [] }
+        let options = store.projects.map(makeOption)
+        return SessionComposerRanking.sorted(options, query: query, title: { $0.title })
     }
 
     /// The full flattened list, in on-screen order, used for keyboard
     /// navigation and selection clamping.
     private var flattenedOptions: [ComposerOption] {
-        filteredRecentOptions + filteredTemplateOptions
+        filteredRecentOptions + filteredTemplateOptions + filteredProjectOptions
     }
 
     private var selectedOption: ComposerOption? {
@@ -151,20 +195,43 @@ struct SessionComposerPalette: View {
             ComposerResultsTable(
                 sections: [
                     (title: filteredRecentOptions.isEmpty ? nil : "RECENT", options: filteredRecentOptions),
-                    (title: "TEMPLATES", options: filteredTemplateOptions)
+                    (title: "TEMPLATES", options: filteredTemplateOptions),
+                    (title: filteredProjectOptions.isEmpty ? nil : "PROJECTS", options: filteredProjectOptions)
                 ],
                 query: query,
                 selectedIndex: $selectedIndex,
                 hoveredOptionID: $hoveredOptionID,
                 rowFontSize: Self.rowFontSize,
                 subtitleFontSize: Self.subtitleFontSize,
-                sectionHeaderFontSize: Self.sectionHeaderFontSize
+                sectionHeaderFontSize: Self.sectionHeaderFontSize,
+                onEditTemplate: { newTemplateToEdit = $0 },
+                onDuplicateTemplate: { _ = store.duplicateTemplate(id: $0.id) },
+                onDuplicateAndEditTemplate: {
+                    if let copy = store.duplicateTemplate(id: $0.id) { newTemplateToEdit = copy }
+                },
+                onEditPresetFile: { openPresetInEditor($0) },
+                onRequestDeleteTemplate: {
+                    templateToDelete = $0
+                    showDeleteConfirmation = true
+                }
             ) { option in
-                isPresented = false
+                // Does NOT dismiss the popover here — `option.action()` (a
+                // template commit) only clears `isPresented` once the store
+                // confirms the write succeeded (S6). Dismissing eagerly, as
+                // this used to, closed the composer with no session and no
+                // visible error whenever `commit()`'s pre-check failed.
                 option.action()
             }
 
             Divider()
+
+            if let writeError = composerStore.writeError {
+                Text(writeError)
+                    .font(.system(size: Self.subtitleFontSize))
+                    .foregroundStyle(Color(nsColor: .systemRed))
+                    .padding(.horizontal, 10)
+                    .padding(.top, 6)
+            }
 
             newTemplateRow
         }
@@ -184,6 +251,10 @@ struct SessionComposerPalette: View {
         .environment(\.colorScheme, scheme)
         .onAppear {
             composerStore.open(projectBinding: request.projectBinding, workspaceStore: store)
+            // S5: row 0 is the project's default template (Phase 1's
+            // default-first ordering) and the legend reads "↵ start" — seed
+            // the selection so Return isn't a dead key on first open.
+            selectedIndex = 0
         }
         .onChange(of: isPresented) { presented in
             if !presented {
@@ -192,15 +263,51 @@ struct SessionComposerPalette: View {
                 newTemplateName = ""
             }
         }
-        .onChange(of: query) { newValue in
-            if !newValue.isEmpty {
-                if selectedIndex == nil { selectedIndex = 0 }
-            } else if let selectedIndex, selectedIndex == 0 {
-                self.selectedIndex = nil
+        .onDisappear {
+            // The only reliable teardown hook for popover content — the row
+            // hosting this popover can leave the hierarchy (project
+            // removed, sidebar view-mode switch, `windowDidResignKey` /
+            // `mouseExited` closing the popover) without
+            // `onChange(of: isPresented)` ever firing, which otherwise
+            // latches `SessionComposerStore.isOpen` true forever (B3).
+            composerStore.cancel()
+        }
+        .onChange(of: query) { _ in
+            // Clamp into range rather than nil-ing out — the old logic only
+            // reset when the index was exactly 0, so a stale index from a
+            // shrunk list (e.g. RECENT reordering after a commit) survived
+            // a query change untouched.
+            let count = flattenedOptions.count
+            guard count > 0 else {
+                selectedIndex = nil
+                return
+            }
+            if let current = selectedIndex {
+                if current >= UInt(count) {
+                    selectedIndex = UInt(count - 1)
+                }
+            } else {
+                selectedIndex = 0
             }
         }
         .sheet(item: $newTemplateToEdit) { template in
             TemplateEditForm(template: template)
+        }
+        .alert(
+            "Delete Template?",
+            isPresented: $showDeleteConfirmation,
+            presenting: templateToDelete
+        ) { template in
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                store.removeTemplate(id: template.id)
+            }
+        } message: { template in
+            if store.templateInUse(id: template.id) {
+                Text("Sessions using \"\(template.name)\" will keep their current configuration but won't be relaunchable with this template.")
+            } else {
+                Text("This will permanently remove \"\(template.name)\".")
+            }
         }
     }
 
@@ -208,13 +315,15 @@ struct SessionComposerPalette: View {
 
     private var queryRow: some View {
         HStack(spacing: 0) {
-            ComposerQueryField(query: $composerStore.searchText, fontSize: Self.fieldFontSize) { event in
+            ComposerQueryField(
+                query: $composerStore.searchText,
+                fontSize: Self.fieldFontSize,
+                focusTrigger: $composerStore.focusSearchFieldTrigger,
+                hasSelection: selectedOption != nil
+            ) { event in
                 handle(event)
             }
             .frame(height: Self.fieldHeight)
-
-            Divider()
-                .frame(height: Self.fieldHeight * 0.5)
 
             projectControl
         }
@@ -226,11 +335,16 @@ struct SessionComposerPalette: View {
         let label = currentProject?.name ?? "Select project"
 
         if isProjectLocked {
+            // No hairline divider here (nit): a divider next to a static
+            // label with no `▾` reads as a control that isn't one.
             Text(label)
                 .font(.system(size: Self.rowFontSize, weight: .medium))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
         } else {
+            Divider()
+                .frame(height: Self.fieldHeight * 0.5)
+
             Button {
                 isProjectDropdownOpen = true
             } label: {
@@ -246,9 +360,13 @@ struct SessionComposerPalette: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            // UNVERIFIED beyond source reading: this is a `.popover` nested
+            // inside the composer's own `.popover`. Whether the child
+            // taking key dismisses the parent (the exact mechanism ship
+            // gate 2 exists to catch) can only be settled by running the
+            // app.
             .popover(isPresented: $isProjectDropdownOpen, arrowEdge: .bottom) {
                 ProjectDropdownView(
-                    query: query,
                     selectedProjectId: composerStore.selectedProjectId
                 ) { project in
                     composerStore.selectedProjectId = project.id
@@ -320,31 +438,59 @@ struct SessionComposerPalette: View {
         newTemplateName = ""
     }
 
-    // MARK: - Actions
+    // MARK: - Template context menu actions (S4, ported from
+    // `TemplatePickerView` — that view now has zero callers, so everything
+    // it owned, most seriously `store.removeTemplate`'s only UI caller, was
+    // unreachable).
 
-    private func commit(template: AgentTemplate) {
-        Task {
-            await composerStore.commit(template: template, coordinator: coordinator, workspaceStore: store)
+    /// Preset files live at `~/.ghostties/presets/<slug>.md`. Duplicated
+    /// from `TemplatePickerView.openPresetInEditor` (that method is
+    /// `private` to a different file, not reachable from here).
+    private func openPresetInEditor(_ template: AgentTemplate) {
+        let filename = template.name.lowercased().replacingOccurrences(of: " ", with: "-") + ".md"
+        let path = (PresetLoader.presetsDirectoryPath as NSString).appendingPathComponent(filename)
+
+        // Validate the resolved path stays within the presets directory.
+        let resolvedPath = (path as NSString).standardizingPath
+        let presetsDir = (PresetLoader.presetsDirectoryPath as NSString).standardizingPath
+        guard resolvedPath.hasPrefix(presetsDir + "/") else { return }
+
+        let url = URL(fileURLWithPath: resolvedPath)
+        if FileManager.default.fileExists(atPath: resolvedPath) {
+            NSWorkspace.shared.open(url)
         }
     }
 
-    /// Return commits the highlighted row and closes the composer.
-    /// Option+Return commits but keeps the composer open — a deliberate
-    /// interpretation of the brief's "⌥↵ needs Backport.onKeyPress"
-    /// constraint for rapid-fire session creation in the same project; Sean
-    /// hasn't specified the exact UX for this modifier, so this is a
-    /// reasonable default, not a locked decision.
+    // MARK: - Actions
+
+    private func commit(template: AgentTemplate) {
+        // S1: reset the stale index up front. `recordRecent` (inside the
+        // store's commit) reorders RECENT, which would otherwise leave
+        // `selectedIndex` pointing at the wrong row if the composer stays
+        // open on a failed commit (S6).
+        selectedIndex = nil
+        Task {
+            let success = await composerStore.commit(template: template, coordinator: coordinator, workspaceStore: store)
+            if success {
+                isPresented = false
+            }
+        }
+    }
+
+    /// Return and ⌥+Return are identical: both start the session, which
+    /// already reveals/focuses it (`SessionCoordinator.createSession` makes
+    /// the new surface "the sole occupant of the terminal area"), then
+    /// close the composer like any other commit. An earlier version of this
+    /// file invented a "commit but keep composer open" meaning for ⌥+Return
+    /// that contradicted the plan's own legend (`↵ start · ⌥↵ start +
+    /// reveal · esc cancel`) — deleted, not kept as a fallback.
     private func handle(_ event: ComposerQueryField.KeyboardEvent) {
         switch event {
         case .exit:
             isPresented = false
 
-        case .submit(let keepOpen):
-            guard let option = selectedOption else { break }
-            if !keepOpen {
-                isPresented = false
-            }
-            option.action()
+        case .submit:
+            selectedOption?.action()
 
         case .move(.up):
             if flattenedOptions.isEmpty { break }
@@ -367,12 +513,36 @@ struct SessionComposerPalette: View {
 /// Analog of `CommandOption` with an INJECTABLE id (derived from the
 /// underlying template/project id), fixing the churn `CommandOption.id =
 /// UUID()` causes on every keystroke recompute.
+///
+/// `template`/`templateGroup` are non-nil only for options backed by a
+/// template — `ComposerRow` uses them to decide whether (and which)
+/// context menu to attach; project options and other rows carry no menu.
 struct ComposerOption: Identifiable, Hashable {
     let id: UUID
     let title: String
     let subtitle: String?
     let leadingIcon: String?
     let action: () -> Void
+    let template: AgentTemplate?
+    let templateGroup: SessionTemplateResolver.Group?
+
+    init(
+        id: UUID,
+        title: String,
+        subtitle: String?,
+        leadingIcon: String?,
+        action: @escaping () -> Void,
+        template: AgentTemplate? = nil,
+        templateGroup: SessionTemplateResolver.Group? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.leadingIcon = leadingIcon
+        self.action = action
+        self.template = template
+        self.templateGroup = templateGroup
+    }
 
     static func == (lhs: ComposerOption, rhs: ComposerOption) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
@@ -385,18 +555,28 @@ struct ComposerOption: Identifiable, Hashable {
 /// calling `.exit`) is REMOVED — the project dropdown and
 /// `+ Add project…`'s `NSOpenPanel` both take first responder, and either
 /// would otherwise kill the composer mid-interaction (ship gate 2) — and
-/// submit goes through `Backport.onKeyPress` instead of `.onSubmit`, since
-/// `.onSubmit` carries no modifier info and ⌥↵ needs to be distinguishable
-/// from a plain Return.
+/// Return is wired through BOTH `.onSubmit` and `Backport.onKeyPress`:
+/// `Backport.onKeyPress` is a documented no-op below macOS 14
+/// (`Helpers/Backport.swift:53-68`) and the app's deployment target is
+/// 13.0, so `.onSubmit` alone is what makes Return work pre-14. If both
+/// fire on 14+, `SessionComposerStore.commit()`'s re-entry guard (`S9`)
+/// makes the second call a no-op rather than a double-commit — this repo
+/// cannot verify from source alone whether both actually fire, only that a
+/// double-fire would be harmless if they do.
 struct ComposerQueryField: View {
     @Binding var query: String
     var fontSize: CGFloat
+    @Binding var focusTrigger: Bool
+    /// Whether there's a highlighted row to commit. When false, Return is a
+    /// deliberate no-op (nit: `.onKeyPress` used to return `.handled`
+    /// unconditionally, swallowing Return against an empty list).
+    var hasSelection: Bool
     var onEvent: ((KeyboardEvent) -> Void)?
     @FocusState private var isTextFieldFocused: Bool
 
     enum KeyboardEvent {
         case exit
-        case submit(keepOpen: Bool)
+        case submit
         case move(MoveCommandDirection)
     }
 
@@ -427,14 +607,30 @@ struct ComposerQueryField: View {
                 .focused($isTextFieldFocused)
                 .onExitCommand { onEvent?(.exit) }
                 .onMoveCommand { onEvent?(.move($0)) }
-                .backport.onKeyPress(.return) { modifiers in
-                    onEvent?(.submit(keepOpen: modifiers.contains(.option)))
+                // B1: `.onSubmit` is the ONLY Return handler that works
+                // below macOS 14 — the app's deployment target is 13.0.
+                .onSubmit {
+                    guard hasSelection else { return }
+                    onEvent?(.submit)
+                }
+                .backport.onKeyPress(.return) { _ in
+                    guard hasSelection else { return .ignored }
+                    onEvent?(.submit)
                     return .handled
                 }
                 .onAppear {
                     DispatchQueue.main.async {
                         isTextFieldFocused = true
                     }
+                }
+                .onChange(of: focusTrigger) { triggered in
+                    // S7: consumes `SessionComposerStore.focusSearchFieldTrigger`
+                    // — previously set on re-open but read nowhere, so the
+                    // "opening while already open focuses the field" parity
+                    // the doc comment claimed was a complete no-op.
+                    guard triggered else { return }
+                    isTextFieldFocused = true
+                    focusTrigger = false
                 }
         }
     }
@@ -443,11 +639,11 @@ struct ComposerQueryField: View {
 // MARK: - Results table
 
 /// Forked from `CommandTable`, with two changes: it renders named sections
-/// (RECENT / TEMPLATES — `CommandPaletteView` has no section grouping at
-/// all) and it uses a plain `VStack`, never `LazyVStack` — this repo has a
-/// known bug class where `LazyVStack` never re-invokes `ForEach`'s content
-/// closure when an element changes but its `id` does not, which froze
-/// sidebar rows at first construction (PR #121).
+/// (RECENT / TEMPLATES / PROJECTS — `CommandPaletteView` has no section
+/// grouping at all) and it uses a plain `VStack`, never `LazyVStack` — this
+/// repo has a known bug class where `LazyVStack` never re-invokes
+/// `ForEach`'s content closure when an element changes but its `id` does
+/// not, which froze sidebar rows at first construction (PR #121).
 private struct ComposerResultsTable: View {
     var sections: [(title: String?, options: [ComposerOption])]
     var query: String
@@ -456,6 +652,11 @@ private struct ComposerResultsTable: View {
     var rowFontSize: CGFloat
     var subtitleFontSize: CGFloat
     var sectionHeaderFontSize: CGFloat
+    var onEditTemplate: (AgentTemplate) -> Void
+    var onDuplicateTemplate: (AgentTemplate) -> Void
+    var onDuplicateAndEditTemplate: (AgentTemplate) -> Void
+    var onEditPresetFile: (AgentTemplate) -> Void
+    var onRequestDeleteTemplate: (AgentTemplate) -> Void
     var action: (ComposerOption) -> Void
 
     private var flattened: [ComposerOption] {
@@ -490,7 +691,12 @@ private struct ComposerResultsTable: View {
                                         isSelected: isSelected(option),
                                         hoveredID: $hoveredOptionID,
                                         titleFontSize: rowFontSize,
-                                        subtitleFontSize: subtitleFontSize
+                                        subtitleFontSize: subtitleFontSize,
+                                        onEditTemplate: onEditTemplate,
+                                        onDuplicateTemplate: onDuplicateTemplate,
+                                        onDuplicateAndEditTemplate: onDuplicateAndEditTemplate,
+                                        onEditPresetFile: onEditPresetFile,
+                                        onRequestDeleteTemplate: onRequestDeleteTemplate
                                     ) {
                                         action(option)
                                     }
@@ -519,6 +725,14 @@ private struct ComposerResultsTable: View {
 /// Reuses `String.matchedIndices(for:)` (`CommandPalette.swift`,
 /// module-scope) for highlighting — redeclaring it would be a compile
 /// error.
+///
+/// S4: carries a `.contextMenu`, ported from
+/// `TemplatePickerView.templateRow` (`TemplatePickerView.swift:186-217`),
+/// for template-backed rows only (`option.template != nil`) — project rows
+/// get no menu. Perf note (`project_perf-contextmenu-render-cost.md`):
+/// per-row `.contextMenu` in a long-lived sidebar list is a known
+/// bottleneck, but this is a transient popover showing ~10 rows, so it's
+/// acceptable; no `.popover`/`.draggable` is added per row alongside it.
 private struct ComposerRow: View {
     let option: ComposerOption
     var query: String
@@ -526,6 +740,11 @@ private struct ComposerRow: View {
     @Binding var hoveredID: UUID?
     var titleFontSize: CGFloat
     var subtitleFontSize: CGFloat
+    var onEditTemplate: (AgentTemplate) -> Void
+    var onDuplicateTemplate: (AgentTemplate) -> Void
+    var onDuplicateAndEditTemplate: (AgentTemplate) -> Void
+    var onEditPresetFile: (AgentTemplate) -> Void
+    var onRequestDeleteTemplate: (AgentTemplate) -> Void
     var action: () -> Void
 
     private var highlightedTitle: Text {
@@ -584,6 +803,33 @@ private struct ComposerRow: View {
         .onHover { hovering in
             hoveredID = hovering ? option.id : nil
         }
+        .contextMenu {
+            templateContextMenu
+        }
+    }
+
+    /// Replicates `TemplatePickerView.templateRow`'s context menu exactly:
+    /// presets get "Duplicate and Edit..." (+ "Edit Preset File..." when a
+    /// description exists), built-ins get "Duplicate and Edit..." only,
+    /// user templates get Edit… / Duplicate / Delete. Renders nothing for
+    /// non-template rows (project options).
+    @ViewBuilder
+    private var templateContextMenu: some View {
+        if let template = option.template, let group = option.templateGroup {
+            if group == .preset {
+                Button("Duplicate and Edit...") { onDuplicateAndEditTemplate(template) }
+                if template.templateDescription != nil {
+                    Button("Edit Preset File...") { onEditPresetFile(template) }
+                }
+            } else if template.isDefault {
+                Button("Duplicate and Edit...") { onDuplicateAndEditTemplate(template) }
+            } else {
+                Button("Edit...") { onEditTemplate(template) }
+                Button("Duplicate") { onDuplicateTemplate(template) }
+                Divider()
+                Button("Delete", role: .destructive) { onRequestDeleteTemplate(template) }
+            }
+        }
     }
 }
 
@@ -593,16 +839,31 @@ private struct ComposerRow: View {
 /// ordering, no visible headers: cascade pick (pre-selected) -> recently-used
 /// most-recent-first -> everything else alphabetically (locked decision).
 /// `+ Add project…` is always the last row.
+///
+/// UNVERIFIED beyond source reading (flagged at the call site too): this
+/// view is presented as a `.popover` nested inside the composer's own
+/// `.popover`. A child popover taking key can dismiss the parent, and
+/// removing the text-field-blur handler on `ComposerQueryField` does NOT by
+/// itself fix popover-loses-key dismissal — this is the exact mechanism
+/// ship gate 2 exists to catch, and it can only be settled by running the
+/// app.
 private struct ProjectDropdownView: View {
-    let query: String
     let selectedProjectId: UUID?
     var onSelect: (Project) -> Void
     var onAddProject: () -> Void
 
     @EnvironmentObject private var store: WorkspaceStore
 
+    /// Decoupled from the composer's search field (nit): this used to read
+    /// `SessionComposerStore.shared.searchText` directly, so typing
+    /// "claude" to find a template and then opening the dropdown showed
+    /// every project filtered out even though this view has no visible
+    /// search field of its own. Starts empty, unaffected by the composer's
+    /// query.
+    @State private var query: String = ""
+
     private var orderedProjects: [Project] {
-        let recentIds = SessionComposerStore.shared.recentSelections.map { $0.projectId }
+        let recentIds = SessionComposerStore.shared.recentProjectIds
         return SessionComposerProjectOrdering.order(
             projects: store.projects,
             cascadePick: selectedProjectId,

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -1,0 +1,659 @@
+import AppKit
+import SwiftUI
+
+/// The session composer, presented in the existing sidebar popover (Phase 2
+/// of session-creation-unified — fixes D3/D11). A forked COPY of
+/// `CommandPalette.swift`, not an edit of it: that file is byte-identical to
+/// upstream and editing it in place converts a zero-conflict file into a
+/// permanent rebase liability. See
+/// `reference_command-palette-reuse` for the gotchas this fork works around.
+///
+/// Differences from the system palette, each tied to a specific defect:
+/// - Sectioned RECENT / TEMPLATES results instead of one flat list.
+/// - A trailing divided project control (Treatment 2) instead of a
+///   project-chip row — Spotlight direction, project selector on the right.
+/// - Prefix-first relevance ranking (`SessionComposerRanking`) instead of
+///   boolean-match + color scoring.
+/// - Focus-loss auto-dismiss removed: the project dropdown and
+///   `+ Add project…`'s `NSOpenPanel` both take first responder, and either
+///   would otherwise kill the composer mid-interaction (ship gate 2).
+/// - `ComposerOption.id` is injectable (derived from the underlying
+///   template/project id) instead of a fresh `UUID()` per recompute, so
+///   options don't churn hover/scroll-to-selection on every keystroke.
+/// - Proportions brought down to DESIGN.md's 11pt sidebar scale instead of
+///   the system palette's 20pt field / 48pt row (D11).
+///
+/// NO session-name field — an unpinned session's name is its live terminal
+/// title (locked decision). The search field only ever filters templates
+/// and projects.
+struct SessionComposerPalette: View {
+    @Binding var isPresented: Bool
+    let request: SessionComposerRequest
+
+    @EnvironmentObject private var store: WorkspaceStore
+    @EnvironmentObject private var coordinator: SessionCoordinator
+    @ObservedObject private var composerStore = SessionComposerStore.shared
+
+    @State private var selectedIndex: UInt?
+    @State private var hoveredOptionID: UUID?
+    @State private var isProjectDropdownOpen = false
+    @State private var isAddingTemplate = false
+    @State private var newTemplateName = ""
+    @State private var newTemplateToEdit: AgentTemplate?
+    @FocusState private var newTemplateNameFocused: Bool
+
+    // MARK: - DESIGN.md scale (D11) — see `TemplatePickerView` for precedent.
+
+    private static let paletteWidth: CGFloat = 320
+    private static let fieldHeight: CGFloat = 30
+    private static let fieldFontSize: CGFloat = 13
+    private static let rowFontSize: CGFloat = 12
+    private static let subtitleFontSize: CGFloat = 10
+    private static let sectionHeaderFontSize: CGFloat = 10
+
+    private var isProjectLocked: Bool {
+        if case .locked = request.projectBinding { return true }
+        return false
+    }
+
+    private var query: String {
+        composerStore.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var currentProject: Project? {
+        guard let id = composerStore.selectedProjectId else { return nil }
+        return store.projects.first(where: { $0.id == id })
+    }
+
+    // MARK: - Options
+
+    private func makeOption(for template: AgentTemplate) -> ComposerOption {
+        ComposerOption(
+            id: template.id,
+            title: template.name,
+            subtitle: template.templateDescription ?? template.command,
+            leadingIcon: template.icon ?? iconName(for: template),
+            action: { commit(template: template) }
+        )
+    }
+
+    private func iconName(for template: AgentTemplate) -> String {
+        switch template.kind {
+        case .shell: return "terminal"
+        case .claudeCode: return template.agent != nil ? "cpu" : "sparkle"
+        case .custom: return "gearshape"
+        case .browser: return "globe"
+        }
+    }
+
+    private var availableTemplates: [AgentTemplate] {
+        guard let project = currentProject else { return [] }
+        return SessionTemplateResolver.templates(for: project, store: store)
+    }
+
+    /// Recent `(project, template)` pairs scoped to the current project,
+    /// most-recent-first, deduplicated by template.
+    private var recentOptions: [ComposerOption] {
+        guard let project = currentProject else { return [] }
+        let recentIds = composerStore.recentSelections
+            .filter { $0.projectId == project.id }
+            .map { $0.templateId }
+
+        var seen = Set<UUID>()
+        var result: [ComposerOption] = []
+        for id in recentIds {
+            guard !seen.contains(id), let template = availableTemplates.first(where: { $0.id == id }) else { continue }
+            seen.insert(id)
+            result.append(makeOption(for: template))
+        }
+        return result
+    }
+
+    private var filteredRecentOptions: [ComposerOption] {
+        SessionComposerRanking.sorted(recentOptions, query: query, title: { $0.title })
+    }
+
+    private var filteredTemplateOptions: [ComposerOption] {
+        let recentIds = Set(filteredRecentOptions.map { $0.id })
+        let base = availableTemplates
+            .map(makeOption)
+            .filter { !recentIds.contains($0.id) }
+        return SessionComposerRanking.sorted(base, query: query, title: { $0.title })
+    }
+
+    /// The full flattened list, in on-screen order, used for keyboard
+    /// navigation and selection clamping.
+    private var flattenedOptions: [ComposerOption] {
+        filteredRecentOptions + filteredTemplateOptions
+    }
+
+    private var selectedOption: ComposerOption? {
+        guard let selectedIndex else { return nil }
+        let options = flattenedOptions
+        return if selectedIndex < options.count {
+            options[Int(selectedIndex)]
+        } else {
+            options.last
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        let backgroundColor = Color(nsColor: .windowBackgroundColor)
+        let scheme: ColorScheme = OSColor(backgroundColor).isLightColor ? .light : .dark
+
+        VStack(alignment: .leading, spacing: 0) {
+            queryRow
+
+            Divider()
+
+            ComposerResultsTable(
+                sections: [
+                    (title: filteredRecentOptions.isEmpty ? nil : "RECENT", options: filteredRecentOptions),
+                    (title: "TEMPLATES", options: filteredTemplateOptions)
+                ],
+                query: query,
+                selectedIndex: $selectedIndex,
+                hoveredOptionID: $hoveredOptionID,
+                rowFontSize: Self.rowFontSize,
+                subtitleFontSize: Self.subtitleFontSize,
+                sectionHeaderFontSize: Self.sectionHeaderFontSize
+            ) { option in
+                isPresented = false
+                option.action()
+            }
+
+            Divider()
+
+            newTemplateRow
+        }
+        .frame(width: Self.paletteWidth)
+        .background(
+            ZStack {
+                Rectangle().fill(.ultraThinMaterial)
+                Rectangle().fill(backgroundColor).blendMode(.color)
+            }
+            .compositingGroup()
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(nsColor: .tertiaryLabelColor).opacity(0.75))
+        )
+        .environment(\.colorScheme, scheme)
+        .onAppear {
+            composerStore.open(projectBinding: request.projectBinding, workspaceStore: store)
+        }
+        .onChange(of: isPresented) { presented in
+            if !presented {
+                composerStore.cancel()
+                isAddingTemplate = false
+                newTemplateName = ""
+            }
+        }
+        .onChange(of: query) { newValue in
+            if !newValue.isEmpty {
+                if selectedIndex == nil { selectedIndex = 0 }
+            } else if let selectedIndex, selectedIndex == 0 {
+                self.selectedIndex = nil
+            }
+        }
+        .sheet(item: $newTemplateToEdit) { template in
+            TemplateEditForm(template: template)
+        }
+    }
+
+    // MARK: - Query row (search field + trailing project control)
+
+    private var queryRow: some View {
+        HStack(spacing: 0) {
+            ComposerQueryField(query: $composerStore.searchText, fontSize: Self.fieldFontSize) { event in
+                handle(event)
+            }
+            .frame(height: Self.fieldHeight)
+
+            Divider()
+                .frame(height: Self.fieldHeight * 0.5)
+
+            projectControl
+        }
+        .padding(.horizontal, 10)
+    }
+
+    @ViewBuilder
+    private var projectControl: some View {
+        let label = currentProject?.name ?? "Select project"
+
+        if isProjectLocked {
+            Text(label)
+                .font(.system(size: Self.rowFontSize, weight: .medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+        } else {
+            Button {
+                isProjectDropdownOpen = true
+            } label: {
+                HStack(spacing: 4) {
+                    Text(label)
+                        .font(.system(size: Self.rowFontSize, weight: .medium))
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .medium))
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $isProjectDropdownOpen, arrowEdge: .bottom) {
+                ProjectDropdownView(
+                    query: query,
+                    selectedProjectId: composerStore.selectedProjectId
+                ) { project in
+                    composerStore.selectedProjectId = project.id
+                    isProjectDropdownOpen = false
+                } onAddProject: {
+                    composerStore.addProjectViaPanel(workspaceStore: store)
+                    isProjectDropdownOpen = false
+                }
+                .environmentObject(store)
+            }
+        }
+    }
+
+    // MARK: - Footer: + New template…
+
+    @ViewBuilder
+    private var newTemplateRow: some View {
+        if isAddingTemplate {
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11))
+                    .frame(width: 16)
+                TextField("Template name", text: $newTemplateName)
+                    .font(.system(size: Self.rowFontSize, weight: .medium))
+                    .textFieldStyle(.plain)
+                    .focused($newTemplateNameFocused)
+                    .onSubmit { commitNewTemplate() }
+                    .onExitCommand { cancelNewTemplate() }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .onAppear {
+                DispatchQueue.main.async { newTemplateNameFocused = true }
+            }
+        } else {
+            Button {
+                newTemplateName = ""
+                isAddingTemplate = true
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 11))
+                        .frame(width: 16)
+                    Text("New template…")
+                        .font(.system(size: Self.rowFontSize, weight: .medium))
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+        }
+    }
+
+    private func commitNewTemplate() {
+        guard isAddingTemplate else { return }
+        isAddingTemplate = false
+        let trimmed = newTemplateName.trimmingCharacters(in: .whitespacesAndNewlines)
+        newTemplateName = ""
+        guard !trimmed.isEmpty else { return }
+        let template = store.addTemplate(AgentTemplate(name: trimmed, kind: .custom))
+        newTemplateToEdit = template
+    }
+
+    private func cancelNewTemplate() {
+        isAddingTemplate = false
+        newTemplateName = ""
+    }
+
+    // MARK: - Actions
+
+    private func commit(template: AgentTemplate) {
+        Task {
+            await composerStore.commit(template: template, coordinator: coordinator, workspaceStore: store)
+        }
+    }
+
+    /// Return commits the highlighted row and closes the composer.
+    /// Option+Return commits but keeps the composer open — a deliberate
+    /// interpretation of the brief's "⌥↵ needs Backport.onKeyPress"
+    /// constraint for rapid-fire session creation in the same project; Sean
+    /// hasn't specified the exact UX for this modifier, so this is a
+    /// reasonable default, not a locked decision.
+    private func handle(_ event: ComposerQueryField.KeyboardEvent) {
+        switch event {
+        case .exit:
+            isPresented = false
+
+        case .submit(let keepOpen):
+            guard let option = selectedOption else { break }
+            if !keepOpen {
+                isPresented = false
+            }
+            option.action()
+
+        case .move(.up):
+            if flattenedOptions.isEmpty { break }
+            let current = selectedIndex ?? UInt(flattenedOptions.count)
+            selectedIndex = (current == 0) ? UInt(flattenedOptions.count - 1) : current - 1
+
+        case .move(.down):
+            if flattenedOptions.isEmpty { break }
+            let current = selectedIndex ?? UInt.max
+            selectedIndex = (current >= UInt(flattenedOptions.count - 1)) ? 0 : current + 1
+
+        case .move:
+            break
+        }
+    }
+}
+
+// MARK: - ComposerOption
+
+/// Analog of `CommandOption` with an INJECTABLE id (derived from the
+/// underlying template/project id), fixing the churn `CommandOption.id =
+/// UUID()` causes on every keystroke recompute.
+struct ComposerOption: Identifiable, Hashable {
+    let id: UUID
+    let title: String
+    let subtitle: String?
+    let leadingIcon: String?
+    let action: () -> Void
+
+    static func == (lhs: ComposerOption, rhs: ComposerOption) -> Bool { lhs.id == rhs.id }
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}
+
+// MARK: - Query field
+
+/// The composer's search field. Forked from `CommandPaletteQuery` with two
+/// changes: the focus-loss auto-dismiss (`onChange(of: isTextFieldFocused)`
+/// calling `.exit`) is REMOVED — the project dropdown and
+/// `+ Add project…`'s `NSOpenPanel` both take first responder, and either
+/// would otherwise kill the composer mid-interaction (ship gate 2) — and
+/// submit goes through `Backport.onKeyPress` instead of `.onSubmit`, since
+/// `.onSubmit` carries no modifier info and ⌥↵ needs to be distinguishable
+/// from a plain Return.
+struct ComposerQueryField: View {
+    @Binding var query: String
+    var fontSize: CGFloat
+    var onEvent: ((KeyboardEvent) -> Void)?
+    @FocusState private var isTextFieldFocused: Bool
+
+    enum KeyboardEvent {
+        case exit
+        case submit(keepOpen: Bool)
+        case move(MoveCommandDirection)
+    }
+
+    var body: some View {
+        ZStack {
+            Group {
+                Button { onEvent?(.move(.up)) } label: { Color.clear }
+                    .buttonStyle(PlainButtonStyle())
+                    .keyboardShortcut(.upArrow, modifiers: [])
+                Button { onEvent?(.move(.down)) } label: { Color.clear }
+                    .buttonStyle(PlainButtonStyle())
+                    .keyboardShortcut(.downArrow, modifiers: [])
+
+                Button { onEvent?(.move(.up)) } label: { Color.clear }
+                    .buttonStyle(PlainButtonStyle())
+                    .keyboardShortcut(.init("p"), modifiers: [.control])
+                Button { onEvent?(.move(.down)) } label: { Color.clear }
+                    .buttonStyle(PlainButtonStyle())
+                    .keyboardShortcut(.init("n"), modifiers: [.control])
+            }
+            .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
+
+            TextField("Search templates and projects…", text: $query)
+                .padding(.vertical, 6)
+                .font(.system(size: fontSize, weight: .light))
+                .textFieldStyle(.plain)
+                .focused($isTextFieldFocused)
+                .onExitCommand { onEvent?(.exit) }
+                .onMoveCommand { onEvent?(.move($0)) }
+                .backport.onKeyPress(.return) { modifiers in
+                    onEvent?(.submit(keepOpen: modifiers.contains(.option)))
+                    return .handled
+                }
+                .onAppear {
+                    DispatchQueue.main.async {
+                        isTextFieldFocused = true
+                    }
+                }
+        }
+    }
+}
+
+// MARK: - Results table
+
+/// Forked from `CommandTable`, with two changes: it renders named sections
+/// (RECENT / TEMPLATES — `CommandPaletteView` has no section grouping at
+/// all) and it uses a plain `VStack`, never `LazyVStack` — this repo has a
+/// known bug class where `LazyVStack` never re-invokes `ForEach`'s content
+/// closure when an element changes but its `id` does not, which froze
+/// sidebar rows at first construction (PR #121).
+private struct ComposerResultsTable: View {
+    var sections: [(title: String?, options: [ComposerOption])]
+    var query: String
+    @Binding var selectedIndex: UInt?
+    @Binding var hoveredOptionID: UUID?
+    var rowFontSize: CGFloat
+    var subtitleFontSize: CGFloat
+    var sectionHeaderFontSize: CGFloat
+    var action: (ComposerOption) -> Void
+
+    private var flattened: [ComposerOption] {
+        sections.flatMap { $0.options }
+    }
+
+    var body: some View {
+        if flattened.isEmpty {
+            Text("No matches")
+                .font(.system(size: rowFontSize))
+                .foregroundStyle(.secondary)
+                .padding(12)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
+                            if !section.options.isEmpty {
+                                if let title = section.title {
+                                    Text(title)
+                                        .font(.system(size: sectionHeaderFontSize, weight: .semibold))
+                                        .foregroundStyle(.tertiary)
+                                        .padding(.horizontal, 4)
+                                        .padding(.top, 6)
+                                        .padding(.bottom, 2)
+                                }
+
+                                ForEach(section.options) { option in
+                                    ComposerRow(
+                                        option: option,
+                                        query: query,
+                                        isSelected: isSelected(option),
+                                        hoveredID: $hoveredOptionID,
+                                        titleFontSize: rowFontSize,
+                                        subtitleFontSize: subtitleFontSize
+                                    ) {
+                                        action(option)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(8)
+                }
+                .frame(maxHeight: 220)
+                .onChange(of: selectedIndex) { _ in
+                    guard let selectedIndex, selectedIndex < flattened.count else { return }
+                    proxy.scrollTo(flattened[Int(selectedIndex)].id)
+                }
+            }
+        }
+    }
+
+    private func isSelected(_ option: ComposerOption) -> Bool {
+        guard let selectedIndex, let index = flattened.firstIndex(where: { $0.id == option.id }) else { return false }
+        return Int(selectedIndex) == index || (Int(selectedIndex) >= flattened.count && index == flattened.count - 1)
+    }
+}
+
+/// Forked from `CommandRow`, resized to DESIGN.md's 11pt sidebar scale.
+/// Reuses `String.matchedIndices(for:)` (`CommandPalette.swift`,
+/// module-scope) for highlighting — redeclaring it would be a compile
+/// error.
+private struct ComposerRow: View {
+    let option: ComposerOption
+    var query: String
+    var isSelected: Bool
+    @Binding var hoveredID: UUID?
+    var titleFontSize: CGFloat
+    var subtitleFontSize: CGFloat
+    var action: () -> Void
+
+    private var highlightedTitle: Text {
+        guard !query.isEmpty, let indices = option.title.matchedIndices(for: query) else {
+            return Text(option.title).font(.system(size: titleFontSize, weight: .medium))
+        }
+
+        var attributed = AttributedString(option.title)
+        attributed[attributed.startIndex...].font = .system(size: titleFontSize, weight: .medium)
+
+        for idx in indices {
+            let offset = option.title.distance(from: option.title.startIndex, to: idx)
+            let attrStart = attributed.index(attributed.startIndex, offsetByCharacters: offset)
+            let attrEnd = attributed.index(attrStart, offsetByCharacters: 1)
+            attributed[attrStart..<attrEnd].font = .system(size: titleFontSize, weight: .bold)
+            attributed[attrStart..<attrEnd].foregroundColor = Color.accentColor
+        }
+
+        return Text(attributed)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if let icon = option.leadingIcon {
+                    Image(systemName: icon)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 16)
+                }
+
+                VStack(alignment: .leading, spacing: 1) {
+                    highlightedTitle
+
+                    if let subtitle = option.subtitle {
+                        Text(subtitle)
+                            .font(.system(size: subtitleFontSize))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+            .background(
+                isSelected
+                    ? Color.accentColor.opacity(0.2)
+                    : (hoveredID == option.id ? Color.secondary.opacity(0.2) : Color.clear)
+            )
+            .cornerRadius(5)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            hoveredID = hovering ? option.id : nil
+        }
+    }
+}
+
+// MARK: - Project dropdown
+
+/// The open project dropdown (Treatment 2's trailing `▾` control). Three-tier
+/// ordering, no visible headers: cascade pick (pre-selected) -> recently-used
+/// most-recent-first -> everything else alphabetically (locked decision).
+/// `+ Add project…` is always the last row.
+private struct ProjectDropdownView: View {
+    let query: String
+    let selectedProjectId: UUID?
+    var onSelect: (Project) -> Void
+    var onAddProject: () -> Void
+
+    @EnvironmentObject private var store: WorkspaceStore
+
+    private var orderedProjects: [Project] {
+        let recentIds = SessionComposerStore.shared.recentSelections.map { $0.projectId }
+        return SessionComposerProjectOrdering.order(
+            projects: store.projects,
+            cascadePick: selectedProjectId,
+            recentProjectIds: recentIds
+        )
+    }
+
+    private var filteredProjects: [Project] {
+        SessionComposerRanking.sorted(orderedProjects, query: query, title: { $0.name })
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(filteredProjects) { project in
+                    Button {
+                        onSelect(project)
+                    } label: {
+                        HStack(spacing: 6) {
+                            Text(project.name)
+                                .font(.system(size: 12, weight: project.id == selectedProjectId ? .semibold : .regular))
+                            Spacer()
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Divider().padding(.horizontal, 8).padding(.vertical, 2)
+
+                Button(action: onAddProject) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .medium))
+                            .frame(width: 14)
+                        Text("Add project…")
+                            .font(.system(size: 12, weight: .medium))
+                        Spacer()
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+            }
+            .padding(6)
+        }
+        .frame(width: 220)
+        .frame(maxHeight: 240)
+    }
+}

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -160,7 +160,11 @@ struct SessionComposerPalette: View {
     /// unfiltered. Selecting a row here sets the composer's selected
     /// project; it does not start a session.
     private var filteredProjectOptions: [ComposerOption] {
-        guard !query.isEmpty else { return [] }
+        // N3: `.locked` fixes the project at the write path (`commit()`
+        // resolves from the bound project, never `selectedProjectId`), so
+        // letting a project row re-scope the list here would show project B
+        // while `commit()` still creates in locked project A.
+        guard !isProjectLocked, !query.isEmpty else { return [] }
         let options = store.projects.map(makeOption)
         return SessionComposerRanking.sorted(options, query: query, title: { $0.title })
     }
@@ -272,23 +276,14 @@ struct SessionComposerPalette: View {
             // latches `SessionComposerStore.isOpen` true forever (B3).
             composerStore.cancel()
         }
-        .onChange(of: query) { _ in
-            // Clamp into range rather than nil-ing out — the old logic only
-            // reset when the index was exactly 0, so a stale index from a
-            // shrunk list (e.g. RECENT reordering after a commit) survived
-            // a query change untouched.
-            let count = flattenedOptions.count
-            guard count > 0 else {
-                selectedIndex = nil
-                return
-            }
-            if let current = selectedIndex {
-                if current >= UInt(count) {
-                    selectedIndex = UInt(count - 1)
-                }
-            } else {
-                selectedIndex = 0
-            }
+        .onChange(of: query) { _ in clampSelectedIndex() }
+        .onChange(of: composerStore.selectedProjectId) { _ in
+            // N5: changing the project via the dropdown or a project row
+            // changes `flattenedOptions.count` with `query` unchanged, so
+            // the query-only clamp above never ran — `selectedOption` fell
+            // back to `options.last` and the highlight silently jumped to
+            // the bottom of the list.
+            clampSelectedIndex()
         }
         .sheet(item: $newTemplateToEdit) { template in
             TemplateEditForm(template: template)
@@ -463,17 +458,51 @@ struct SessionComposerPalette: View {
 
     // MARK: - Actions
 
+    /// Clamp `selectedIndex` into range rather than nil-ing out — the old
+    /// logic only reset when the index was exactly 0, so a stale index from
+    /// a shrunk list (e.g. RECENT reordering after a commit) survived a
+    /// query or project change untouched. Shared by the `query` and
+    /// `selectedProjectId` triggers (N5) — either can change
+    /// `flattenedOptions.count`.
+    private func clampSelectedIndex() {
+        let count = flattenedOptions.count
+        guard count > 0 else {
+            selectedIndex = nil
+            return
+        }
+        if let current = selectedIndex {
+            if current >= UInt(count) {
+                selectedIndex = UInt(count - 1)
+            }
+        } else {
+            selectedIndex = 0
+        }
+    }
+
     private func commit(template: AgentTemplate) {
         // S1: reset the stale index up front. `recordRecent` (inside the
-        // store's commit) reorders RECENT, which would otherwise leave
+        // store's precommit) reorders RECENT, which would otherwise leave
         // `selectedIndex` pointing at the wrong row if the composer stays
-        // open on a failed commit (S6).
+        // open on a failed commit (S6). Synchronous and load-bearing (N1):
+        // it is what makes a double Return a no-op if both `.onSubmit` and
+        // `.onKeyPress` ever fire on macOS 14+.
         selectedIndex = nil
-        Task {
-            let success = await composerStore.commit(template: template, coordinator: coordinator, workspaceStore: store)
-            if success {
-                isPresented = false
-            }
+
+        // N1: `precommit` is synchronous — it validates, records the
+        // recent pair, and dispatches the actual session spawn from a
+        // detached `Task` it does not wait on. Dismissing here, on that
+        // synchronous result, is what keeps the popover from lingering
+        // over the newly-created session while `createQuickSession`
+        // resolves the binary path (a 3s-timeout shell-out).
+        let success = composerStore.precommit(template: template, coordinator: coordinator, workspaceStore: store)
+        if success {
+            isPresented = false
+        } else {
+            // N4: precommit failed — the composer stays open with
+            // `writeError` showing. `selectedIndex` was just nil'd above,
+            // so Return is dead until the user types or arrows; re-seed
+            // row 0 so Return works again immediately.
+            selectedIndex = 0
         }
     }
 
@@ -559,10 +588,12 @@ struct ComposerOption: Identifiable, Hashable {
 /// `Backport.onKeyPress` is a documented no-op below macOS 14
 /// (`Helpers/Backport.swift:53-68`) and the app's deployment target is
 /// 13.0, so `.onSubmit` alone is what makes Return work pre-14. If both
-/// fire on 14+, `SessionComposerStore.commit()`'s re-entry guard (`S9`)
-/// makes the second call a no-op rather than a double-commit — this repo
-/// cannot verify from source alone whether both actually fire, only that a
-/// double-fire would be harmless if they do.
+/// fire on 14+, `SessionComposerPalette.commit(template:)` nil-ing
+/// `selectedIndex` SYNCHRONOUSLY before calling
+/// `SessionComposerStore.precommit()` (N1) makes the second call's
+/// `selectedOption` nil and its `.submit` handler a no-op rather than a
+/// double-commit — this repo cannot verify from source alone whether both
+/// actually fire, only that a double-fire would be harmless if they do.
 struct ComposerQueryField: View {
     @Binding var query: String
     var fontSize: CGFloat
@@ -854,14 +885,11 @@ private struct ProjectDropdownView: View {
 
     @EnvironmentObject private var store: WorkspaceStore
 
-    /// Decoupled from the composer's search field (nit): this used to read
-    /// `SessionComposerStore.shared.searchText` directly, so typing
-    /// "claude" to find a template and then opening the dropdown showed
-    /// every project filtered out even though this view has no visible
-    /// search field of its own. Starts empty, unaffected by the composer's
-    /// query.
-    @State private var query: String = ""
-
+    // N6: this view has no search field of its own — the main composer
+    // field does the filtering (locked decision) — so a local `query`
+    // and a `filteredProjects` indirection over it were dead: always
+    // equal to `orderedProjects`. Removed rather than kept as unused
+    // scaffolding.
     private var orderedProjects: [Project] {
         let recentIds = SessionComposerStore.shared.recentProjectIds
         return SessionComposerProjectOrdering.order(
@@ -871,14 +899,10 @@ private struct ProjectDropdownView: View {
         )
     }
 
-    private var filteredProjects: [Project] {
-        SessionComposerRanking.sorted(orderedProjects, query: query, title: { $0.name })
-    }
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 2) {
-                ForEach(filteredProjects) { project in
+                ForEach(orderedProjects) { project in
                     Button {
                         onSelect(project)
                     } label: {
@@ -914,7 +938,7 @@ private struct ProjectDropdownView: View {
             }
             .padding(6)
         }
-        .frame(width: 220)
+        .frame(width: WorkspaceLayout.sidebarWidth)
         .frame(maxHeight: 240)
     }
 }

--- a/macos/Sources/Features/Ghostties/SessionComposerRanking.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerRanking.swift
@@ -23,38 +23,57 @@ enum SessionComposerRanking {
         }
     }
 
-    /// Returns the best tier `title` matches `query` at, or `nil` if it
-    /// doesn't match at all. Reuses `String.matchedIndices(for:)`
-    /// (`CommandPalette.swift`, module-scope) for the substring/initials
-    /// fallback so highlighting stays consistent with the inherited row
-    /// rendering.
-    static func matchTier(title: String, query: String) -> MatchTier? {
+    /// Returns the best tier `title` (or, failing that, `subtitle`) matches
+    /// `query` at, or `nil` if neither matches. Upstream `CommandPaletteView`
+    /// matches title OR subtitle (`CommandPalette.swift:78-79`) — without
+    /// this a template's command/description isn't searchable. Reuses
+    /// `String.matchedIndices(for:)` (`CommandPalette.swift`, module-scope)
+    /// for the substring/initials fallback so highlighting stays consistent
+    /// with the inherited row rendering.
+    static func matchTier(title: String, subtitle: String? = nil, query: String) -> MatchTier? {
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
 
-        if title.range(of: query, options: [.caseInsensitive, .anchored]) != nil {
+        let titleTier = rawMatchTier(for: title, query: query)
+        let subtitleTier = subtitle.flatMap { rawMatchTier(for: $0, query: query) }
+
+        switch (titleTier, subtitleTier) {
+        case let (t?, s?): return min(t, s)
+        case let (t?, nil): return t
+        case let (nil, s?): return s
+        case (nil, nil): return nil
+        }
+    }
+
+    private static func rawMatchTier(for text: String, query: String) -> MatchTier? {
+        if text.range(of: query, options: [.caseInsensitive, .anchored]) != nil {
             return .exactPrefix
         }
-        if title.range(of: query, options: .caseInsensitive) != nil {
+        if text.range(of: query, options: .caseInsensitive) != nil {
             return .substring
         }
         // At this point there's no substring match, so a non-nil result
         // from matchedIndices(for:) can only have come from its initials
         // fallback.
-        if title.matchedIndices(for: query) != nil {
+        if text.matchedIndices(for: query) != nil {
             return .initials
         }
         return nil
     }
 
-    /// Filters `items` to those matching `query` (by `title`) and sorts by
-    /// match tier, preserving each item's original relative order within
-    /// its tier (a stable partition, not a full sort). When `query` is
-    /// blank, returns `items` unfiltered and unreordered.
-    static func sorted<T>(_ items: [T], query: String, title: (T) -> String) -> [T] {
+    /// Filters `items` to those matching `query` (by `title` or `subtitle`)
+    /// and sorts by match tier, preserving each item's original relative
+    /// order within its tier (a stable partition, not a full sort). When
+    /// `query` is blank, returns `items` unfiltered and unreordered.
+    static func sorted<T>(
+        _ items: [T],
+        query: String,
+        title: (T) -> String,
+        subtitle: (T) -> String? = { _ in nil }
+    ) -> [T] {
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return items }
 
         let ranked: [(offset: Int, tier: MatchTier, item: T)] = items.enumerated().compactMap { offset, item in
-            guard let tier = matchTier(title: title(item), query: query) else { return nil }
+            guard let tier = matchTier(title: title(item), subtitle: subtitle(item), query: query) else { return nil }
             return (offset, tier, item)
         }
 

--- a/macos/Sources/Features/Ghostties/SessionComposerRanking.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerRanking.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Pure, testable relevance ranking + project ordering for the session
+/// composer (Phase 2 of session-creation-unified). Neither type touches
+/// SwiftUI or `@MainActor` state — they are plain functions over value
+/// types so the ship-gate behaviors that CAN be unit tested (gates 3 and 4)
+/// have real coverage.
+enum SessionComposerRanking {
+
+    /// Relevance tiers, best match first. `CommandPalette`'s inherited
+    /// `filteredOptions` only ever does a boolean match + color scoring —
+    /// this replaces that with an ordering where an exact prefix match
+    /// always outranks a substring match, which always outranks an
+    /// initials match (e.g. "cc" -> "Claude Code"). Color scoring is
+    /// dropped entirely for this surface (D11 in the plan).
+    enum MatchTier: Int, Comparable {
+        case exactPrefix
+        case substring
+        case initials
+
+        static func < (lhs: MatchTier, rhs: MatchTier) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    /// Returns the best tier `title` matches `query` at, or `nil` if it
+    /// doesn't match at all. Reuses `String.matchedIndices(for:)`
+    /// (`CommandPalette.swift`, module-scope) for the substring/initials
+    /// fallback so highlighting stays consistent with the inherited row
+    /// rendering.
+    static func matchTier(title: String, query: String) -> MatchTier? {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+
+        if title.range(of: query, options: [.caseInsensitive, .anchored]) != nil {
+            return .exactPrefix
+        }
+        if title.range(of: query, options: .caseInsensitive) != nil {
+            return .substring
+        }
+        // At this point there's no substring match, so a non-nil result
+        // from matchedIndices(for:) can only have come from its initials
+        // fallback.
+        if title.matchedIndices(for: query) != nil {
+            return .initials
+        }
+        return nil
+    }
+
+    /// Filters `items` to those matching `query` (by `title`) and sorts by
+    /// match tier, preserving each item's original relative order within
+    /// its tier (a stable partition, not a full sort). When `query` is
+    /// blank, returns `items` unfiltered and unreordered.
+    static func sorted<T>(_ items: [T], query: String, title: (T) -> String) -> [T] {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return items }
+
+        let ranked: [(offset: Int, tier: MatchTier, item: T)] = items.enumerated().compactMap { offset, item in
+            guard let tier = matchTier(title: title(item), query: query) else { return nil }
+            return (offset, tier, item)
+        }
+
+        return ranked
+            .sorted { lhs, rhs in
+                if lhs.tier != rhs.tier { return lhs.tier < rhs.tier }
+                return lhs.offset < rhs.offset
+            }
+            .map { $0.item }
+    }
+}
+
+/// The three-tier project dropdown ordering (locked decision, no visible
+/// section headers): cascade pick first (if present in `projects`), then
+/// recently-used most-recent-first, then everything else alphabetically.
+enum SessionComposerProjectOrdering {
+    static func order(
+        projects: [Project],
+        cascadePick: UUID?,
+        recentProjectIds: [UUID]
+    ) -> [Project] {
+        var seen = Set<UUID>()
+        var result: [Project] = []
+
+        if let cascadePick, let match = projects.first(where: { $0.id == cascadePick }) {
+            result.append(match)
+            seen.insert(match.id)
+        }
+
+        for id in recentProjectIds where !seen.contains(id) {
+            guard let match = projects.first(where: { $0.id == id }) else { continue }
+            result.append(match)
+            seen.insert(match.id)
+        }
+
+        let remaining = projects
+            .filter { !seen.contains($0.id) }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        result.append(contentsOf: remaining)
+
+        return result
+    }
+}

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -30,7 +30,7 @@ struct SessionComposerRequest {
 }
 
 /// A `(project, template)` pair recorded on commit, most-recent-first, for
-/// the composer's RECENT section. Persisted as JSON in `@AppStorage` since
+/// the composer's RECENT section. Persisted as JSON via `defaults` since
 /// `AppStorage` has no native support for `Codable` arrays.
 struct RecentComposerSelection: Codable, Equatable {
     let projectId: UUID
@@ -51,11 +51,21 @@ final class SessionComposerStore: ObservableObject {
 
     static let shared = SessionComposerStore()
 
-    private init() {}
+    /// The `UserDefaults` domain persisted state is read/written through.
+    /// Injectable so `isolatedForTesting:` gets a private domain instead of
+    /// silently writing real app state (`.standard`) — see that initializer.
+    private let defaults: UserDefaults
+
+    private init() {
+        self.defaults = .standard
+    }
 
     #if DEBUG
-    /// Test-only initialiser — isolated state, no singleton side-effects.
-    init(isolatedForTesting: Void) {}
+    /// Test-only initialiser — a private `UserDefaults` suite, no singleton
+    /// side-effects, and no risk of a test polluting real recents.
+    init(isolatedForTesting: Void) {
+        self.defaults = UserDefaults(suiteName: "ghostties.sessionComposerStore.test.\(UUID().uuidString)") ?? .standard
+    }
     #endif
 
     // MARK: - Visibility
@@ -72,16 +82,33 @@ final class SessionComposerStore: ObservableObject {
     @Published var selectedProjectId: UUID?
     @Published var searchText: String = ""
 
+    /// The binding this open() call was made with, retained so `commit()`
+    /// can enforce `.locked` at the write path even if `selectedProjectId`
+    /// has drifted (Phase 3 is the first caller that relies on `.locked`
+    /// meaning locked).
+    private(set) var currentProjectBinding: SessionComposerRequest.ProjectBinding = .open
+
     // MARK: - Error state
 
     @Published private(set) var writeError: String?
 
+    // MARK: - Re-entry guard
+
+    /// Guards `commit()` against a held Return landing twice before the
+    /// popover tears down asynchronously — mirrors
+    /// `TemplatePickerView.commitNewCustomTemplate`'s
+    /// `guard isAddingCustomTemplate else { return }` re-entry guard.
+    private var isCommitting = false
+
     // MARK: - Recent (project, template) pairs
 
-    @AppStorage("ghostties.sessionComposerRecentSelections")
-    private var recentSelectionsData: Data = Data()
-
+    private static let recentSelectionsKey = "ghostties.sessionComposerRecentSelections"
     private static let maxRecents = 3
+
+    private var recentSelectionsData: Data {
+        get { defaults.data(forKey: Self.recentSelectionsKey) ?? Data() }
+        set { defaults.set(newValue, forKey: Self.recentSelectionsKey) }
+    }
 
     var recentSelections: [RecentComposerSelection] {
         (try? JSONDecoder().decode([RecentComposerSelection].self, from: recentSelectionsData)) ?? []
@@ -98,19 +125,54 @@ final class SessionComposerStore: ObservableObject {
         recentSelectionsData = (try? JSONEncoder().encode(current)) ?? Data()
     }
 
+    // MARK: - Recent project ids (separate from `recentSelections`)
+
+    /// Deduped by PROJECT, most-recent-first, longer than `maxRecents` —
+    /// `recentSelections` is capped at 3 pairs and deduped on the pair, so a
+    /// user who runs three templates in one project fills all three slots
+    /// with that one project and the dropdown's "recently used" tier
+    /// degenerates to a single entry. This is the project-only MRU the
+    /// dropdown ordering and the smart-default cascade both read from.
+    private static let recentProjectIdsKey = "ghostties.sessionComposerRecentProjectIds"
+    private static let maxRecentProjects = 10
+
+    var recentProjectIds: [UUID] {
+        guard let strings = try? JSONDecoder().decode([String].self, from: recentProjectIdsData) else { return [] }
+        return strings.compactMap { UUID(uuidString: $0) }
+    }
+
+    private var recentProjectIdsData: Data {
+        get { defaults.data(forKey: Self.recentProjectIdsKey) ?? Data() }
+        set { defaults.set(newValue, forKey: Self.recentProjectIdsKey) }
+    }
+
+    private func recordRecentProject(_ projectId: UUID) {
+        var current = recentProjectIds
+        current.removeAll { $0 == projectId }
+        current.insert(projectId, at: 0)
+        if current.count > Self.maxRecentProjects {
+            current = Array(current.prefix(Self.maxRecentProjects))
+        }
+        recentProjectIdsData = (try? JSONEncoder().encode(current.map(\.uuidString))) ?? Data()
+    }
+
     // MARK: - Open / focus / cancel
 
-    /// Open the composer for `projectBinding`, or — if already open — focus
-    /// the existing search field instead of spawning a second instance
-    /// (D11, mirrors `NewTaskComposerStore.open`).
+    /// Open the composer for `projectBinding`. If already open, the reset
+    /// and binding are STILL re-applied (only the "second instance" early
+    /// exit is skipped) — otherwise a popover that was orphaned by its
+    /// hosting row leaving the hierarchy (project removed, sidebar
+    /// view-mode switch, `windowDidResignKey`/`mouseExited` closing the
+    /// popover without the row's `@State` transitioning) leaves `isOpen`
+    /// latched `true` forever, and the next open() for a DIFFERENT project
+    /// silently reuses the stale `selectedProjectId` (D3/D11 regression;
+    /// see also the `.onDisappear` teardown in `SessionComposerPalette`).
     func open(projectBinding: SessionComposerRequest.ProjectBinding, workspaceStore: WorkspaceStore) {
-        if isOpen {
-            focusSearchFieldTrigger = true
-            return
-        }
+        let wasOpen = isOpen
 
         searchText = ""
         writeError = nil
+        currentProjectBinding = projectBinding
 
         switch projectBinding {
         case .locked(let project), .prefilled(let project):
@@ -119,10 +181,15 @@ final class SessionComposerStore: ObservableObject {
             selectedProjectId = resolveDefaultProject(workspaceStore: workspaceStore)
         }
 
+        if wasOpen {
+            focusSearchFieldTrigger = true
+        }
         isOpen = true
     }
 
-    /// Close the composer without writing anything (Esc / cancel).
+    /// Close the composer without writing anything (Esc / cancel / popover
+    /// teardown). Idempotent — safe to call from `.onDisappear` even if
+    /// `cancel()` already ran via `onChange(of: isPresented)`.
     func cancel() {
         isOpen = false
         searchText = ""
@@ -135,33 +202,61 @@ final class SessionComposerStore: ObservableObject {
     /// This is the ONLY write path — it calls
     /// `coordinator.createQuickSession(for:template:)` and nothing else
     /// (ship gate 5).
+    ///
+    /// Returns `true` once the project has been validated and the session
+    /// creation call has been dispatched, `false` if the pre-check failed
+    /// (`writeError` is set in that case and the caller must NOT dismiss —
+    /// dismissing before this returns is exactly the bug where the popover
+    /// vanished with no session and no visible message).
+    @discardableResult
     func commit(
         template: AgentTemplate,
         coordinator: SessionCoordinator,
         workspaceStore: WorkspaceStore
-    ) async {
-        guard let projectId = selectedProjectId,
+    ) async -> Bool {
+        guard !isCommitting else { return false }
+        isCommitting = true
+        defer { isCommitting = false }
+
+        // `.locked` enforces at the write path — resolved from the bound
+        // project, never from `selectedProjectId` — so the enum case isn't
+        // decorative once Phase 3 starts relying on it. `.prefilled`/`.open`
+        // resolve from `selectedProjectId` as before, since the user is
+        // allowed to change the project for those bindings.
+        let resolvedProjectId: UUID?
+        if case .locked(let lockedProject) = currentProjectBinding {
+            resolvedProjectId = lockedProject.id
+        } else {
+            resolvedProjectId = selectedProjectId
+        }
+
+        guard let projectId = resolvedProjectId,
               let project = workspaceStore.projects.first(where: { $0.id == projectId }) else {
             writeError = "Selected project no longer exists."
-            return
+            return false
         }
 
         writeError = nil
         recordRecent(projectId: projectId, templateId: template.id)
+        recordRecentProject(projectId)
         isOpen = false
         searchText = ""
 
         _ = await coordinator.createQuickSession(for: project, template: template)
+        return true
     }
 
     // MARK: - Add project via NSOpenPanel
 
     /// Invoked from the open project dropdown's "+ Add project…" row.
-    /// Opens `NSOpenPanel`, adds the project, and auto-selects it, without
-    /// closing the composer (ship gate 2).
+    /// Opens `NSOpenPanel`, adds the project, auto-selects it, and records
+    /// it as the most-recent project so it becomes the cascade default
+    /// (mirrors `NewTaskComposerStore.addProjectViaPanel` setting
+    /// `mruProjectId`) — without closing the composer (ship gate 2).
     func addProjectViaPanel(workspaceStore: WorkspaceStore) {
         guard let newId = workspaceStore.addProjectViaFolderPicker() else { return }
         selectedProjectId = newId
+        recordRecentProject(newId)
     }
 
     // MARK: - Smart-default cascade
@@ -180,7 +275,7 @@ final class SessionComposerStore: ObservableObject {
             return cwdMatch
         }
 
-        if let mru = recentSelections.first?.projectId, projects.contains(where: { $0.id == mru }) {
+        if let mru = recentProjectIds.first, projects.contains(where: { $0.id == mru }) {
             return mru
         }
 

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -92,14 +92,6 @@ final class SessionComposerStore: ObservableObject {
 
     @Published private(set) var writeError: String?
 
-    // MARK: - Re-entry guard
-
-    /// Guards `commit()` against a held Return landing twice before the
-    /// popover tears down asynchronously — mirrors
-    /// `TemplatePickerView.commitNewCustomTemplate`'s
-    /// `guard isAddingCustomTemplate else { return }` re-entry guard.
-    private var isCommitting = false
-
     // MARK: - Recent (project, template) pairs
 
     private static let recentSelectionsKey = "ghostties.sessionComposerRecentSelections"
@@ -217,16 +209,16 @@ final class SessionComposerStore: ObservableObject {
     /// (`writeError` is set in that case and the caller must NOT dismiss —
     /// dismissing before this returns is exactly the bug where the popover
     /// vanished with no session and no visible message).
+    ///
+    /// Double-Return protection lives in `SessionComposerPalette.commit(template:)`'s
+    /// synchronous `selectedIndex = nil` (see that function), not here —
+    /// this function has no suspension point for a second call to land in.
     @discardableResult
     func precommit(
         template: AgentTemplate,
         coordinator: SessionCoordinator,
         workspaceStore: WorkspaceStore
     ) -> Bool {
-        guard !isCommitting else { return false }
-        isCommitting = true
-        defer { isCommitting = false }
-
         // `.locked` enforces at the write path — resolved from the bound
         // project, never from `selectedProjectId` — so the enum case isn't
         // decorative once Phase 3 starts relying on it. `.prefilled`/`.open`

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -198,10 +198,19 @@ final class SessionComposerStore: ObservableObject {
 
     // MARK: - Commit
 
-    /// Validate, create the session, record the recent pair, and close.
-    /// This is the ONLY write path — it calls
-    /// `coordinator.createQuickSession(for:template:)` and nothing else
-    /// (ship gate 5).
+    /// Validate and record the recent pair, SYNCHRONOUSLY, then dispatch
+    /// session creation without waiting on it. This is the ONLY write path
+    /// — it calls `coordinator.createQuickSession(for:template:)` and
+    /// nothing else (ship gate 5).
+    ///
+    /// Split from a single `async` `commit()` (N1): the prior shape awaited
+    /// `createQuickSession`, which shells out to resolve the binary path
+    /// with a 3-second timeout — so the view stayed presented for up to 3s
+    /// after the query had already blanked and the new session was already
+    /// showing behind the still-open composer. The pre-check below is the
+    /// only part that can still fail with something to show on screen
+    /// (`writeError`), so it is what the view dismisses on; the spawn is
+    /// fired from a detached `Task` the view does not await.
     ///
     /// Returns `true` once the project has been validated and the session
     /// creation call has been dispatched, `false` if the pre-check failed
@@ -209,11 +218,11 @@ final class SessionComposerStore: ObservableObject {
     /// dismissing before this returns is exactly the bug where the popover
     /// vanished with no session and no visible message).
     @discardableResult
-    func commit(
+    func precommit(
         template: AgentTemplate,
         coordinator: SessionCoordinator,
         workspaceStore: WorkspaceStore
-    ) async -> Bool {
+    ) -> Bool {
         guard !isCommitting else { return false }
         isCommitting = true
         defer { isCommitting = false }
@@ -242,7 +251,16 @@ final class SessionComposerStore: ObservableObject {
         isOpen = false
         searchText = ""
 
-        _ = await coordinator.createQuickSession(for: project, template: template)
+        // N2: fire-and-forget from here on. The composer is already
+        // dismissed by the time this runs, so a genuine spawn failure
+        // (`ghostty.app` nil, CEF-init failure for browser templates) has
+        // no composer left to surface it into. This is exactly the
+        // existing Option-click instant-create path's behaviour today —
+        // the composer is at parity, not newly regressed.
+        Task.detached { [coordinator] in
+            _ = await coordinator.createQuickSession(for: project, template: template)
+        }
+
         return true
     }
 

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -1,0 +1,210 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+/// Describes how a `SessionComposerPalette` was invoked (Phase 2 of
+/// session-creation-unified). Nothing else parameterizes the composer.
+struct SessionComposerRequest {
+    /// How the composer is presented. Only `.anchored` (the sidebar
+    /// popover) is built in Phase 2 — `.centered` is declared now so the
+    /// type is stable, but Phase 3 is the first caller to actually use it.
+    enum Presentation {
+        case anchored
+        case centered
+    }
+
+    /// How the project is bound at open time.
+    enum ProjectBinding {
+        /// The project is fixed and cannot be changed from inside the
+        /// composer (the sidebar's per-project "+ New Session").
+        case locked(Project)
+        /// The project starts pre-selected but the user can change it via
+        /// the trailing dropdown.
+        case prefilled(Project)
+        /// No project pre-selected — the smart-default cascade decides.
+        case open
+    }
+
+    let presentation: Presentation
+    let projectBinding: ProjectBinding
+}
+
+/// A `(project, template)` pair recorded on commit, most-recent-first, for
+/// the composer's RECENT section. Persisted as JSON in `@AppStorage` since
+/// `AppStorage` has no native support for `Codable` arrays.
+struct RecentComposerSelection: Codable, Equatable {
+    let projectId: UUID
+    let templateId: UUID
+}
+
+/// State machine and commit logic for the session composer (Phase 2,
+/// D3/D11). Mirrors `NewTaskComposerStore`'s shape deliberately — same
+/// singleton pattern, same open/focus/cancel vocabulary — but it is a
+/// separate type: the composer commits by calling
+/// `SessionCoordinator.createQuickSession(for:template:)`, it never writes
+/// a `.md` task file, and it has no title field (an unpinned session's name
+/// is its live terminal title — locked decision, never re-add one).
+@MainActor
+final class SessionComposerStore: ObservableObject {
+
+    // MARK: - Shared instance
+
+    static let shared = SessionComposerStore()
+
+    private init() {}
+
+    #if DEBUG
+    /// Test-only initialiser — isolated state, no singleton side-effects.
+    init(isolatedForTesting: Void) {}
+    #endif
+
+    // MARK: - Visibility
+
+    @Published private(set) var isOpen: Bool = false
+
+    /// When true, the search field should receive first responder on the
+    /// next render cycle. Cleared by the view after the focus request is
+    /// consumed. Mirrors `NewTaskComposerStore.focusTitleFieldTrigger`.
+    @Published var focusSearchFieldTrigger: Bool = false
+
+    // MARK: - Field state
+
+    @Published var selectedProjectId: UUID?
+    @Published var searchText: String = ""
+
+    // MARK: - Error state
+
+    @Published private(set) var writeError: String?
+
+    // MARK: - Recent (project, template) pairs
+
+    @AppStorage("ghostties.sessionComposerRecentSelections")
+    private var recentSelectionsData: Data = Data()
+
+    private static let maxRecents = 3
+
+    var recentSelections: [RecentComposerSelection] {
+        (try? JSONDecoder().decode([RecentComposerSelection].self, from: recentSelectionsData)) ?? []
+    }
+
+    private func recordRecent(projectId: UUID, templateId: UUID) {
+        var current = recentSelections
+        let entry = RecentComposerSelection(projectId: projectId, templateId: templateId)
+        current.removeAll { $0 == entry }
+        current.insert(entry, at: 0)
+        if current.count > Self.maxRecents {
+            current = Array(current.prefix(Self.maxRecents))
+        }
+        recentSelectionsData = (try? JSONEncoder().encode(current)) ?? Data()
+    }
+
+    // MARK: - Open / focus / cancel
+
+    /// Open the composer for `projectBinding`, or — if already open — focus
+    /// the existing search field instead of spawning a second instance
+    /// (D11, mirrors `NewTaskComposerStore.open`).
+    func open(projectBinding: SessionComposerRequest.ProjectBinding, workspaceStore: WorkspaceStore) {
+        if isOpen {
+            focusSearchFieldTrigger = true
+            return
+        }
+
+        searchText = ""
+        writeError = nil
+
+        switch projectBinding {
+        case .locked(let project), .prefilled(let project):
+            selectedProjectId = project.id
+        case .open:
+            selectedProjectId = resolveDefaultProject(workspaceStore: workspaceStore)
+        }
+
+        isOpen = true
+    }
+
+    /// Close the composer without writing anything (Esc / cancel).
+    func cancel() {
+        isOpen = false
+        searchText = ""
+        writeError = nil
+    }
+
+    // MARK: - Commit
+
+    /// Validate, create the session, record the recent pair, and close.
+    /// This is the ONLY write path — it calls
+    /// `coordinator.createQuickSession(for:template:)` and nothing else
+    /// (ship gate 5).
+    func commit(
+        template: AgentTemplate,
+        coordinator: SessionCoordinator,
+        workspaceStore: WorkspaceStore
+    ) async {
+        guard let projectId = selectedProjectId,
+              let project = workspaceStore.projects.first(where: { $0.id == projectId }) else {
+            writeError = "Selected project no longer exists."
+            return
+        }
+
+        writeError = nil
+        recordRecent(projectId: projectId, templateId: template.id)
+        isOpen = false
+        searchText = ""
+
+        _ = await coordinator.createQuickSession(for: project, template: template)
+    }
+
+    // MARK: - Add project via NSOpenPanel
+
+    /// Invoked from the open project dropdown's "+ Add project…" row.
+    /// Opens `NSOpenPanel`, adds the project, and auto-selects it, without
+    /// closing the composer (ship gate 2).
+    func addProjectViaPanel(workspaceStore: WorkspaceStore) {
+        guard let newId = workspaceStore.addProjectViaFolderPicker() else { return }
+        selectedProjectId = newId
+    }
+
+    // MARK: - Smart-default cascade
+
+    /// Same three-step cascade as `NewTaskComposerStore.resolveDefaultProject`
+    /// (cwd of the frontmost terminal -> MRU -> most-recently-touched).
+    /// Duplicated rather than shared: `NewTaskComposerStore` is a boundary
+    /// file for this phase (it commits a `.md` task file the session
+    /// composer must never touch), so its cascade is private and not
+    /// reachable from here without editing that file.
+    private func resolveDefaultProject(workspaceStore: WorkspaceStore) -> UUID? {
+        let projects = workspaceStore.projects
+        guard !projects.isEmpty else { return nil }
+
+        if let cwdMatch = resolveFromFrontmostTerminal(projects: projects) {
+            return cwdMatch
+        }
+
+        if let mru = recentSelections.first?.projectId, projects.contains(where: { $0.id == mru }) {
+            return mru
+        }
+
+        let sorted = projects.sorted {
+            switch ($0.lastActiveAt, $1.lastActiveAt) {
+            case let (a?, b?): return a > b
+            case (_?, nil): return true
+            default: return false
+            }
+        }
+        return sorted.first?.id
+    }
+
+    private func resolveFromFrontmostTerminal(projects: [Project]) -> UUID? {
+        guard let keyWindow = NSApp.keyWindow else { return nil }
+        let windowTitle = keyWindow.title
+
+        for project in projects {
+            let rootURL = URL(fileURLWithPath: project.rootPath)
+            let basename = rootURL.lastPathComponent
+            if windowTitle == basename || windowTitle.hasPrefix(project.rootPath) {
+                return project.id
+            }
+        }
+        return nil
+    }
+}

--- a/macos/Tests/Ghostties/SessionComposerRankingTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerRankingTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import Ghostty
+
+/// Tests for the two pure, testable pieces of the session composer's
+/// behavior (Phase 2): prefix-first relevance ranking (ship gate 3) and the
+/// three-tier project dropdown ordering (ship gate 4). Neither type touches
+/// SwiftUI or `@MainActor` state.
+final class SessionComposerRankingTests: XCTestCase {
+
+    // MARK: - matchTier
+
+    func testMatchTierExactPrefixOutranksSubstring() {
+        XCTAssertEqual(SessionComposerRanking.matchTier(title: "Claude Code", query: "cl"), .exactPrefix)
+        XCTAssertEqual(SessionComposerRanking.matchTier(title: "Reclaude", query: "cl"), .substring)
+    }
+
+    func testMatchTierSubstringOutranksInitials() {
+        // "cc" is not a substring of "Claude Code" but matches its initials.
+        XCTAssertEqual(SessionComposerRanking.matchTier(title: "Claude Code", query: "cc"), .initials)
+        // "cc" is a substring of "accumulate" without being a prefix.
+        XCTAssertEqual(SessionComposerRanking.matchTier(title: "accumulate", query: "cc"), .substring)
+    }
+
+    func testMatchTierIsCaseInsensitive() {
+        XCTAssertEqual(SessionComposerRanking.matchTier(title: "Claude Code", query: "CL"), .exactPrefix)
+    }
+
+    func testMatchTierNilWhenNoMatch() {
+        XCTAssertNil(SessionComposerRanking.matchTier(title: "Claude Code", query: "zzz"))
+    }
+
+    func testMatchTierNilForBlankQuery() {
+        XCTAssertNil(SessionComposerRanking.matchTier(title: "Claude Code", query: "   "))
+    }
+
+    // MARK: - sorted(_:query:title:) — the "type a prefix, Return always starts that session" gate
+
+    func testSortedRanksExactPrefixFirstRegardlessOfInputOrder() {
+        // "blue" must not surface rows by dot color (the defect this
+        // replaces) — none of these have any color association at all,
+        // and the exact-prefix match must still win.
+        let items = ["Background Worker", "Blueprint", "Blue Ghost Shell"]
+        let result = SessionComposerRanking.sorted(items, query: "blue", title: { $0 })
+        XCTAssertEqual(result.first, "Blueprint")
+    }
+
+    func testSortedPreservesOriginalOrderWithinATier() {
+        let items = ["Bravo", "Beta", "Bango"]
+        let result = SessionComposerRanking.sorted(items, query: "b", title: { $0 })
+        // All three are exact-prefix matches on "b" — original order
+        // (stable partition, not a re-sort) must be preserved.
+        XCTAssertEqual(result, ["Bravo", "Beta", "Bango"])
+    }
+
+    func testSortedDropsNonMatches() {
+        let items = ["Claude Code", "Shell", "Browser"]
+        let result = SessionComposerRanking.sorted(items, query: "claude", title: { $0 })
+        XCTAssertEqual(result, ["Claude Code"])
+    }
+
+    func testSortedReturnsInputUnchangedForBlankQuery() {
+        let items = ["Zed", "Alpha", "Middle"]
+        XCTAssertEqual(SessionComposerRanking.sorted(items, query: "", title: { $0 }), items)
+    }
+
+    // MARK: - SessionComposerProjectOrdering — the three-tier gate
+
+    func testOrderPutsCascadePickFirst() {
+        let a = Project(name: "Alpha", rootPath: "/a")
+        let b = Project(name: "Beta", rootPath: "/b")
+        let c = Project(name: "Gamma", rootPath: "/c")
+
+        let result = SessionComposerProjectOrdering.order(
+            projects: [a, b, c],
+            cascadePick: c.id,
+            recentProjectIds: []
+        )
+
+        XCTAssertEqual(result.map(\.id), [c.id, a.id, b.id])
+    }
+
+    func testOrderPutsRecentlyUsedBeforeAlphabeticalTail() {
+        let a = Project(name: "Alpha", rootPath: "/a")
+        let b = Project(name: "Beta", rootPath: "/b")
+        let c = Project(name: "Gamma", rootPath: "/c")
+
+        // No cascade pick. Beta was used most recently, then Gamma.
+        // Alpha (alphabetically first) must still fall to the tail.
+        let result = SessionComposerProjectOrdering.order(
+            projects: [a, b, c],
+            cascadePick: nil,
+            recentProjectIds: [b.id, c.id]
+        )
+
+        XCTAssertEqual(result.map(\.id), [b.id, c.id, a.id])
+    }
+
+    func testOrderTailIsAlphabeticalOnceCascadeAndRecentAreExcluded() {
+        let a = Project(name: "Zebra", rootPath: "/z")
+        let b = Project(name: "Alpha", rootPath: "/a")
+        let c = Project(name: "Mango", rootPath: "/m")
+
+        let result = SessionComposerProjectOrdering.order(
+            projects: [a, b, c],
+            cascadePick: nil,
+            recentProjectIds: []
+        )
+
+        XCTAssertEqual(result.map(\.name), ["Alpha", "Mango", "Zebra"])
+    }
+
+    func testOrderDoesNotDuplicateACascadePickThatIsAlsoRecent() {
+        let a = Project(name: "Alpha", rootPath: "/a")
+        let b = Project(name: "Beta", rootPath: "/b")
+
+        let result = SessionComposerProjectOrdering.order(
+            projects: [a, b],
+            cascadePick: a.id,
+            recentProjectIds: [a.id, b.id]
+        )
+
+        XCTAssertEqual(result.map(\.id), [a.id, b.id])
+    }
+
+    func testOrderIgnoresRecentIdsNotInTheProjectList() {
+        let a = Project(name: "Alpha", rootPath: "/a")
+        let staleId = UUID()
+
+        let result = SessionComposerProjectOrdering.order(
+            projects: [a],
+            cascadePick: nil,
+            recentProjectIds: [staleId]
+        )
+
+        XCTAssertEqual(result.map(\.id), [a.id])
+    }
+}

--- a/macos/Tests/Ghostties/SessionComposerRankingTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerRankingTests.swift
@@ -63,6 +63,26 @@ final class SessionComposerRankingTests: XCTestCase {
         XCTAssertEqual(SessionComposerRanking.sorted(items, query: "", title: { $0 }), items)
     }
 
+    /// The regression `testSortedRanksExactPrefixFirstRegardlessOfInputOrder`
+    /// was named for but didn't exercise: the loser there is dropped as a
+    /// non-match, so the comparator's `lhs.tier != rhs.tier` branch never
+    /// runs. Here both items match, a substring match precedes a prefix
+    /// match in input order, and the tier must still win.
+    func testSortedRanksExactPrefixBeforeSubstringWhenSubstringComesFirstInInputOrder() {
+        let items = ["Reclaude", "Claude Code"]
+        let result = SessionComposerRanking.sorted(items, query: "cl", title: { $0 })
+        XCTAssertEqual(result, ["Claude Code", "Reclaude"])
+    }
+
+    /// Same tier-reordering gate, one level down: a substring match must
+    /// outrank an initials match even when the initials match comes first
+    /// in input order.
+    func testSortedRanksSubstringBeforeInitialsWhenInitialsComesFirstInInputOrder() {
+        let items = ["Claude Code", "accumulate"]
+        let result = SessionComposerRanking.sorted(items, query: "cc", title: { $0 })
+        XCTAssertEqual(result, ["accumulate", "Claude Code"])
+    }
+
     // MARK: - SessionComposerProjectOrdering — the three-tier gate
 
     func testOrderPutsCascadePickFirst() {


### PR DESCRIPTION
**Stacked on #129 — merge that first.** Base branch is `feat/session-template-resolver`, not `main`.
Merge bottom-up and rebase this after #129 lands; squash-merge plus stacked PRs conflict in this
repo (`reference_stacked-pr-squash-merge-conflict.md`).

Phase 2 of `docs/plans/session-creation-unified.html`. A Spotlight-style session composer replaces
the template list in the sidebar's `+ New Session` popover. Fixes **D3** and **D11**.

## What changed

**`SessionComposerPalette`** — a forked copy of upstream's `CommandPalette.swift`, renamed and
parameterized. `CommandPalette.swift` itself is **untouched**: its diff against upstream is 2 lines
and editing it in place would have converted a zero-conflict file into a permanent rebase liability.
Inherited free: keyboard nav with wraparound, selection clamping, initials-match highlighting,
scroll-to-selection. Added: RECENT / PROJECTS / TEMPLATES sections (upstream's list is flat), and
prefix-first relevance ranking, which is *not* inherited — upstream ranks by substring match then
dot colour, so typing "blue" surfaced rows by colour.

**`SessionComposerStore`** — mirrors `NewTaskComposerStore`'s shape. Templates come from Phase 1's
`SessionTemplateResolver`.

**D3 — Option-key polarity inverted.** A plain click now opens the composer; Option-click keeps the
old instant-create. The modifier should be the shortcut, not the escape hatch.

**D11 — type scale.** The forked palette's proportions were system-Spotlight scale (20pt field,
`maxWidth: 500`). Brought to `DESIGN.md`'s sidebar scale: 11pt field, width pinned to
`WorkspaceLayout.sidebarWidth`.

## One plan contradiction I had to resolve

The plan wires `.locked(project)` as Phase 2's only call site, **and** gates Phase 2 on the project
dropdown's behaviour. Those can't both hold: under `.locked` the trailing control never renders, so
the dropdown, `+ Add project…`, and the whole three-tier ordering were unreachable — two ship gates
describing behaviour no code path could produce.

Resolved to **`.prefilled(project)`**: the clicked project is pre-selected and the control stays
live. That matches the approved Treatment 2 mock, which shows a `▾` opening a project list — a
locked composer with a dead chevron contradicts the design. `.locked` stays in the enum for Phase 3.

## Review — four rounds, first three all DO-NOT-SHIP

Between them, four blockers. Three were in the original build:

- **Return was dead in the shipped build.** The fork routed Return solely through
  `Backport.onKeyPress`, which is explicitly a no-op below macOS 14 — and this app's
  `MACOSX_DEPLOYMENT_TARGET` is **13.0**. On the minimum supported OS, typing a prefix and pressing
  Return did nothing. `.onSubmit` restored alongside it.
- **`isOpen` could latch true forever.** It was cleared only via `onChange(of: isPresented)`, but
  that binding is row-local `@State` that gets *destroyed* rather than flipped — by
  `windowDidResignKey`, by `mouseExited`, by a sidebar tab switch, by row recycling. Once stranded,
  every later `+ New Session` early-returned and created the session **in the previous project**.
  Fixed by always re-applying the binding and adding `.onDisappear`.
- **The composer silently deleted template management.** `TemplatePickerView` ended up with zero
  callers, so Edit, Duplicate, Delete and "Edit Preset File…" became unreachable — there was no way
  to delete a template anywhere in the app. The context menu is now ported onto composer rows, with
  the in-use-aware delete confirmation.

Plus ten should-fixes, the sharpest being that the **three-tier project ordering collapsed to two
tiers**: tier 2 derived project-MRU from the `(project, template)` recents list, capped at three, so
running three templates in one project filled every slot with that one project. Now backed by a
separate project-MRU.

The fourth blocker was **introduced by the fix pass itself**, and traces to an instruction of mine
that was too broad. Asking for "don't dismiss when the commit fails" made dismissal `await` the
whole session spawn — which resolves the binary path by shelling out with a **3-second timeout**. So
Return blanked the query immediately, the terminal flipped to the new session *behind* the
still-open composer, and the popover dismissed up to three seconds later; a second click in that
window silently did nothing. Now split into a synchronous `precommit()` the view dismisses on, plus
a detached `Task` for the spawn.

## Tests

**726 passed / 2 failed / 1 skipped** (729 total), read from the result bundle — raw `xcodebuild`
log lines carry a constant −49 offset in this repo. +16 over Phase 1's 710.

The 2 failures are pre-existing and not from this branch: `ThrottleTrailingEdgeHypothesisTests`, an
untracked file another session left in the shared worktree that Xcode's synchronized groups compile
anyway. It fails identically on `main`.

**Worth knowing what those tests do and don't cover.** All 16 new tests exercise the pure ranking
and ordering functions. **Nothing covers the commit path** — `precommit`, the dismissal, the
selection reset. That is where all four blockers lived, and it is SwiftUI view state, which is why
it went untested rather than because it was overlooked. The four review rounds are doing the work a
test suite would otherwise do here.

## What is NOT verified — please read before merging

Screen capture is TCC-denied in this environment (`screencapture` returns "could not create image
from display"), so **there are no screenshots and nothing here was observed running.** Everything
above is verified by code inspection and unit tests. Three things specifically cannot be settled by
reading, and want a few minutes of clicking:

1. **The project dropdown is a `.popover` nested inside the composer's `.popover`.** On macOS a
   child popover taking key can dismiss the parent. Removing the text-field-blur handler fixes
   blur-dismissal but not key-loss dismissal. Open the dropdown and confirm the composer survives.
2. **`+ Add project…` opens a modal `NSOpenPanel`** from inside that nested popover. Same class of
   risk, one layer deeper.
3. **The template edit sheet is presented from inside a popover.** Same key-window question.

If any of the three dismisses the composer, it's a Phase 3 problem — the centered overlay presents
from the window rather than a popover, which sidesteps the whole class.

## Deliberate omissions, flagged not hidden

- **The preset preview card was not ported.** A preview-on-tap card fights the composer's
  type-and-Return model. Consequence: `ghostties.skipPresetPreview` is now an orphaned `@AppStorage`
  key, and presets launch immediately for everyone regardless of its stored value.
- **⌥↵ is currently identical to ↵.** The plan's legend says "start + reveal"; whether "reveal" is
  distinguishable depends on whether `createQuickSession` already focuses the new session. Called
  out in review rather than faked.
- **`isCommitting` is now vestigial.** After the `precommit()` split it is set and cleared inside
  one synchronous call, so it can never be observed by a second caller. The real double-Return
  protection is the synchronous `selectedIndex = nil`. Harmless, but it reads as a guard that isn't.
- **The smart-default cascade is duplicated** (~25 lines) rather than shared, because it is private
  to `NewTaskComposerStore` and that file was out of bounds. Verified line-by-line as a faithful
  copy, not a drift. Filed to `BACKLOG.md`.
