### PR TITLE
Session composer Phase 3: centered overlay, Cmd+T preference, toolbar cascade removal

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -959,3 +959,25 @@ Sidebar/UX wave night. Ten PRs merged: the six-PR overnight wave (#96, #100, #10
 - [ ] **`duplicateTemplate` drops `mcpConfigPath`.** The memberwise copy in `WorkspaceStore.duplicateTemplate` omits `mcpConfigPath`, directly beneath its own `NOTE: Update this if AgentTemplate gains new stored properties.` Duplicating a folder-format preset silently loses its MCP config. Pre-existing on `main`, not introduced by Phase 1. | app | new
 - [ ] **Name-collision rename has no user feedback.** Typing an existing template name now silently yields "X 2", and correcting it back in the edit sheet silently keeps "X 2". Correct per the locked spec, but it dead-ends with no message. Wants one line under the name field: "A template named X already exists." | app | new
 - [ ] **Untracked `ThrottleTrailingEdgeHypothesisTests.swift` pollutes every local test run.** It sits untracked in the shared worktree, Xcode's synchronized groups compile it anyway, and 2 of its 4 tests fail by design — so a local unfiltered run reads 696/2/1 instead of the committed tree's 694/0/1. Decide whether it lands, moves, or goes. | build | new
+
+## 2026-08-19 — Session-composer Phase 3 (carried + parked)
+
+**Carried — on-objective, next thread picks these up:**
+
+- [ ] **Merge PR #131 (Phase 3)** — merge-ready at `ffb030c8d`, 3 review rounds + final pass, 11 defects fixed, suite 786/2/1. Gated on Sean's two manual checks: (1) Cmd+T then type 3 chars without clicking — does focus land in the field or in the shell behind the scrim; (2) row popover open → Cmd+T — does the composer survive. Neither is settleable by source-tracing. | app | new
+- [ ] **Phase 4 — project-creation convergence** — one `addProjectViaFolderPicker(startingAt:)` signature with a persisted `@AppStorage` last-used path + real `panel.title` (D10), used by all four callers (`WorkspaceSidebarView.swift:220`, `NewTaskComposerStore.swift:162`, `OrphanTriageStore.swift:104`, `OrphanTriageCardView.swift:137` — miss one and it keeps its own behavior); header add chains into the composer at `.locked(newProject)`; `WorkspaceViewContainer.swift:807`'s `projects.first` replaced with the composer's resolver. Branch off `main` AFTER #131 lands. | app | new
+- [ ] **Phase 5 — stop force-pinning** (optional) — drop the force-pin at `WorkspaceStore.swift:638` and `SessionCoordinator.swift:491`. Held separate because it visibly reorders existing sidebars on upgrade. Taste call, Sean's. | design | new
+
+**Merge-order hazard — check before merging anything:**
+
+- [ ] **`backlog/migrate-ghostties` branches off Phase 3's `eea7f3992`** — so it carries Phase 3's first two commits as ancestors. If it merges to `main` before #131, it silently drags unreviewed Phase 3 code onto main. Merge #131 first, or rebase that branch onto main. Belongs to a sibling session — do not rewrite it. | build | new
+
+**Parked — Phase 3 follow-ups, all recorded by round-3/4 review, none blocking:**
+
+- [ ] **Centering offset doesn't animate** — `transitionTo` sets `widthModel.width` as a plain assignment while only the constraint goes through `.animator()`, so Cmd+S makes the composer card jump instantly then the sidebar slides behind it for 200ms. Comment already corrected to state this honestly. | design | new
+- [ ] **One `widthModel.$width` subscription in `setup()`** would replace the four hand-placed `syncComposerCenteringOffset()` calls and cover `layout()`'s reclamp at `:710` without touching `layout()` — closing the documented gap. | app | new
+- [ ] **`browserShadowHost` not hidden from VoiceOver** alongside `sidebarHostingView`/`terminalShadowHost` while the composer is up. | a11y | new
+- [ ] **Install's fade-in completion has no generation guard** (`:1641-1654`) while dismiss's does (`:1716`) — Cmd+T then instant Escape posts `.layoutChanged` into an overlay already fading out. | a11y | new
+- [ ] **"Full-bleed" wording now wrong in 3 places** after the titlebar-band exclusion: `DESIGN.md` §4, `SessionComposerOverlay.swift:21-22` and `:32`. | docs | new
+- [ ] **Titlebar-band click-through** — the excluded band doesn't hit-test, so clicks fall through to the sidebar's toolbar row; the sidebar's own "+ New Session" button sits in that band and is live *through* the modal. Round-2's "no safe AppKit primitive found" reasoning was WRONG — `sidebarToggleButton.isEnabled = false` paired in install/dismiss (exactly like the `setAccessibilityHidden` pair beside it) is that primitive. Don't let the old reasoning get enshrined. | app | new
+- [ ] **#130 merged with three interactions unverified** — a `.popover` inside the composer's `.popover`; `+ Add project…` opening a modal `NSOpenPanel` inside it; edit sheet + delete inside popover content. Sean authorised the merge knowing this. Any of the three may dismiss the composer. Round 3's R1 fix (`didResignActive` instead of `windowDidResignKey`) should have closed the panel/sheet/alert cases — unconfirmed by observation. | app | new

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -125,17 +125,19 @@ Ghostties uses exactly two font families and a strict size/weight discipline.
 - No Dynamic Type in sidebar UI — density is intentional at 11pt
 - SF Mono for all monospaced content; never SF Pro in the terminal card
 
-### Centered modal (session composer)
+### Centered modal — a third surface class
 
-A third surface class, distinct from sidebar UI — introduced in Phase 3 of session-creation-unified (`SessionComposerPalette`, `.centered` presentation only). It floats free of the sidebar column at 360pt wide, so it does not inherit the 11pt sidebar density; the anchored popover presentation (the same view, `.anchored`) keeps the sidebar scale unchanged.
+A surface that floats free of the sidebar column entirely — not anchored to it, not part of it — does not inherit the 11pt sidebar density. It gets its own scale:
 
-| Element                  | Font        | Size | Weight     |
-| ------------------------ | ----------- | ---- | ---------- |
-| Query field               | SF Pro Text | 15pt | `.regular` |
-| Row title                 | SF Pro Text | 13pt | `.medium`  |
-| Row subtitle               | SF Pro Text | 11pt | —          |
+| Element     | Font        | Size | Weight     |
+| ----------- | ----------- | ---- | ---------- |
+| Query field | SF Pro Text | 15pt | `.regular` |
+| Row title   | SF Pro Text | 13pt | `.medium`  |
+| Row subtitle | SF Pro Text | 11pt | —          |
 
-Query field height: 38pt. Row vertical padding: 8pt (the 4pt spacing scale's own value — not the sidebar popover's legacy 5pt).
+Query field height: 38pt. Row vertical padding: 8pt (the 4pt spacing scale's own value — not the sidebar popover's legacy 5pt, see §7's Known Deviations).
+
+**Current example:** the session composer's `.centered` presentation (`SessionComposerPalette`, floats at 360pt wide, introduced in Phase 3 of session-creation-unified). Its `.anchored` presentation — the same view, popped out of a sidebar row — stays on the sidebar scale instead, since it IS anchored to the sidebar column. The rule is about floating free of the sidebar, not about which view happens to implement it — the next surface that floats free of the sidebar uses this scale too, whether or not it's `SessionComposerPalette`.
 
 ## 4. Component Stylings
 
@@ -154,9 +156,9 @@ Query field height: 38pt. Row vertical padding: 8pt (the 4pt spacing scale's own
 .shadow(color: .black.opacity(0.20), radius: 12)
 ```
 
-### Centered modal (session composer card)
+### Centered modal — component stylings
 
-Peer surface to the terminal card, not a one-off: same 12pt `.continuous` corner radius (`WorkspaceLayout.terminalCornerRadius`), and reuses the Overlay sidebar's shadow spec above rather than inventing a third shadow level. Paired with a full-bleed black-0.25 scrim (`SessionComposerOverlay`) so the card reads as "on top of" the terminal — the scrim excludes the titlebar band so traffic lights and window dragging aren't affected. `.anchored` (the sidebar popover presentation of the same view) is unchanged — unstyled 10pt radius, relies on the native `NSPopover` chrome/shadow instead.
+Any surface floating free of the sidebar (§3) is a peer to the terminal card, not a one-off: same 12pt `.continuous` corner radius (`WorkspaceLayout.terminalCornerRadius`). Current example: the session composer's `.centered` presentation card. Its shadow is its own level (§6) — `0.20/12/0` — which is NOT actually shared with the Overlay sidebar's real code values (`0.2/6/(2,0)`, see §6's Known Deviation note); it happens to match what the Overlay row is *documented* as, not what it *is*. Paired with a full-bleed black-0.25 scrim (`SessionComposerOverlay`) so the card reads as "on top of" the terminal — the scrim excludes the titlebar band (0 in fullscreen, where there's no titlebar to protect) so traffic lights and window dragging aren't affected. `.anchored` (the sidebar popover presentation of the same view) is unchanged — unstyled 10pt radius, relies on the native `NSPopover` chrome/shadow instead; see §7's Known Deviations.
 
 ```swift
 .clipShape(RoundedRectangle(cornerRadius: WorkspaceLayout.terminalCornerRadius, style: .continuous))
@@ -194,25 +196,32 @@ Never use arbitrary values (13pt, 22pt, 7pt, etc.).
 
 ## 6. Depth & Elevation
 
-Two shadow levels — terminal card and overlay. The centered composer card reuses the Overlay level rather than adding a third.
+Three shadow levels.
 
-| Level         | Opacity | Radius | Y   | Usage                                              |
-| ------------- | ------- | ------ | --- | --------------------------------------------------- |
-| Card (pinned) | `0.15`  | `8`    | `2` | Terminal card in pinned sidebar                    |
-| Overlay       | `0.20`  | `12`   | `0` | Sidebar in overlay mode; centered composer card    |
+| Level                  | Opacity | Radius | Y   | Usage                          |
+| ---------------------- | ------- | ------ | --- | ------------------------------- |
+| Card (pinned)          | `0.15`  | `8`    | `2` | Terminal card in pinned sidebar |
+| Overlay (documented)   | `0.20`  | `12`   | `0` | Sidebar in overlay mode         |
+| Centered composer card | `0.20`  | `12`   | `0` | Session composer, `.centered` presentation (`WorkspaceLayout.composerModalShadowOpacity`/`composerModalShadowRadius`) |
+
+**Known deviation (pre-existing, not from Phase 3):** the "Overlay" row's actual code values (`WorkspaceViewContainer.swift`, `sidebarOverlayBackground.layer`) are opacity `0.2`, radius `6`, offset `(2, 0)` — not `0.20/12/0` as documented above. This table has been wrong since before session-creation-unified; flagged here rather than silently propagated. The centered composer card row is verified correct against its actual `.shadow(...)` call — it does NOT reuse the Overlay sidebar's real shadow, despite sharing the same *documented* numbers; it's its own level that happens to match what Overlay was supposed to be.
 
 **Critical:** `shadowPath` must be set explicitly in `layout()`. Without it, CoreAnimation rasterizes from the alpha channel every frame (GPU performance hit).
 
 ## 7. Shapes
 
-One radius. One style. No exceptions — for surfaces documented here.
+One radius. One style. No exceptions.
 
-| Surface                          | Radius | Style         |
-| --------------------------------- | ------ | ------------- |
-| Terminal card                     | 12pt   | `.continuous` |
+| Surface                              | Radius | Style         |
+| ------------------------------------- | ------ | ------------- |
+| Terminal card                         | 12pt   | `.continuous` |
 | Centered composer card (`.centered`) | 12pt   | `.continuous` |
 
-Always pass `style: .continuous` to `RoundedRectangle` — it matches Apple's squircle aesthetic. (The composer's `.anchored` sidebar-popover presentation keeps its own unstyled 10pt radius from Phase 2 — a legacy exception, not a new one; do not extend it further.)
+Always pass `style: .continuous` to `RoundedRectangle` — it matches Apple's squircle aesthetic.
+
+### Known Deviations
+
+- **Composer popover (`.anchored` presentation, `SessionComposerPalette`).** 10pt radius, unstyled default (`.circular`), not `.continuous`. Shipped in Phase 2, before this rule was written down as covering the composer at all. Not extended further — the `.centered` presentation above is `.continuous`, and any future presentation should be too. Do not fix this by loosening the rule again; fix it by eventually restyling the popover instead.
 
 ## 8. Do's and Don'ts
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -125,6 +125,18 @@ Ghostties uses exactly two font families and a strict size/weight discipline.
 - No Dynamic Type in sidebar UI — density is intentional at 11pt
 - SF Mono for all monospaced content; never SF Pro in the terminal card
 
+### Centered modal (session composer)
+
+A third surface class, distinct from sidebar UI — introduced in Phase 3 of session-creation-unified (`SessionComposerPalette`, `.centered` presentation only). It floats free of the sidebar column at 360pt wide, so it does not inherit the 11pt sidebar density; the anchored popover presentation (the same view, `.anchored`) keeps the sidebar scale unchanged.
+
+| Element                  | Font        | Size | Weight     |
+| ------------------------ | ----------- | ---- | ---------- |
+| Query field               | SF Pro Text | 15pt | `.regular` |
+| Row title                 | SF Pro Text | 13pt | `.medium`  |
+| Row subtitle               | SF Pro Text | 11pt | —          |
+
+Query field height: 38pt. Row vertical padding: 8pt (the 4pt spacing scale's own value — not the sidebar popover's legacy 5pt).
+
 ## 4. Component Stylings
 
 ### Terminal card (pinned mode)
@@ -140,6 +152,15 @@ Ghostties uses exactly two font families and a strict size/weight discipline.
 ```swift
 // Higher opacity shadow to lift from content
 .shadow(color: .black.opacity(0.20), radius: 12)
+```
+
+### Centered modal (session composer card)
+
+Peer surface to the terminal card, not a one-off: same 12pt `.continuous` corner radius (`WorkspaceLayout.terminalCornerRadius`), and reuses the Overlay sidebar's shadow spec above rather than inventing a third shadow level. Paired with a full-bleed black-0.25 scrim (`SessionComposerOverlay`) so the card reads as "on top of" the terminal — the scrim excludes the titlebar band so traffic lights and window dragging aren't affected. `.anchored` (the sidebar popover presentation of the same view) is unchanged — unstyled 10pt radius, relies on the native `NSPopover` chrome/shadow instead.
+
+```swift
+.clipShape(RoundedRectangle(cornerRadius: WorkspaceLayout.terminalCornerRadius, style: .continuous))
+.shadow(color: .black.opacity(WorkspaceLayout.composerModalShadowOpacity), radius: WorkspaceLayout.composerModalShadowRadius)
 ```
 
 ### Row / hover states
@@ -173,24 +194,25 @@ Never use arbitrary values (13pt, 22pt, 7pt, etc.).
 
 ## 6. Depth & Elevation
 
-Two shadow levels only — terminal card and overlay sidebar. No shadows elsewhere.
+Two shadow levels — terminal card and overlay. The centered composer card reuses the Overlay level rather than adding a third.
 
-| Level         | Opacity | Radius | Y   | Usage                           |
-| ------------- | ------- | ------ | --- | ------------------------------- |
-| Card (pinned) | `0.15`  | `8`    | `2` | Terminal card in pinned sidebar |
-| Overlay       | `0.20`  | `12`   | `0` | Sidebar in overlay mode         |
+| Level         | Opacity | Radius | Y   | Usage                                              |
+| ------------- | ------- | ------ | --- | --------------------------------------------------- |
+| Card (pinned) | `0.15`  | `8`    | `2` | Terminal card in pinned sidebar                    |
+| Overlay       | `0.20`  | `12`   | `0` | Sidebar in overlay mode; centered composer card    |
 
 **Critical:** `shadowPath` must be set explicitly in `layout()`. Without it, CoreAnimation rasterizes from the alpha channel every frame (GPU performance hit).
 
 ## 7. Shapes
 
-One radius. One style. No exceptions.
+One radius. One style. No exceptions — for surfaces documented here.
 
-| Surface       | Radius | Style         |
-| ------------- | ------ | ------------- |
-| Terminal card | 12pt   | `.continuous` |
+| Surface                          | Radius | Style         |
+| --------------------------------- | ------ | ------------- |
+| Terminal card                     | 12pt   | `.continuous` |
+| Centered composer card (`.centered`) | 12pt   | `.continuous` |
 
-Always pass `style: .continuous` to `RoundedRectangle` — it matches Apple's squircle aesthetic.
+Always pass `style: .continuous` to `RoundedRectangle` — it matches Apple's squircle aesthetic. (The composer's `.anchored` sidebar-popover presentation keeps its own unstyled 10pt radius from Phase 2 — a legacy exception, not a new one; do not extend it further.)
 
 ## 8. Do's and Don'ts
 

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -982,22 +982,39 @@ class AppDelegate: NSObject,
         return mode == "projectFirst"
     }
 
-    /// Reclaims ⌘T for "New Session" in project-first workspace mode,
-    /// overriding Ghostty's native `new_tab` binding — which would otherwise
-    /// create a real NSWindow tab, or fall back to opening a whole new
-    /// window (see `TerminalController.newTab(_:)`), neither of which
-    /// matches the sidebar-session model. Same intercept-before-
-    /// `performKeyEquivalent` technique as `setupSessionCyclingShortcut()`
-    /// above — a local monitor runs before AppKit's key-equivalent dispatch
-    /// entirely, so it reliably wins the race regardless of what's bound in
-    /// `src/config/Config.zig` or the user's own keybinds.
+    /// Just the `contentView is WorkspaceViewContainer` half of
+    /// `isProjectFirstWorkspaceWindow(_:)` above, with no sidebar-view-mode
+    /// check (F2, Phase 3 review). Used exclusively by
+    /// `setupNewSessionShortcut()`: Cmd+T must reach the container in BOTH
+    /// project-first and task-first workspace windows now, because
+    /// `WorkspaceViewContainer`'s `.workspaceNewSession` observer (Phase 3
+    /// — moved there from `WorkspaceSidebarView`) lives at the container
+    /// level and doesn't care which sidebar view mode is mounted; it opens
+    /// the composer overlay or creates a session instantly either way. Cmd+W
+    /// and Cmd+1-9 stay on `isProjectFirstWorkspaceWindow(_:)` — they're
+    /// genuinely project-first-only (task-first has no session list for
+    /// them to act on).
+    private static func isWorkspaceWindow(_ window: NSWindow) -> Bool {
+        window.contentView is WorkspaceViewContainer
+    }
+
+    /// Reclaims ⌘T for "New Session" in workspace windows (both sidebar view
+    /// modes, F2 fix — see `isWorkspaceWindow(_:)`), overriding Ghostty's
+    /// native `new_tab` binding — which would otherwise create a real
+    /// NSWindow tab, or fall back to opening a whole new window (see
+    /// `TerminalController.newTab(_:)`), neither of which matches the
+    /// sidebar-session model. Same intercept-before-`performKeyEquivalent`
+    /// technique as `setupSessionCyclingShortcut()` above — a local monitor
+    /// runs before AppKit's key-equivalent dispatch entirely, so it reliably
+    /// wins the race regardless of what's bound in `src/config/Config.zig`
+    /// or the user's own keybinds.
     private func setupNewSessionShortcut() {
         _ = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.modifierFlags.intersection([.command, .shift, .control, .option]) == [.command],
                   event.charactersIgnoringModifiers?.lowercased() == "t"
             else { return event }
 
-            guard let window = NSApp.keyWindow, Self.isProjectFirstWorkspaceWindow(window) else { return event }
+            guard let window = NSApp.keyWindow, Self.isWorkspaceWindow(window) else { return event }
 
             NSApp.sendAction(#selector(TerminalController.newWorkspaceSession(_:)), to: nil, from: nil)
             return nil

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -743,17 +743,18 @@ class AppDelegate: NSObject,
         newSessionItem.keyEquivalentModifierMask = [.command]
         newSessionItem.setImageIfDesired(systemSymbolName: "plus.rectangle")
 
-        // Hidden duplicate: Cmd+Shift+T also creates a new session — kept as
-        // an alias so muscle memory from earlier betas (where Cmd+Shift+T was
-        // the only binding) still works, same pattern as `sidebarItemCmdS` above.
+        // "New Session (Instant)" — Cmd+Shift+T (Phase 3 of
+        // session-creation-unified). Always creates immediately with no UI,
+        // ignoring the `ghostties.newSessionOpensComposer` preference
+        // entirely — unlike Cmd+T above, which is preference-driven.
+        // Promoted from a hidden Cmd+T alias to a visible, distinctly-named
+        // item now that Cmd+T can open the composer instead.
         let newSessionItemCmdShiftT = NSMenuItem(
-            title: "New Session",
-            action: #selector(TerminalController.newWorkspaceSession(_:)),
+            title: "New Session (Instant)",
+            action: #selector(TerminalController.newWorkspaceSessionInstant(_:)),
             keyEquivalent: "t"
         )
         newSessionItemCmdShiftT.keyEquivalentModifierMask = [.command, .shift]
-        newSessionItemCmdShiftT.isHidden = true
-        newSessionItemCmdShiftT.allowsKeyEquivalentWhenHidden = true
 
         // "Sidebar View" submenu — radio group for the sidebar views.
         // Tasks is intentionally hidden here (not deleted) — see

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -122,6 +122,17 @@ private struct ProjectDisclosureRowContent: View, Equatable {
             }
         }
         .background(expandedContainerBackground)
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceComposerOverlayWillPresent)) { notification in
+            // F5 (Phase 3 review): `SessionComposerStore` is one app-wide
+            // singleton — if this row's popover stays open while the
+            // centered overlay opens, the overlay's `open(.open, ...)`
+            // silently overwrites `currentProjectBinding`/`selectedProjectId`
+            // out from under it, and `.locked`'s write-path enforcement is
+            // defeated by the second opener. Single-presentation invariant:
+            // the overlay always wins.
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            showingTemplatePicker = false
+        }
     }
 
     // MARK: - Expanded Session List

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -448,14 +448,24 @@ struct RecentsListView: View {
 /// reached via `coordinator.containerView` since this view has no direct
 /// reference to the AppKit container.
 struct NewSessionToolbarButton: View {
-    @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
 
     @State private var isHovered = false
 
     var body: some View {
         Button {
-            (coordinator.containerView as? WorkspaceViewContainer)?.presentComposerOverlay(projectBinding: .open)
+            // F9 (Phase 3 review): `coordinator.containerView` is always a
+            // `WorkspaceViewContainer` in practice — it's set exactly once,
+            // from `WorkspaceViewContainer.viewDidMoveToWindow()` — so this
+            // cast is a class invariant, not a real runtime branch. The old
+            // `Menu` silently did nothing if the invariant ever broke; assert
+            // instead so a regression is caught in development rather than
+            // shipping as a silently-dead button.
+            guard let container = coordinator.containerView as? WorkspaceViewContainer else {
+                assertionFailure("NewSessionToolbarButton: coordinator.containerView is not a WorkspaceViewContainer")
+                return
+            }
+            container.presentComposerOverlay(projectBinding: .open)
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: "plus")
@@ -467,7 +477,10 @@ struct NewSessionToolbarButton: View {
         .buttonStyle(.plain)
         .foregroundStyle(isHovered ? .primary : .secondary)
         .onHover { isHovered = $0 }
-        .disabled(store.projects.isEmpty)
+        // F9 (Phase 3 review): with zero projects, the composer's own
+        // "+ Add project…" row (in the open project dropdown) is the only
+        // way to add one from this tab — disabling the button that reaches
+        // it made that path unreachable.
         .accessibilityLabel("New Session")
     }
 }

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -241,24 +241,6 @@ struct RecentsListView: View {
         )
     }
 
-    // MARK: - Actions
-
-    /// Static so `NewSessionToolbarButton` shares this exactly — see
-    /// `SessionTemplateResolver.templates(for:store:)`.
-    static func startNewSession(in project: Project, template: AgentTemplate?, store: WorkspaceStore, coordinator: SessionCoordinator) {
-        let resolved: AgentTemplate = template ?? {
-            if let defaultId = project.defaultTemplateId,
-               let t = store.templates.first(where: { $0.id == defaultId }) {
-                return t
-            }
-            return store.templates.first(where: { $0.kind == .shell })
-                ?? AgentTemplate.shell
-        }()
-        Task {
-            await coordinator.createQuickSession(for: project, template: resolved)
-        }
-    }
-
     // MARK: - Rename
 
     private func beginRename(session: AgentSession) {
@@ -460,10 +442,11 @@ struct RecentsListView: View {
 
 /// Labelled toolbar button for the Sessions tab, presented in
 /// `WorkspaceSidebarView.titlebarToolbar` right-aligned on the traffic-light
-/// row. Opens the same project-picker flyout menu the former `newSessionRow`
-/// showed inline in the list — see `SessionTemplateResolver.templates(for:store:)`
-/// and `RecentsListView.startNewSession(in:template:store:coordinator:)`, which
-/// this calls directly so the menu logic is never duplicated.
+/// row. Opens the centered session composer overlay (Phase 3 of
+/// session-creation-unified) instead of the old two-level project → template
+/// cascade menu (D7) — see `WorkspaceViewContainer.presentComposerOverlay(projectBinding:)`,
+/// reached via `coordinator.containerView` since this view has no direct
+/// reference to the AppKit container.
 struct NewSessionToolbarButton: View {
     @EnvironmentObject private var store: WorkspaceStore
     @EnvironmentObject private var coordinator: SessionCoordinator
@@ -471,25 +454,8 @@ struct NewSessionToolbarButton: View {
     @State private var isHovered = false
 
     var body: some View {
-        Menu {
-            ForEach(store.projects) { project in
-                let templates = SessionTemplateResolver.templates(for: project, store: store)
-                if templates.count <= 1 {
-                    // Single template — tap creates directly, no submenu needed.
-                    Button(project.name) {
-                        RecentsListView.startNewSession(in: project, template: templates.first, store: store, coordinator: coordinator)
-                    }
-                } else {
-                    // Multiple templates — submenu: project name → template list.
-                    Menu(project.name) {
-                        ForEach(templates) { template in
-                            Button(template.name) {
-                                RecentsListView.startNewSession(in: project, template: template, store: store, coordinator: coordinator)
-                            }
-                        }
-                    }
-                }
-            }
+        Button {
+            (coordinator.containerView as? WorkspaceViewContainer)?.presentComposerOverlay(projectBinding: .open)
         } label: {
             HStack(spacing: 4) {
                 Image(systemName: "plus")
@@ -498,13 +464,7 @@ struct NewSessionToolbarButton: View {
                     .font(.system(size: 12, weight: .medium))
             }
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        // `Menu` can otherwise claim more horizontal space than its label
-        // content needs; this keeps it hugging the icon+text so the
-        // trailing-aligned `Spacer()` in `WorkspaceSidebarView.titlebarToolbar`
-        // has room to push it flush against the sidebar's trailing edge.
-        .fixedSize()
+        .buttonStyle(.plain)
         .foregroundStyle(isHovered ? .primary : .secondary)
         .onHover { isHovered = $0 }
         .disabled(store.projects.isEmpty)

--- a/macos/Sources/Features/Ghostties/SessionComposerOverlay.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerOverlay.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Centered composer surfaced by Cmd+T (when the `ghostties.newSessionOpensComposer`
+/// preference is on, the default) and the sidebar toolbar's "+ New Session"
+/// button (Phase 3 of session-creation-unified — replaces the 28-project
+/// toolbar cascade, D7). Wraps `SessionComposerPalette` in a scrim so the
+/// card reads as "on top of" the terminal rather than terminal content
+/// itself: Ghostties has only two shadow levels and no modal vocabulary, so
+/// the overlay shadow alone (0.20/12/0) isn't enough on a busy dark
+/// terminal.
+///
+/// Scrim: black at 0.25 opacity, dismissed by clicking anywhere on it. This
+/// is a locked design decision (docs/plans/session-creation-unified.html,
+/// "Yours to decide" — "the centered composer dims the terminal behind it,
+/// strawman taken as written") — not a proposal to re-open.
+///
+/// Hosted by `WorkspaceViewContainer` via the now-internal
+/// `TransparentHostingView`. The hosting NSHostingView is pinned to the
+/// container's full bounds (not just centerX/centerY) so this view's scrim
+/// can actually dim the whole terminal — a hosting view sized only to the
+/// composer card's own bounds would have nothing wider than the card to
+/// dim against. The card itself is centered and fixed-width via ordinary
+/// SwiftUI layout (`ZStack`'s default center alignment + `.frame(width:)`
+/// on `SessionComposerPalette`), not AppKit constraints.
+struct SessionComposerOverlay: View {
+    let request: SessionComposerRequest
+
+    @ObservedObject private var composerStore = SessionComposerStore.shared
+
+    private var isPresented: Binding<Bool> {
+        Binding(
+            get: { composerStore.isOpen },
+            set: { newValue in
+                if !newValue { composerStore.cancel() }
+            }
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.25)
+                .contentShape(Rectangle())
+                .onTapGesture { composerStore.cancel() }
+
+            SessionComposerPalette(isPresented: isPresented, request: request)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/macos/Sources/Features/Ghostties/SessionComposerOverlay.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerOverlay.swift
@@ -6,8 +6,9 @@ import SwiftUI
 /// toolbar cascade, D7). Wraps `SessionComposerPalette` in a scrim so the
 /// card reads as "on top of" the terminal rather than terminal content
 /// itself: Ghostties has only two shadow levels and no modal vocabulary, so
-/// the overlay shadow alone (0.20/12/0) isn't enough on a busy dark
-/// terminal.
+/// the overlay shadow alone (0.20/12/0, applied to the card itself by
+/// `SessionComposerPalette` for the `.centered` presentation) isn't enough
+/// on a busy dark terminal by itself.
 ///
 /// Scrim: black at 0.25 opacity, dismissed by clicking anywhere on it. This
 /// is a locked design decision (docs/plans/session-creation-unified.html,
@@ -25,6 +26,13 @@ import SwiftUI
 struct SessionComposerOverlay: View {
     let request: SessionComposerRequest
 
+    /// Shifts the card's center rightward off the window's center so it
+    /// centers on the terminal card instead (Sean's design decision 2,
+    /// Phase 3 review) — `WorkspaceViewContainer.terminalCardHorizontalOffset`,
+    /// the live sidebar width when pinned, 0 otherwise. Applied as leading
+    /// padding on the card only; the scrim stays full-bleed underneath it.
+    var horizontalOffset: CGFloat = 0
+
     @ObservedObject private var composerStore = SessionComposerStore.shared
 
     private var isPresented: Binding<Bool> {
@@ -38,11 +46,28 @@ struct SessionComposerOverlay: View {
 
     var body: some View {
         ZStack {
-            Color.black.opacity(0.25)
-                .contentShape(Rectangle())
-                .onTapGesture { composerStore.cancel() }
+            // F7 (Phase 3 review): the scrim excludes the titlebar band
+            // (traffic lights + drag region) rather than covering the full
+            // window height. Two problems, one fix: painting a 25%-dimmed
+            // rectangle under the titlebar left the traffic lights — which
+            // live in the theme frame above this content view — rendering
+            // at full brightness inside a dimmed band, and the scrim's own
+            // `.contentShape`/`.onTapGesture` claimed mouse-down there too,
+            // so the window couldn't be dragged by its titlebar while the
+            // composer was open and a click up there dismissed it instead.
+            VStack(spacing: 0) {
+                Color.clear
+                    .frame(height: WorkspaceLayout.titlebarSpacerHeight)
+                Color.black.opacity(0.25)
+                    .contentShape(Rectangle())
+                    .onTapGesture { composerStore.cancel() }
+                    .accessibilityElement()
+                    .accessibilityLabel("Dismiss session composer")
+                    .accessibilityAddTraits(.isButton)
+            }
 
             SessionComposerPalette(isPresented: isPresented, request: request)
+                .padding(.leading, horizontalOffset)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/macos/Sources/Features/Ghostties/SessionComposerOverlay.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerOverlay.swift
@@ -28,10 +28,16 @@ struct SessionComposerOverlay: View {
 
     /// Shifts the card's center rightward off the window's center so it
     /// centers on the terminal card instead (Sean's design decision 2,
-    /// Phase 3 review) — `WorkspaceViewContainer.terminalCardHorizontalOffset`,
-    /// the live sidebar width when pinned, 0 otherwise. Applied as leading
-    /// padding on the card only; the scrim stays full-bleed underneath it.
-    var horizontalOffset: CGFloat = 0
+    /// Phase 3 review). Applied as leading padding on the card only; the
+    /// scrim stays full-bleed underneath it.
+    ///
+    /// R5 (Phase 3 review round 2): an `@ObservedObject`, not a captured
+    /// `CGFloat` — the offset used to be baked into `rootView` once at
+    /// present-time, so it went stale the moment Cmd+S/Cmd+Shift+E or
+    /// Cmd+Shift+1/2 changed the sidebar's width or mode while the composer
+    /// was still open. `WorkspaceViewContainer` writes the live value into
+    /// this same shared model instance at every site that can change it.
+    @ObservedObject var centeringModel: ComposerCenteringModel
 
     @ObservedObject private var composerStore = SessionComposerStore.shared
 
@@ -57,7 +63,7 @@ struct SessionComposerOverlay: View {
             // composer was open and a click up there dismissed it instead.
             VStack(spacing: 0) {
                 Color.clear
-                    .frame(height: WorkspaceLayout.titlebarSpacerHeight)
+                    .frame(height: centeringModel.titlebarBandHeight)
                 Color.black.opacity(0.25)
                     .contentShape(Rectangle())
                     .onTapGesture { composerStore.cancel() }
@@ -67,7 +73,7 @@ struct SessionComposerOverlay: View {
             }
 
             SessionComposerPalette(isPresented: isPresented, request: request)
-                .padding(.leading, horizontalOffset)
+                .padding(.leading, centeringModel.horizontalOffset)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -59,10 +59,81 @@ struct SessionComposerPalette: View {
         }
     }
 
-    private static let fieldHeight: CGFloat = 30
-    private static let fieldFontSize: CGFloat = 11
-    private static let rowFontSize: CGFloat = 12
-    private static let subtitleFontSize: CGFloat = 10
+    // MARK: - Two surface classes (Phase 3 review — "New centered-modal
+    // surface class")
+    //
+    // `.anchored` (the Phase 2 sidebar popover) and `.centered` (the Phase 3
+    // overlay card) are typographically distinct — the card grew 220pt to
+    // 360pt but originally kept the sidebar's own 11pt density, reading as a
+    // stretched popover rather than a standalone surface. `.anchored`'s
+    // values below are UNCHANGED from Phase 2 (do not restyle the sidebar
+    // popover); `.centered` gets its own scale, documented as a canonical
+    // surface class in `DESIGN.md` §3/§4/§6/§7 rather than living only here.
+    private var fieldHeight: CGFloat {
+        switch request.presentation {
+        case .anchored: return 30
+        case .centered: return 38
+        }
+    }
+
+    private var fieldFontSize: CGFloat {
+        switch request.presentation {
+        case .anchored: return 11
+        case .centered: return 15
+        }
+    }
+
+    private var rowFontSize: CGFloat {
+        switch request.presentation {
+        case .anchored: return 12
+        case .centered: return 13
+        }
+    }
+
+    private var subtitleFontSize: CGFloat {
+        switch request.presentation {
+        case .anchored: return 10
+        case .centered: return 11
+        }
+    }
+
+    /// Row vertical padding — `ComposerRow`'s existing 5pt (Phase 2,
+    /// `.anchored` only) predates the 4pt spacing scale; left as-is since
+    /// restyling the popover is out of scope. `.centered` gets the scale's
+    /// 8pt.
+    private var rowVerticalPadding: CGFloat {
+        switch request.presentation {
+        case .anchored: return 5
+        case .centered: return 8
+        }
+    }
+
+    /// Card corner radius — `.anchored` keeps its existing 10pt (unstyled,
+    /// Phase 2, not touched). `.centered` uses the DESIGN.md §7 terminal-card
+    /// radius/style (`WorkspaceLayout.terminalCornerRadius`, `.continuous`) —
+    /// the composer card is a peer surface to the terminal card, not a
+    /// one-off.
+    private var cornerRadius: CGFloat {
+        switch request.presentation {
+        case .anchored: return 10
+        case .centered: return WorkspaceLayout.terminalCornerRadius
+        }
+    }
+
+    /// DESIGN.md §7: "One radius. One style. No exceptions... Always pass
+    /// `style: .continuous`." `.anchored` keeps the unstyled default
+    /// (`.circular`) it shipped with in Phase 2; `.centered` is `.continuous`.
+    private var cornerStyle: RoundedCornerStyle {
+        switch request.presentation {
+        case .anchored: return .circular
+        case .centered: return .continuous
+        }
+    }
+
+    private var composerClipShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: cornerRadius, style: cornerStyle)
+    }
+
     private static let sectionHeaderFontSize: CGFloat = 10
 
     private var isProjectLocked: Bool {
@@ -212,9 +283,10 @@ struct SessionComposerPalette: View {
                 query: query,
                 selectedIndex: $selectedIndex,
                 hoveredOptionID: $hoveredOptionID,
-                rowFontSize: Self.rowFontSize,
-                subtitleFontSize: Self.subtitleFontSize,
+                rowFontSize: rowFontSize,
+                subtitleFontSize: subtitleFontSize,
                 sectionHeaderFontSize: Self.sectionHeaderFontSize,
+                rowVerticalPadding: rowVerticalPadding,
                 onEditTemplate: { newTemplateToEdit = $0 },
                 onDuplicateTemplate: { _ = store.duplicateTemplate(id: $0.id) },
                 onDuplicateAndEditTemplate: {
@@ -238,7 +310,7 @@ struct SessionComposerPalette: View {
 
             if let writeError = composerStore.writeError {
                 Text(writeError)
-                    .font(.system(size: Self.subtitleFontSize))
+                    .font(.system(size: subtitleFontSize))
                     .foregroundStyle(Color(nsColor: .systemRed))
                     .padding(.horizontal, 10)
                     .padding(.top, 6)
@@ -254,10 +326,19 @@ struct SessionComposerPalette: View {
             }
             .compositingGroup()
         )
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(composerClipShape)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
+            composerClipShape
                 .stroke(Color(nsColor: .tertiaryLabelColor).opacity(0.75))
+        )
+        // Overlay shadow (DESIGN.md §6, `.centered` only — Phase 3 review
+        // fix). `.anchored` relies on the native NSPopover chrome/shadow
+        // instead; adding a second shadow there would double up.
+        .shadow(
+            color: request.presentation == .centered
+                ? .black.opacity(WorkspaceLayout.composerModalShadowOpacity)
+                : .clear,
+            radius: request.presentation == .centered ? WorkspaceLayout.composerModalShadowRadius : 0
         )
         .environment(\.colorScheme, scheme)
         .onAppear {
@@ -319,13 +400,13 @@ struct SessionComposerPalette: View {
         HStack(spacing: 0) {
             ComposerQueryField(
                 query: $composerStore.searchText,
-                fontSize: Self.fieldFontSize,
+                fontSize: fieldFontSize,
                 focusTrigger: $composerStore.focusSearchFieldTrigger,
                 hasSelection: selectedOption != nil
             ) { event in
                 handle(event)
             }
-            .frame(height: Self.fieldHeight)
+            .frame(height: fieldHeight)
 
             projectControl
         }
@@ -340,19 +421,19 @@ struct SessionComposerPalette: View {
             // No hairline divider here (nit): a divider next to a static
             // label with no `▾` reads as a control that isn't one.
             Text(label)
-                .font(.system(size: Self.rowFontSize, weight: .medium))
+                .font(.system(size: rowFontSize, weight: .medium))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
         } else {
             Divider()
-                .frame(height: Self.fieldHeight * 0.5)
+                .frame(height: fieldHeight * 0.5)
 
             Button {
                 isProjectDropdownOpen = true
             } label: {
                 HStack(spacing: 4) {
                     Text(label)
-                        .font(.system(size: Self.rowFontSize, weight: .medium))
+                        .font(.system(size: rowFontSize, weight: .medium))
                         .lineLimit(1)
                     Image(systemName: "chevron.down")
                         .font(.system(size: 9, weight: .medium))
@@ -392,7 +473,7 @@ struct SessionComposerPalette: View {
                     .font(.system(size: 11))
                     .frame(width: 16)
                 TextField("Template name", text: $newTemplateName)
-                    .font(.system(size: Self.rowFontSize, weight: .medium))
+                    .font(.system(size: rowFontSize, weight: .medium))
                     .textFieldStyle(.plain)
                     .focused($newTemplateNameFocused)
                     .onSubmit { commitNewTemplate() }
@@ -413,7 +494,7 @@ struct SessionComposerPalette: View {
                         .font(.system(size: 11))
                         .frame(width: 16)
                     Text("New template…")
-                        .font(.system(size: Self.rowFontSize, weight: .medium))
+                        .font(.system(size: rowFontSize, weight: .medium))
                     Spacer()
                 }
                 .contentShape(Rectangle())
@@ -495,6 +576,14 @@ struct SessionComposerPalette: View {
         // `.onKeyPress` ever fire on macOS 14+.
         selectedIndex = nil
 
+        // F1 (Phase 3 review): capture the target project BEFORE precommit
+        // runs — `.locked`'s enforced project can differ from whatever
+        // `selectedProjectId` reads after `precommit` records the recent
+        // pair and closes the store, and this notification exists
+        // specifically to auto-expand the project the session actually
+        // landed in.
+        let targetProject = currentProject
+
         // N1: `precommit` is synchronous — it validates, records the
         // recent pair, and dispatches the actual session spawn from a
         // detached `Task` it does not wait on. Dismissing here, on that
@@ -504,6 +593,16 @@ struct SessionComposerPalette: View {
         let success = composerStore.precommit(template: template, coordinator: coordinator, workspaceStore: store)
         if success {
             isPresented = false
+            // F1: without this, a session created via the composer into a
+            // collapsed project spawns with no visible sidebar row — see
+            // `WorkspaceLayout.workspaceDidCreateSessionInProject`.
+            if let targetProject {
+                NotificationCenter.default.post(
+                    name: .workspaceDidCreateSessionInProject,
+                    object: coordinator.containerView?.window,
+                    userInfo: ["projectId": targetProject.id]
+                )
+            }
         } else {
             // N4: precommit failed — the composer stays open with
             // `writeError` showing. `selectedIndex` was just nil'd above,
@@ -690,6 +789,7 @@ private struct ComposerResultsTable: View {
     var rowFontSize: CGFloat
     var subtitleFontSize: CGFloat
     var sectionHeaderFontSize: CGFloat
+    var rowVerticalPadding: CGFloat
     var onEditTemplate: (AgentTemplate) -> Void
     var onDuplicateTemplate: (AgentTemplate) -> Void
     var onDuplicateAndEditTemplate: (AgentTemplate) -> Void
@@ -730,6 +830,7 @@ private struct ComposerResultsTable: View {
                                         hoveredID: $hoveredOptionID,
                                         titleFontSize: rowFontSize,
                                         subtitleFontSize: subtitleFontSize,
+                                        verticalPadding: rowVerticalPadding,
                                         onEditTemplate: onEditTemplate,
                                         onDuplicateTemplate: onDuplicateTemplate,
                                         onDuplicateAndEditTemplate: onDuplicateAndEditTemplate,
@@ -778,6 +879,7 @@ private struct ComposerRow: View {
     @Binding var hoveredID: UUID?
     var titleFontSize: CGFloat
     var subtitleFontSize: CGFloat
+    var verticalPadding: CGFloat
     var onEditTemplate: (AgentTemplate) -> Void
     var onDuplicateTemplate: (AgentTemplate) -> Void
     var onDuplicateAndEditTemplate: (AgentTemplate) -> Void
@@ -828,7 +930,7 @@ private struct ComposerRow: View {
                 Spacer()
             }
             .padding(.horizontal, 8)
-            .padding(.vertical, 5)
+            .padding(.vertical, verticalPadding)
             .contentShape(Rectangle())
             .background(
                 isSelected

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -373,6 +373,20 @@ struct SessionComposerPalette: View {
             // the bottom of the list.
             clampSelectedIndex()
         }
+        .onChange(of: composerStore.focusSearchFieldTrigger) { triggered in
+            // R8 (Phase 3 review round 2): mirrors the S5 seed in `onAppear`
+            // for the "re-open while already installed" path (F4) —
+            // `onAppear` doesn't reliably re-fire there (observed, see F4's
+            // comment in `WorkspaceViewContainer.presentComposerOverlay`),
+            // so a `selectedIndex` left `nil` by a just-completed commit
+            // (S1's reset) never gets re-seeded, and Return goes dead on a
+            // fast re-present. `focusSearchFieldTrigger` is exactly
+            // `open()`'s "already open" signal (S7) — unlike `isOpen`
+            // itself, which SwiftUI's `.onChange` won't re-fire on since it
+            // stays `true` across the whole re-open.
+            guard triggered else { return }
+            clampSelectedIndex()
+        }
         .sheet(item: $newTemplateToEdit) { template in
             TemplateEditForm(template: template)
         }
@@ -739,7 +753,11 @@ struct ComposerQueryField: View {
 
             TextField("Search templates and projects…", text: $query)
                 .padding(.vertical, 6)
-                .font(.system(size: fontSize, weight: .light))
+                // R6 (Phase 3 review round 2): `.light` isn't an allowed
+                // DESIGN.md weight (§3: `.regular`/`.medium`, `.semibold`
+                // sparingly), and DESIGN.md's own new "centered modal" row
+                // documents this field as `.regular` — reconciling to that.
+                .font(.system(size: fontSize, weight: .regular))
                 .textFieldStyle(.plain)
                 .focused($isTextFieldFocused)
                 .onExitCommand { onEvent?(.exit) }

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -47,11 +47,18 @@ struct SessionComposerPalette: View {
     @FocusState private var newTemplateNameFocused: Bool
 
     // MARK: - DESIGN.md scale (D11) — see `TemplatePickerView` for precedent.
-    // `paletteWidth` pulls from `WorkspaceLayout.sidebarWidth` (DESIGN.md §2
+    // `paletteWidth` pulls from `WorkspaceLayout` tokens (DESIGN.md §2
     // forbids hardcoded pt values where an equivalent token exists); the
-    // other constants have no `WorkspaceLayout` equivalent.
+    // other constants have no `WorkspaceLayout` equivalent. Width varies by
+    // presentation (Phase 3): `.anchored` matches the sidebar it pops out
+    // of; `.centered` is wider since it floats free of the sidebar column.
+    private var paletteWidth: CGFloat {
+        switch request.presentation {
+        case .anchored: return WorkspaceLayout.sidebarWidth
+        case .centered: return WorkspaceLayout.composerOverlayWidth
+        }
+    }
 
-    private static let paletteWidth: CGFloat = WorkspaceLayout.sidebarWidth
     private static let fieldHeight: CGFloat = 30
     private static let fieldFontSize: CGFloat = 11
     private static let rowFontSize: CGFloat = 12
@@ -239,7 +246,7 @@ struct SessionComposerPalette: View {
 
             newTemplateRow
         }
-        .frame(width: Self.paletteWidth)
+        .frame(width: paletteWidth)
         .background(
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -8,7 +8,7 @@ struct SessionComposerRequest {
     /// How the composer is presented. Only `.anchored` (the sidebar
     /// popover) is built in Phase 2 — `.centered` is declared now so the
     /// type is stable, but Phase 3 is the first caller to actually use it.
-    enum Presentation {
+    enum Presentation: Equatable {
         case anchored
         case centered
     }

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -72,18 +72,28 @@ final class SessionComposerStore: ObservableObject {
 
     @Published private(set) var isOpen: Bool = false
 
-    /// The window that most recently opened the composer (Phase 3 review
-    /// round 3, Blocker 3). This store is one process-wide singleton, but
-    /// only one workspace window's overlay should be "the" composer at a
-    /// time — without this, two windows could each install their own
-    /// overlay against the same shared state (`selectedProjectId`/
+    /// The window that most recently opened the CENTERED composer overlay
+    /// (Phase 3 review round 3, Blocker 3). This store is one process-wide
+    /// singleton, but only one workspace window's overlay should be "the"
+    /// composer at a time — without this, two windows could each install
+    /// their own overlay against the same shared state (`selectedProjectId`/
     /// `searchText`/`currentProjectBinding`), each visibly showing
     /// whichever window opened last, with Escape in either tearing down
     /// both. `WorkspaceViewContainer.presentComposerOverlay` writes this on
-    /// every open (dismissing any other window's overlay first); its
-    /// `$isOpen` sink and `dismissComposerOverlayIfPresented` check it
-    /// before acting. `weak` so this never keeps a window alive and simply
-    /// reads `nil` once one is gone.
+    /// every CENTERED-overlay open (dismissing any other window's overlay
+    /// first); its `$isOpen` sink and `dismissComposerOverlayIfPresented`
+    /// check it before acting.
+    ///
+    /// Deliberately NOT written by the ANCHORED popover's `open()` call
+    /// (`SessionComposerPalette.swift`'s `.onAppear`) — a row popover in
+    /// window B while window A's centered overlay is up still leaves two
+    /// composers live against the shared store. That's pre-existing
+    /// behavior (the round-2 `NSApp.isActive` gate produced the same
+    /// outcome) and explicitly out of scope here — not chased by this
+    /// property, which only arbitrates between CENTERED overlays.
+    ///
+    /// `weak` so this never keeps a window alive and simply reads `nil`
+    /// once one is gone.
     weak var owningWindow: NSWindow?
 
     /// When true, the search field should receive first responder on the

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -72,6 +72,20 @@ final class SessionComposerStore: ObservableObject {
 
     @Published private(set) var isOpen: Bool = false
 
+    /// The window that most recently opened the composer (Phase 3 review
+    /// round 3, Blocker 3). This store is one process-wide singleton, but
+    /// only one workspace window's overlay should be "the" composer at a
+    /// time — without this, two windows could each install their own
+    /// overlay against the same shared state (`selectedProjectId`/
+    /// `searchText`/`currentProjectBinding`), each visibly showing
+    /// whichever window opened last, with Escape in either tearing down
+    /// both. `WorkspaceViewContainer.presentComposerOverlay` writes this on
+    /// every open (dismissing any other window's overlay first); its
+    /// `$isOpen` sink and `dismissComposerOverlayIfPresented` check it
+    /// before acting. `weak` so this never keeps a window alive and simply
+    /// reads `nil` once one is gone.
+    weak var owningWindow: NSWindow?
+
     /// When true, the search field should receive first responder on the
     /// next render cycle. Cleared by the view after the focus request is
     /// consumed. Mirrors `NewTaskComposerStore.focusTitleFieldTrigger`.

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -271,6 +271,15 @@ final class SessionComposerStore: ObservableObject {
 
     // MARK: - Smart-default cascade
 
+    /// Resolves the same three-step smart-default cascade used by `open(projectBinding: .open, ...)`,
+    /// without opening the composer UI. Phase 3's instant-create paths
+    /// (Cmd+Shift+T, and Cmd+T when `ghostties.newSessionOpensComposer` is
+    /// off) need the cascade pick but must never touch `isOpen` or any of
+    /// the other UI-facing state `open()` resets.
+    func resolveCascadeProject(workspaceStore: WorkspaceStore) -> UUID? {
+        resolveDefaultProject(workspaceStore: workspaceStore)
+    }
+
     /// Same three-step cascade as `NewTaskComposerStore.resolveDefaultProject`
     /// (cwd of the frontmost terminal -> MRU -> most-recently-touched).
     /// Duplicated rather than shared: `NewTaskComposerStore` is a boundary

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -219,6 +219,19 @@ final class SessionComposerStore: ObservableObject {
         coordinator: SessionCoordinator,
         workspaceStore: WorkspaceStore
     ) -> Bool {
+        // R3 (Phase 3 review round 2): the keyboard path's double-Return
+        // guard (`SessionComposerPalette.commit(template:)` nil-ing
+        // `selectedIndex` synchronously) doesn't cover the mouse path —
+        // `ComposerRow`'s `Button(action:)` calls `option.action()` directly
+        // and never reads `selectedIndex`. A fast double-click on a
+        // template row (well inside the system's ~500ms double-click
+        // interval, especially during the centered overlay's 0.2s
+        // dismiss-fade before hit-testing is disabled) could otherwise fire
+        // `precommit` twice and create two sessions. `isOpen` is already set
+        // `false` synchronously below on the first successful call, so this
+        // guard rejects the second one for free.
+        guard isOpen else { return false }
+
         // `.locked` enforces at the write path — resolved from the bound
         // project, never from `selectedProjectId` — so the enum case isn't
         // decorative once Phase 3 starts relying on it. `.prefilled`/`.open`

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -31,6 +31,11 @@ enum WorkspaceLayout {
     /// First-pass value — tunable.
     static let sidebarMaxWidth: CGFloat = 480
 
+    /// Width of the centered session composer overlay's card (Phase 3 of
+    /// session-creation-unified). Wider than `sidebarWidth` since it floats
+    /// free of the sidebar column instead of popping out of it.
+    static let composerOverlayWidth: CGFloat = 360
+
     /// Height reserved at top for window traffic light controls.
     static let titlebarSpacerHeight: CGFloat = 28
 
@@ -323,9 +328,20 @@ extension Notification.Name {
     /// running sessions before the store deletes the project's records.
     static let workspaceProjectWillBeRemoved = Notification.Name("com.seansmithdesign.ghostties.workspace.projectWillBeRemoved")
 
-    /// Posted by TerminalController when the user presses Cmd+T.
-    /// The notification object is the originating NSWindow.
+    /// Posted by TerminalController when the user presses Cmd+T. The
+    /// notification object is the originating NSWindow. Observed by
+    /// `WorkspaceViewContainer` (Phase 3 of session-creation-unified — moved
+    /// from `WorkspaceSidebarView` so both sidebar view modes receive it,
+    /// D2), which opens the composer overlay or creates instantly depending
+    /// on the `ghostties.newSessionOpensComposer` preference.
     static let workspaceNewSession = Notification.Name("com.seansmithdesign.ghostties.workspace.newSession")
+
+    /// Posted by TerminalController when the user presses Cmd+Shift+T
+    /// ("New Session (Instant)", Phase 3). The notification object is the
+    /// originating NSWindow. Unlike `workspaceNewSession` above, this
+    /// ALWAYS creates a session immediately with no UI — it ignores the
+    /// `ghostties.newSessionOpensComposer` preference entirely.
+    static let workspaceNewSessionInstant = Notification.Name("com.seansmithdesign.ghostties.workspace.newSessionInstant")
 
     /// Posted by AppDelegate's Cmd+W local-event monitor, project-first
     /// workspace mode only (see `AppDelegate.isProjectFirstWorkspaceWindow(_:)`).

--- a/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceLayout.swift
@@ -36,6 +36,16 @@ enum WorkspaceLayout {
     /// free of the sidebar column instead of popping out of it.
     static let composerOverlayWidth: CGFloat = 360
 
+    /// Shadow opacity for the centered composer card (Phase 3 review fix —
+    /// reuses DESIGN.md §6's "Overlay" shadow level, the same spec the
+    /// overlay sidebar uses, since the composer card is the same "floats
+    /// above content" surface class).
+    static let composerModalShadowOpacity: Double = 0.20
+
+    /// Shadow blur radius for the centered composer card. Paired with
+    /// `composerModalShadowOpacity` above.
+    static let composerModalShadowRadius: CGFloat = 12
+
     /// Height reserved at top for window traffic light controls.
     static let titlebarSpacerHeight: CGFloat = 28
 
@@ -342,6 +352,25 @@ extension Notification.Name {
     /// ALWAYS creates a session immediately with no UI — it ignores the
     /// `ghostties.newSessionOpensComposer` preference entirely.
     static let workspaceNewSessionInstant = Notification.Name("com.seansmithdesign.ghostties.workspace.newSessionInstant")
+
+    /// Posted by `WorkspaceViewContainer.instantCreateSession()` and
+    /// `SessionComposerPalette.commit(template:)` right after a session is
+    /// created (F1 fix, Phase 3 review). The notification object is the
+    /// originating NSWindow; `userInfo["projectId"]` carries the `UUID` of
+    /// the project the session was created in. `WorkspaceSidebarView`
+    /// observes this to auto-expand that project — without it, a session
+    /// created via the cascade pick (Cmd+T, Cmd+Shift+T, or a composer
+    /// commit) into a collapsed project spawns with no visible row anywhere.
+    static let workspaceDidCreateSessionInProject = Notification.Name("com.seansmithdesign.ghostties.workspace.didCreateSessionInProject")
+
+    /// Posted by `WorkspaceViewContainer.presentComposerOverlay(projectBinding:)`
+    /// right before it opens the centered composer (F5 fix, Phase 3 review).
+    /// The notification object is the originating NSWindow. `ProjectDisclosureRow`
+    /// observes this and closes its own anchored composer popover, if open —
+    /// the single-presentation invariant: the centered overlay always wins
+    /// over a per-row popover, since both share the one `SessionComposerStore`
+    /// singleton's state.
+    static let workspaceComposerOverlayWillPresent = Notification.Name("com.seansmithdesign.ghostties.workspace.composerOverlayWillPresent")
 
     /// Posted by AppDelegate's Cmd+W local-event monitor, project-first
     /// workspace mode only (see `AppDelegate.isProjectFirstWorkspaceWindow(_:)`).

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -141,6 +141,17 @@ struct WorkspaceSidebarView: View {
             guard let index = notification.userInfo?["index"] as? Int else { return }
             focusVisibleSession(atIndex: index)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceDidCreateSessionInProject)) { notification in
+            // F1 (Phase 3 review): auto-expand the project a session was
+            // just created in — the cascade pick (Cmd+T, Cmd+Shift+T, or a
+            // composer commit) routinely lands in a project the user hasn't
+            // clicked and has probably collapsed, unlike the old
+            // `createNewSessionForSelectedProject()` this replaced, which
+            // always expanded the sidebar's own selection.
+            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
+            guard let projectId = notification.userInfo?["projectId"] as? UUID else { return }
+            expandedProjectIds.insert(projectId)
+        }
         .sheet(isPresented: Binding(
             get: { !hasSeenOnboarding },
             set: { _ in }
@@ -157,8 +168,9 @@ struct WorkspaceSidebarView: View {
         HStack(spacing: 8) {
             Spacer()
             // One labelled "new item" control per tab, right-aligned. Projects
-            // gets a plain action button; Sessions gets a menu-presenting
-            // button (project-picker flyout) — see `NewSessionToolbarButton`.
+            // gets a plain action button; Sessions gets a button that opens
+            // the centered session composer overlay (Phase 3 of
+            // session-creation-unified) — see `NewSessionToolbarButton`.
             if sidebarTab == .projects {
                 ToolbarLabelButton(systemName: "plus", label: "New Project", action: presentFolderPicker)
             } else {

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -132,10 +132,6 @@ struct WorkspaceSidebarView: View {
             guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
             selectAdjacentLiveSession(offset: -1)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .workspaceNewSession)) { notification in
-            guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
-            createNewSessionForSelectedProject()
-        }
         .onReceive(NotificationCenter.default.publisher(for: .workspaceCloseSession)) { notification in
             guard notification.object as? NSWindow === coordinator.containerView?.window else { return }
             coordinator.closeCurrentSessionWithConfirmation()
@@ -211,32 +207,10 @@ struct WorkspaceSidebarView: View {
 
     // MARK: - Actions
 
-    private var selectedProject: Project? {
-        guard let id = selectedProjectId else { return nil }
-        return store.projects.first { $0.id == id }
-    }
-
     private func presentFolderPicker() {
         if let id = store.addProjectViaFolderPicker() {
             selectedProjectId = id
             expandedProjectIds.insert(id)
-        }
-    }
-
-    /// Create a new session in the currently selected project.
-    private func createNewSessionForSelectedProject() {
-        guard let project = selectedProject else { return }
-        let template: AgentTemplate
-        if let defaultId = project.defaultTemplateId,
-           let defaultTemplate = store.templates.first(where: { $0.id == defaultId }) {
-            template = defaultTemplate
-        } else {
-            template = AgentTemplate.shell
-        }
-        // Auto-expand the target project so the new session is visible.
-        expandedProjectIds.insert(project.id)
-        Task {
-            await coordinator.createQuickSession(for: project, template: template)
         }
     }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -23,6 +23,30 @@ final class SidebarWidthModel: ObservableObject {
     }
 }
 
+/// Observable form of the composer overlay card's terminal-card-centering
+/// offset (R5, Phase 3 review round 2). `presentComposerOverlay` used to
+/// capture the offset once at present-time and bake it into `rootView`, so
+/// the card stayed parked at its original position after Cmd+S/Cmd+Shift+E
+/// (sidebar toggle) or Cmd+Shift+1/2 (view-mode switch) changed the sidebar
+/// width or mode while the composer was still open. Kept separate from
+/// `SidebarWidthModel` above — that one has a documented "never 0"
+/// invariant this must NOT share, since `.closed`/`.overlay` need 0 here.
+/// `WorkspaceViewContainer.syncComposerCenteringOffset()` writes it at every
+/// site that can change `sidebarMode` or the applied sidebar width.
+@MainActor
+final class ComposerCenteringModel: ObservableObject {
+    @Published var horizontalOffset: CGFloat = 0
+
+    /// Height of the scrim's titlebar-band exclusion (F7's fullscreen
+    /// follow-up, Phase 3 review round 2). Defaults to
+    /// `WorkspaceLayout.titlebarSpacerHeight`, the traffic-light band the
+    /// scrim excludes to keep window dragging working — but there's no
+    /// titlebar to protect in fullscreen, so that band was left undimmed
+    /// for no reason. `WorkspaceViewContainer.windowDidEnterOrExitFullScreen()`
+    /// writes 0 on entering fullscreen and restores the token on exit.
+    @Published var titlebarBandHeight: CGFloat = WorkspaceLayout.titlebarSpacerHeight
+}
+
 /// Wraps sidebar content in a `.frame(width:)` pin driven by `SidebarWidthModel`
 /// instead of a captured constant. Only this thin wrapper observes width
 /// changes, so the wrapped `content`'s identity — and the identity of
@@ -827,6 +851,10 @@ class WorkspaceViewContainer: NSView {
             // get re-clamped.
             self?.needsLayout = true
         })
+        // R5 (Phase 3 review round 2): a view-mode switch (Cmd+Shift+1/2)
+        // changes `currentSidebarWidth` even when `sidebarMode` itself
+        // doesn't — keep the composer overlay's card-centering offset live.
+        syncComposerCenteringOffset()
         updateTrackingAreas()
         invalidateIntrinsicContentSize()
     }
@@ -980,6 +1008,10 @@ class WorkspaceViewContainer: NSView {
         sidebarWidthConstraint.constant = clamped
         currentSidebarWidth = clamped
         widthModel.width = clamped
+        // R5 (Phase 3 review round 2): keep the composer overlay's
+        // card-centering offset following the live drag, same tick as
+        // `widthModel.width` above.
+        syncComposerCenteringOffset()
     }
 
     /// Persist the drag-resized width to this view mode's UserDefaults key.
@@ -1244,6 +1276,12 @@ class WorkspaceViewContainer: NSView {
             // get re-clamped.
             self?.needsLayout = true
         })
+        // R5 (Phase 3 review round 2): `sidebarMode` was already updated at
+        // the top of this function, and `widthModel.width` (if this
+        // transition touches it) was already set synchronously above — keep
+        // the composer overlay's card-centering offset live across
+        // Cmd+S/Cmd+Shift+E sidebar toggles.
+        syncComposerCenteringOffset()
 
         // 5. Non-animatable properties.
         switch newMode {
@@ -1375,7 +1413,34 @@ class WorkspaceViewContainer: NSView {
         // `SessionComposerStore` singleton's `searchText`/`selectedProjectId`,
         // and a cancel in either dismisses both (every container's `$isOpen`
         // sink honors the same `false`).
-        dismissComposerOverlayIfPresented()
+        //
+        // R1 (Phase 3 review round 2): raw resign-key is NOT "the user left
+        // the app" — it also fires whenever a modal panel/sheet/alert OWNED
+        // BY THE COMPOSER takes key: "+ Add project…"'s `NSOpenPanel` via
+        // `panel.runModal()` (`WorkspaceStore.addProjectViaFolderPicker()`),
+        // the template edit `.sheet`, the delete confirmation `.alert`, and
+        // possibly the project dropdown `.popover`. Every one of those keeps
+        // `NSApp.isActive == true` (same app, just a different key window
+        // within it) — dismissing on raw resign-key reintroduced, one layer
+        // down at the AppKit window level, exactly the focus-loss
+        // auto-dismiss `SessionComposerPalette`'s own header comment
+        // documents deliberately removing (ship gate 2): a genuine
+        // app-deactivation (Cmd+Tab away, click another app) sets
+        // `NSApp.isActive` false; none of the composer's own child UI does.
+        // `window?.attachedSheet == nil` is defense-in-depth specifically
+        // for the `.sheet`/`.alert` case, in case `isActive` ever doesn't
+        // hold during a sheet transition.
+        //
+        // A per-container `SessionComposerStore` (instead of `.shared`)
+        // would solve this AND the two-window sharing note above together,
+        // but touches every call site across `SessionComposerPalette.swift`,
+        // `SessionComposerOverlay.swift`, `ProjectDisclosureRow.swift`, and
+        // this file, and would silo the RECENT/MRU state the store also
+        // persists — which is meant to be shared across windows. That's not
+        // a contained change; this gate is.
+        if !NSApp.isActive && window?.attachedSheet == nil {
+            dismissComposerOverlayIfPresented()
+        }
         // Sidebar smart-sections freeze-on-focus (plan unit 4):
         // window blur is treated as the primary release trigger. The next time
         // the window becomes key we'll re-freeze with the (potentially changed)
@@ -1403,6 +1468,11 @@ class WorkspaceViewContainer: NSView {
         // Fullscreen transitions reposition the traffic lights. Trigger a layout
         // pass so titlebarRowTopAnchorConstant re-reads the new close-button frame.
         needsLayout = true
+        // F7 follow-up (Phase 3 review round 2): no titlebar to protect in
+        // fullscreen, so the composer overlay's scrim shouldn't leave that
+        // band undimmed there.
+        let isFullScreen = window?.styleMask.contains(.fullScreen) ?? false
+        composerCenteringModel.titlebarBandHeight = isFullScreen ? 0 : WorkspaceLayout.titlebarSpacerHeight
     }
 
     // MARK: - Session Composer Overlay (Phase 3)
@@ -1438,28 +1508,52 @@ class WorkspaceViewContainer: NSView {
         // closes its own popover.
         NotificationCenter.default.post(name: .workspaceComposerOverlayWillPresent, object: window)
 
-        let request = SessionComposerRequest(presentation: .centered, projectBinding: projectBinding)
-        composerOverlayHostingView.rootView = AnyView(
-            SessionComposerOverlay(request: request, horizontalOffset: terminalCardHorizontalOffset)
-                .environmentObject(WorkspaceStore.shared)
-                .environmentObject(coordinator)
-        )
+        // R2 (Phase 3 review round 2): the post above sets `showingTemplatePicker
+        // = false` synchronously in any open row, but SwiftUI tears the
+        // popover's CONTENT down — firing its `onChange(of: isPresented)` /
+        // `onDisappear`, both of which call `composerStore.cancel()` — on a
+        // LATER runloop turn, not this call stack. Opening/installing the
+        // overlay synchronously right after the post let that deferred
+        // teardown land AFTER us and immediately clobber `isOpen` back to
+        // `false`, killing the just-presented overlay one frame in (and,
+        // while both were briefly alive, leaving the old `.locked` popover
+        // visibly showing a `currentProjectBinding` this call had already
+        // overwritten — the wrong-project write F5 was supposed to close).
+        // Deferring this half to the next runloop turn lets the popover's
+        // teardown (and its `cancel()` calls) finish first, so nothing is
+        // left to clobber `isOpen` after we set it.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
 
-        // F4 (Phase 3 review): OBSERVED, not assumed — a scratch probe
-        // (NSHostingView, remove+re-add vs. rootView-reassign-only) showed
-        // `onAppear` reliably re-fires on a genuine remove+re-add of the
-        // hosting view, but does NOT re-fire when `rootView` is merely
-        // reassigned while the subview stays installed. That second case is
-        // exactly "Cmd+T while the overlay is already open"
-        // (`installComposerOverlayIfNeeded()` below is a no-op then), so
-        // `SessionComposerPalette.onAppear`'s call to `SessionComposerStore
-        // .open(...)` is not a reliable signal for it. Call `open()`
-        // explicitly here instead — it's idempotent, and when the store was
-        // already open this also sets `focusSearchFieldTrigger`, so Cmd+T
-        // while open refocuses the search field rather than doing nothing.
-        SessionComposerStore.shared.open(projectBinding: projectBinding, workspaceStore: WorkspaceStore.shared)
+            let request = SessionComposerRequest(presentation: .centered, projectBinding: projectBinding)
+            self.composerOverlayHostingView.rootView = AnyView(
+                SessionComposerOverlay(request: request, centeringModel: self.composerCenteringModel)
+                    .environmentObject(WorkspaceStore.shared)
+                    .environmentObject(self.coordinator)
+            )
 
-        installComposerOverlayIfNeeded()
+            // F4 (Phase 3 review): OBSERVED, not assumed — a scratch probe
+            // (NSHostingView, remove+re-add vs. rootView-reassign-only) showed
+            // `onAppear` reliably re-fires on a genuine remove+re-add of the
+            // hosting view, but does NOT re-fire when `rootView` is merely
+            // reassigned while the subview stays installed. That second case
+            // is exactly "Cmd+T while the overlay is already open"
+            // (`installComposerOverlayIfNeeded()` below is a no-op then), so
+            // `SessionComposerPalette.onAppear`'s call to
+            // `SessionComposerStore.open(...)` is not a reliable signal for
+            // it. Call `open()` explicitly here instead — it's idempotent,
+            // and when the store was already open this also sets
+            // `focusSearchFieldTrigger`, so Cmd+T while open refocuses the
+            // search field rather than doing nothing.
+            SessionComposerStore.shared.open(projectBinding: projectBinding, workspaceStore: WorkspaceStore.shared)
+
+            self.syncComposerCenteringOffset()
+            // F7 follow-up: correct even if the composer opens while
+            // already fullscreen, not just on a later enter/exit transition.
+            let isFullScreen = self.window?.styleMask.contains(.fullScreen) ?? false
+            self.composerCenteringModel.titlebarBandHeight = isFullScreen ? 0 : WorkspaceLayout.titlebarSpacerHeight
+            self.installComposerOverlayIfNeeded()
+        }
     }
 
     /// Offsets the composer card so it centers on the terminal card rather
@@ -1469,8 +1563,27 @@ class WorkspaceViewContainer: NSView {
     /// card is full-width, so no offset is needed. The scrim itself stays
     /// full-bleed regardless — the sidebar isn't usable while the composer
     /// is up, so dimming it is honest.
+    ///
+    /// Reads `widthModel.width` (the sidebar's live APPLIED width), not
+    /// `currentSidebarWidth` (the user's stored preference) — same
+    /// distinction `resizableWidth` above already draws, so the offset
+    /// tracks what's actually on screen during a drag or transition
+    /// animation, not the target it's animating toward.
     private var terminalCardHorizontalOffset: CGFloat {
-        sidebarMode == .pinned ? currentSidebarWidth : 0
+        sidebarMode == .pinned ? widthModel.width : 0
+    }
+
+    private lazy var composerCenteringModel = ComposerCenteringModel()
+
+    /// Writes the live offset into `composerCenteringModel` — called at
+    /// every site that can change `sidebarMode` or the applied sidebar
+    /// width (R5, Phase 3 review round 2). Deliberately NOT called from
+    /// `layout()`'s resize reclamp — that file remains untouched per the
+    /// original Phase 3 constraint; a window resize (not a sidebar
+    /// toggle/mode-switch/drag) while the composer is open in pinned mode
+    /// is the one residual case this doesn't cover live.
+    private func syncComposerCenteringOffset() {
+        composerCenteringModel.horizontalOffset = terminalCardHorizontalOffset
     }
 
     /// Guards the fade-out `removeFromSuperview()` in
@@ -1491,6 +1604,10 @@ class WorkspaceViewContainer: NSView {
     private func installComposerOverlayIfNeeded() {
         composerOverlayTransitionGeneration += 1
         let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        // R3 (Phase 3 review round 2): re-enable hit-testing on (re-)present
+        // — a fast dismiss-then-reopen can land here while a previous
+        // dismiss's fade-out (see below) had it disabled.
+        composerOverlayHostingView.isHitTestDisabled = false
 
         guard composerOverlayHostingView.superview == nil else {
             NSAnimationContext.runAnimationGroup { context in
@@ -1502,19 +1619,39 @@ class WorkspaceViewContainer: NSView {
 
         composerOverlayHostingView.alphaValue = 0
         addSubview(composerOverlayHostingView)
+        // R9 (Phase 3 review round 2): hide the sidebar and terminal from
+        // VoiceOver navigation while the overlay is up. `NSView` conforms to
+        // `NSAccessibilityProtocol` and exposes `setAccessibilityHidden(_:)`
+        // directly — SwiftUI's `.accessibilityAddTraits(.isModal)` would be
+        // a no-op here (the sidebar/terminal are separate `NSView`s in a
+        // different hosting tree, so `.isModal` has nothing to hide),
+        // confirmed by this round's reviewer, not "fixed" with it.
+        sidebarHostingView.setAccessibilityHidden(true)
+        terminalShadowHost.setAccessibilityHidden(true)
         NSLayoutConstraint.activate([
             composerOverlayHostingView.topAnchor.constraint(equalTo: topAnchor),
             composerOverlayHostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             composerOverlayHostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
             composerOverlayHostingView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-        // F10 (Phase 3 review): announce the new modal content to VoiceOver.
-        NSAccessibility.post(element: composerOverlayHostingView, notification: .layoutChanged)
 
-        NSAnimationContext.runAnimationGroup { context in
+        NSAnimationContext.runAnimationGroup({ context in
             context.duration = reduceMotion ? 0 : 0.2
             composerOverlayHostingView.animator().alphaValue = 1
-        }
+        }, completionHandler: { [weak self] in
+            // R9/F10 (Phase 3 review round 2): posting `.layoutChanged`
+            // before the fade-in and before SwiftUI has laid out the
+            // reassigned `rootView` announced a change without moving VO
+            // focus into the new content (no `NSAccessibilityUIElementsKey`)
+            // — deferred to the fade-in's completion, with the hosting view
+            // itself as the target element so VO actually moves there.
+            guard let self else { return }
+            NSAccessibility.post(
+                element: self.composerOverlayHostingView,
+                notification: .layoutChanged,
+                userInfo: [.uiElements: [self.composerOverlayHostingView as Any]]
+            )
+        })
     }
 
     /// Removes the composer overlay hosting view. No-op if not installed.
@@ -1530,7 +1667,41 @@ class WorkspaceViewContainer: NSView {
     private func dismissComposerOverlayIfPresented() {
         guard composerOverlayHostingView.superview != nil else { return }
 
-        if let controller = window?.windowController as? BaseTerminalController,
+        // R3 (Phase 3 review round 2): disable hit-testing FIRST, before the
+        // fade starts — `NSView.hitTest(_:)` skips HIDDEN views but does not
+        // consider `alphaValue`, so without this the full-bounds scrim stays
+        // fully clickable for the entire 0.2s fade-out. A click into the
+        // terminal to resume typing during that window would otherwise land
+        // on the invisible scrim's `.onTapGesture { cancel() }` (eating the
+        // click and re-entering dismiss, extending the dead window), and a
+        // fast double-click on a template row could fire `commit()` twice —
+        // `ComposerRow`'s `Button(action:)` calls `option.action()` directly
+        // and never reads `selectedIndex`, so the keyboard path's
+        // double-Return guard doesn't cover it.
+        composerOverlayHostingView.isHitTestDisabled = true
+
+        // R9 (Phase 3 review round 2): restore VoiceOver navigation into the
+        // sidebar and terminal — the counterpart to the hide in
+        // `installComposerOverlayIfNeeded()`.
+        sidebarHostingView.setAccessibilityHidden(false)
+        terminalShadowHost.setAccessibilityHidden(false)
+
+        // R4 (Phase 3 review round 2): only steal first responder back to
+        // the terminal if THIS window is actually key. `makeFirstResponder`
+        // doesn't steal key across windows, but `windowDidResignKey` calls
+        // this too — without the guard, every resign-key with the composer
+        // open would call `makeFirstResponder` on a window that just lost
+        // key status, which (via `BaseTerminalController`'s window-delegate
+        // `syncFocusToSurfaceTree()`, wired at nib-load and so running
+        // BEFORE this container's later `viewDidMoveToWindow` registration)
+        // re-sets `ghostty_surface_set_focus(surface, true)` on a non-key
+        // window: a blinking cursor in an inactive window, `SecureInput`
+        // scoped active while the app is inactive, and — with DECSET 1004
+        // (Claude Code's TUI, vim, tmux) — an inverted pty focus report that
+        // never self-corrects, because `SurfaceView_AppKit.focusDidChange`
+        // early-returns when `self.focused` already matches on the way back.
+        if window?.isKeyWindow == true,
+           let controller = window?.windowController as? BaseTerminalController,
            let focusedSurface = controller.focusedSurface {
             window?.makeFirstResponder(focusedSurface)
         }
@@ -1981,6 +2152,19 @@ extension WorkspaceViewContainer: NSTextFieldDelegate {
 /// 85 KB file.
 class TransparentHostingView<Content: View>: NSHostingView<Content> {
     override var isOpaque: Bool { false }
+
+    /// When `true`, this view (and everything inside it) is excluded from
+    /// hit-testing even though it's still on screen (R3, Phase 3 review
+    /// round 2). `NSView.hitTest(_:)` skips HIDDEN views but does not
+    /// consider `alphaValue` — a view fading out via `.animator().alphaValue`
+    /// stays fully clickable for the whole animation unless something like
+    /// this exists. Opt-in and off by default so the sidebar's own use of
+    /// this class (which doesn't fade the same way) is unaffected.
+    var isHitTestDisabled = false
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        isHitTestDisabled ? nil : super.hitTest(point)
+    }
 }
 
 // MARK: - Panel Drag Handle

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -178,6 +178,10 @@ class WorkspaceViewContainer: NSView {
     private lazy var composerOverlayHostingView: TransparentHostingView<AnyView> = {
         let view = TransparentHostingView<AnyView>(rootView: AnyView(EmptyView()))
         view.translatesAutoresizingMaskIntoConstraints = false
+        // F9 (Phase 3 review): matches `sidebarHostingView` — this view is
+        // pinned by four edge constraints, so its own intrinsic-size
+        // reporting is unused work.
+        view.sizingOptions = []
         return view
     }()
 
@@ -192,11 +196,21 @@ class WorkspaceViewContainer: NSView {
     /// Whether Cmd+T opens the composer overlay (true, the default) or
     /// creates a session instantly with no UI (false). Unset defaults to
     /// composer per the locked decision in session-creation-unified.
-    private var newSessionOpensComposerPreference: Bool {
-        guard UserDefaults.standard.object(forKey: Self.newSessionOpensComposerDefaultsKey) != nil else {
+    ///
+    /// Extracted to a testable static function (F11, Phase 3 review) taking
+    /// an explicit `UserDefaults` — this exact absent/true/false resolution
+    /// is precisely the class of bug the review pass was chartered to catch,
+    /// so it's covered directly rather than only through the instance
+    /// property below.
+    static func newSessionOpensComposer(in defaults: UserDefaults) -> Bool {
+        guard defaults.object(forKey: newSessionOpensComposerDefaultsKey) != nil else {
             return true
         }
-        return UserDefaults.standard.bool(forKey: Self.newSessionOpensComposerDefaultsKey)
+        return defaults.bool(forKey: newSessionOpensComposerDefaultsKey)
+    }
+
+    private var newSessionOpensComposerPreference: Bool {
+        Self.newSessionOpensComposer(in: .standard)
     }
 
     /// Sidebar material backing for overlay mode. In pinned mode the shared
@@ -1354,6 +1368,14 @@ class WorkspaceViewContainer: NSView {
         if sidebarMode == .overlay {
             transitionTo(.closed)
         }
+        // F5 (Phase 3 review): the Phase 2 popover auto-closes on blur (native
+        // `NSPopover` behavior); the centered overlay is a plain subview and
+        // survives app deactivation on its own. Two workspace windows can
+        // otherwise each hold an installed overlay sharing the one
+        // `SessionComposerStore` singleton's `searchText`/`selectedProjectId`,
+        // and a cancel in either dismisses both (every container's `$isOpen`
+        // sink honors the same `false`).
+        dismissComposerOverlayIfPresented()
         // Sidebar smart-sections freeze-on-focus (plan unit 4):
         // window blur is treated as the primary release trigger. The next time
         // the window becomes key we'll re-freeze with the (potentially changed)
@@ -1408,21 +1430,77 @@ class WorkspaceViewContainer: NSView {
     /// "+ New Session" button (`NewSessionToolbarButton`, which reaches this
     /// via `coordinator.containerView`).
     func presentComposerOverlay(projectBinding: SessionComposerRequest.ProjectBinding) {
+        // F5 (Phase 3 review): single-presentation invariant — the centered
+        // overlay always wins over any open per-row anchored popover, since
+        // both share the one `SessionComposerStore` singleton's state and a
+        // second opener silently defeats the popover's `.locked` write-path
+        // enforcement otherwise. `ProjectDisclosureRow` observes this and
+        // closes its own popover.
+        NotificationCenter.default.post(name: .workspaceComposerOverlayWillPresent, object: window)
+
         let request = SessionComposerRequest(presentation: .centered, projectBinding: projectBinding)
         composerOverlayHostingView.rootView = AnyView(
-            SessionComposerOverlay(request: request)
+            SessionComposerOverlay(request: request, horizontalOffset: terminalCardHorizontalOffset)
                 .environmentObject(WorkspaceStore.shared)
                 .environmentObject(coordinator)
         )
+
+        // F4 (Phase 3 review): OBSERVED, not assumed — a scratch probe
+        // (NSHostingView, remove+re-add vs. rootView-reassign-only) showed
+        // `onAppear` reliably re-fires on a genuine remove+re-add of the
+        // hosting view, but does NOT re-fire when `rootView` is merely
+        // reassigned while the subview stays installed. That second case is
+        // exactly "Cmd+T while the overlay is already open"
+        // (`installComposerOverlayIfNeeded()` below is a no-op then), so
+        // `SessionComposerPalette.onAppear`'s call to `SessionComposerStore
+        // .open(...)` is not a reliable signal for it. Call `open()`
+        // explicitly here instead — it's idempotent, and when the store was
+        // already open this also sets `focusSearchFieldTrigger`, so Cmd+T
+        // while open refocuses the search field rather than doing nothing.
+        SessionComposerStore.shared.open(projectBinding: projectBinding, workspaceStore: WorkspaceStore.shared)
+
         installComposerOverlayIfNeeded()
     }
 
+    /// Offsets the composer card so it centers on the terminal card rather
+    /// than the whole window (Sean's design decision 2, Phase 3 review) —
+    /// only meaningful in `.pinned` mode, where the sidebar actually pushes
+    /// the terminal card rightward. In `.closed`/`.overlay` the terminal
+    /// card is full-width, so no offset is needed. The scrim itself stays
+    /// full-bleed regardless — the sidebar isn't usable while the composer
+    /// is up, so dimming it is honest.
+    private var terminalCardHorizontalOffset: CGFloat {
+        sidebarMode == .pinned ? currentSidebarWidth : 0
+    }
+
+    /// Guards the fade-out `removeFromSuperview()` in
+    /// `dismissComposerOverlayIfPresented()` against a fast re-open
+    /// (Escape immediately followed by Cmd+T) — bumped on every
+    /// install/dismiss call so a dismiss's deferred completion handler can
+    /// detect it was superseded and skip yanking the freshly re-presented
+    /// overlay back out mid-animation.
+    private var composerOverlayTransitionGeneration = 0
+
     /// Adds the composer overlay hosting view as a subview, pinned to the
     /// container's full bounds — not `layout()` — so its scrim can dim the
-    /// whole terminal. No-op if already installed (re-presenting just swaps
-    /// `rootView` above).
+    /// whole terminal. Fades in (F8, Phase 3 review) to match every other
+    /// appear-over-content transition in this container (`transitionTo(_:)`'s
+    /// 0.2s convention). If the view is still attached (e.g. mid a dismiss
+    /// fade-out that this call is interrupting), just animates it back to
+    /// fully visible instead of re-adding it.
     private func installComposerOverlayIfNeeded() {
-        guard composerOverlayHostingView.superview == nil else { return }
+        composerOverlayTransitionGeneration += 1
+        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+
+        guard composerOverlayHostingView.superview == nil else {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = reduceMotion ? 0 : 0.2
+                composerOverlayHostingView.animator().alphaValue = 1
+            }
+            return
+        }
+
+        composerOverlayHostingView.alphaValue = 0
         addSubview(composerOverlayHostingView)
         NSLayoutConstraint.activate([
             composerOverlayHostingView.topAnchor.constraint(equalTo: topAnchor),
@@ -1430,12 +1508,43 @@ class WorkspaceViewContainer: NSView {
             composerOverlayHostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
             composerOverlayHostingView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+        // F10 (Phase 3 review): announce the new modal content to VoiceOver.
+        NSAccessibility.post(element: composerOverlayHostingView, notification: .layoutChanged)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = reduceMotion ? 0 : 0.2
+            composerOverlayHostingView.animator().alphaValue = 1
+        }
     }
 
     /// Removes the composer overlay hosting view. No-op if not installed.
+    /// Fades out (F8) to match `installComposerOverlayIfNeeded()`'s fade-in,
+    /// and restores first responder to the focused terminal surface
+    /// immediately (F3, Phase 3 review) — `removeFromSuperview()` alone
+    /// hands first responder back to the WINDOW, not the terminal, the same
+    /// failure mode already solved for the command palette
+    /// (`TerminalCommandPaletteView.onChange(of: isPresented)`) and inline
+    /// tab-title editing (`TerminalWindow.tabTitleEditor(_:didFinishEditing:)`).
+    /// Without this, Escape (or any other dismiss) leaves the terminal
+    /// keyboard-dead until the user clicks it.
     private func dismissComposerOverlayIfPresented() {
         guard composerOverlayHostingView.superview != nil else { return }
-        composerOverlayHostingView.removeFromSuperview()
+
+        if let controller = window?.windowController as? BaseTerminalController,
+           let focusedSurface = controller.focusedSurface {
+            window?.makeFirstResponder(focusedSurface)
+        }
+
+        composerOverlayTransitionGeneration += 1
+        let myGeneration = composerOverlayTransitionGeneration
+        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = reduceMotion ? 0 : 0.2
+            composerOverlayHostingView.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            guard let self, self.composerOverlayTransitionGeneration == myGeneration else { return }
+            self.composerOverlayHostingView.removeFromSuperview()
+        })
     }
 
     /// Instant session creation — Cmd+Shift+T (always) and Cmd+T when the
@@ -1457,6 +1566,15 @@ class WorkspaceViewContainer: NSView {
         } else {
             template = AgentTemplate.shell
         }
+
+        // F1 (Phase 3 review): without this, a session created via the
+        // cascade pick into a collapsed project spawns with no visible
+        // sidebar row — see `WorkspaceLayout.workspaceDidCreateSessionInProject`.
+        NotificationCenter.default.post(
+            name: .workspaceDidCreateSessionInProject,
+            object: window,
+            userInfo: ["projectId": project.id]
+        )
 
         Task {
             await coordinator.createQuickSession(for: project, template: template)
@@ -1693,6 +1811,18 @@ class WorkspaceViewContainer: NSView {
         // store closes (Esc, scrim click, or a successful commit) — every
         // close path funnels through `SessionComposerStore.isOpen`, so this
         // is the single place the subview teardown needs to live (Phase 3).
+        //
+        // F9 (Phase 3 review) — LOAD-BEARING DEPENDENCY: this sink only
+        // fires reliably because `@Published` re-emits `willSet` on every
+        // assignment, even one that doesn't change the value. `cancel()`
+        // sets `isOpen = false` unconditionally, including when it's
+        // already `false` — if `isOpen`'s setter ever grows an equality
+        // guard (`didSet`-style "optimization" to skip redundant publishes),
+        // a cancel that lands while `isOpen` is already `false` would
+        // silently stop reaching this sink — the subview would stay
+        // installed until the next `windowDidResignKey` (the only other
+        // dismiss path) rather than closing when the user actually asked.
+        // Do not add that guard.
         SessionComposerStore.shared.$isOpen
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isOpen in

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -2076,9 +2076,12 @@ class WorkspaceViewContainer: NSView {
         // guard (`didSet`-style "optimization" to skip redundant publishes),
         // a cancel that lands while `isOpen` is already `false` would
         // silently stop reaching this sink — the subview would stay
-        // installed until the next `windowDidResignKey` (the only other
-        // dismiss path) rather than closing when the user actually asked.
-        // Do not add that guard.
+        // installed until the next `applicationDidResignActive()` (app
+        // deactivation) or the next cross-window takeover in
+        // `presentComposerOverlay` (the other two dismiss paths, as of
+        // Blocker 3 below — `windowDidResignKey` no longer dismisses the
+        // composer at all) rather than closing when the user actually
+        // asked. Do not add that guard.
         //
         // Blocker 1 (Phase 3 review round 3): `.receive(on: DispatchQueue.main)`
         // is ALWAYS an async hop for Combine's `DispatchQueue` scheduler —
@@ -2100,6 +2103,20 @@ class WorkspaceViewContainer: NSView {
         // if a stale `false` is processed after `presentComposerOverlay`
         // already reopened the store, this now no-ops instead of tearing
         // the fresh overlay back down.
+        //
+        // FRAGILITY (Phase 3 review round 4) — `.receive(on: DispatchQueue.main)`
+        // below is NOT decorative; the live re-read above depends on it.
+        // `@Published` emits in `willSet`, i.e. BEFORE the stored property
+        // is actually updated — the closure below only sees the post-write
+        // value because the scheduler's async hop guarantees this closure
+        // runs strictly after the assignment that triggered it has already
+        // landed. Remove `.receive(on:)` as a "simplification" and this
+        // sink would run synchronously from within `willSet`, so
+        // `!SessionComposerStore.shared.isOpen` would read the PRE-`willSet`
+        // value (`true`, the value being replaced, not the `false` being
+        // set) — the guard above would then always fail, and every dismiss
+        // (scrim click, Escape, everything routed through `cancel()`) would
+        // die silently. Keep the hop.
         SessionComposerStore.shared.$isOpen
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -168,6 +168,37 @@ class WorkspaceViewContainer: NSView {
         return view
     }()
 
+    /// Hosting view for the centered session composer overlay (Phase 3 of
+    /// session-creation-unified). Added as a subview only while
+    /// `SessionComposerStore.shared.isOpen` is true — see
+    /// `presentComposerOverlay(projectBinding:)` and the `isOpen` subscription
+    /// in `setup()`. Pinned to the container's full bounds so
+    /// `SessionComposerOverlay`'s scrim can dim the whole terminal; not
+    /// touched by `layout()`.
+    private lazy var composerOverlayHostingView: TransparentHostingView<AnyView> = {
+        let view = TransparentHostingView<AnyView>(rootView: AnyView(EmptyView()))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    /// UserDefaults key for the Cmd+T preference — composer (default) vs.
+    /// instant create. Mirrors `Ghostty.Config.autoUpdateChannel`'s
+    /// resolution pattern (`ghostties.autoUpdateChannel`): a plain
+    /// `UserDefaults.standard` read, since this container is an AppKit
+    /// `NSView` and can't use the `@AppStorage` property wrapper directly.
+    /// Documented in `SettingsView.swift` beside the update-channel line.
+    private static let newSessionOpensComposerDefaultsKey = "ghostties.newSessionOpensComposer"
+
+    /// Whether Cmd+T opens the composer overlay (true, the default) or
+    /// creates a session instantly with no UI (false). Unset defaults to
+    /// composer per the locked decision in session-creation-unified.
+    private var newSessionOpensComposerPreference: Bool {
+        guard UserDefaults.standard.object(forKey: Self.newSessionOpensComposerDefaultsKey) != nil else {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: Self.newSessionOpensComposerDefaultsKey)
+    }
+
     /// Sidebar material backing for overlay mode. In pinned mode the shared
     /// `backgroundEffectView` already covers the sidebar area, so this is hidden.
     /// In overlay mode it provides the .sidebar material behind the hosting view
@@ -447,6 +478,8 @@ class WorkspaceViewContainer: NSView {
         NotificationCenter.default.removeObserver(self, name: NSWindow.willEnterFullScreenNotification, object: fullScreenObservedWindow)
         NotificationCenter.default.removeObserver(self, name: NSWindow.didEnterFullScreenNotification, object: fullScreenObservedWindow)
         NotificationCenter.default.removeObserver(self, name: NSWindow.didExitFullScreenNotification, object: fullScreenObservedWindow)
+        NotificationCenter.default.removeObserver(self, name: .workspaceNewSession, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .workspaceNewSessionInstant, object: nil)
 
         guard let window = window else { return }
         // Give the coordinator a reference to this view so it can discover
@@ -503,6 +536,27 @@ class WorkspaceViewContainer: NSView {
             object: window
         )
         fullScreenObservedWindow = window
+
+        // Cmd+T (Phase 3 of session-creation-unified). Moved here from
+        // `WorkspaceSidebarView` (D2 fix) so the container — present
+        // regardless of which sidebar view mode is currently mounted —
+        // always receives it, rather than only whichever SwiftUI sidebar
+        // view happens to observe it.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWorkspaceNewSession(_:)),
+            name: .workspaceNewSession,
+            object: window
+        )
+
+        // Cmd+Shift+T ("New Session (Instant)", Phase 3) — always creates
+        // immediately, ignoring the Cmd+T preference entirely.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWorkspaceNewSessionInstant(_:)),
+            name: .workspaceNewSessionInstant,
+            object: window
+        )
 
         // If the window is already key when we move into it, freeze immediately.
         if window.isKeyWindow {
@@ -1329,6 +1383,86 @@ class WorkspaceViewContainer: NSView {
         needsLayout = true
     }
 
+    // MARK: - Session Composer Overlay (Phase 3)
+
+    /// Cmd+T. Opens the composer overlay by default; creates a session
+    /// instantly (no UI) when `ghostties.newSessionOpensComposer` is off —
+    /// both paths use the same smart-default cascade (D1: no more "nothing
+    /// selected" guard).
+    @objc private func handleWorkspaceNewSession(_ notification: Notification) {
+        if newSessionOpensComposerPreference {
+            presentComposerOverlay(projectBinding: .open)
+        } else {
+            instantCreateSession()
+        }
+    }
+
+    /// Cmd+Shift+T. Always creates instantly — the Cmd+T preference is
+    /// never consulted here.
+    @objc private func handleWorkspaceNewSessionInstant(_ notification: Notification) {
+        instantCreateSession()
+    }
+
+    /// Opens the centered session composer overlay. Called from Cmd+T
+    /// (composer preference on, the default) and the sidebar toolbar's
+    /// "+ New Session" button (`NewSessionToolbarButton`, which reaches this
+    /// via `coordinator.containerView`).
+    func presentComposerOverlay(projectBinding: SessionComposerRequest.ProjectBinding) {
+        let request = SessionComposerRequest(presentation: .centered, projectBinding: projectBinding)
+        composerOverlayHostingView.rootView = AnyView(
+            SessionComposerOverlay(request: request)
+                .environmentObject(WorkspaceStore.shared)
+                .environmentObject(coordinator)
+        )
+        installComposerOverlayIfNeeded()
+    }
+
+    /// Adds the composer overlay hosting view as a subview, pinned to the
+    /// container's full bounds — not `layout()` — so its scrim can dim the
+    /// whole terminal. No-op if already installed (re-presenting just swaps
+    /// `rootView` above).
+    private func installComposerOverlayIfNeeded() {
+        guard composerOverlayHostingView.superview == nil else { return }
+        addSubview(composerOverlayHostingView)
+        NSLayoutConstraint.activate([
+            composerOverlayHostingView.topAnchor.constraint(equalTo: topAnchor),
+            composerOverlayHostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            composerOverlayHostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            composerOverlayHostingView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    /// Removes the composer overlay hosting view. No-op if not installed.
+    private func dismissComposerOverlayIfPresented() {
+        guard composerOverlayHostingView.superview != nil else { return }
+        composerOverlayHostingView.removeFromSuperview()
+    }
+
+    /// Instant session creation — Cmd+Shift+T (always) and Cmd+T when the
+    /// `ghostties.newSessionOpensComposer` preference is off. Resolves the
+    /// same smart-default cascade the composer uses, then creates directly
+    /// with the project's default template (falling back to `.shell`), with
+    /// no UI. Mirrors the deleted
+    /// `WorkspaceSidebarView.createNewSessionForSelectedProject()`, but uses
+    /// the cascade pick instead of the sidebar's `selectedProjectId`.
+    private func instantCreateSession() {
+        let store = WorkspaceStore.shared
+        guard let projectId = SessionComposerStore.shared.resolveCascadeProject(workspaceStore: store),
+              let project = store.projects.first(where: { $0.id == projectId }) else { return }
+
+        let template: AgentTemplate
+        if let defaultId = project.defaultTemplateId,
+           let defaultTemplate = store.templates.first(where: { $0.id == defaultId }) {
+            template = defaultTemplate
+        } else {
+            template = AgentTemplate.shell
+        }
+
+        Task {
+            await coordinator.createQuickSession(for: project, template: template)
+        }
+    }
+
     // MARK: - Layout
 
     private func setup() {
@@ -1555,6 +1689,18 @@ class WorkspaceViewContainer: NSView {
             browserToggleButton.alphaValue = 0
         }
 
+        // Dismiss the composer overlay's hosting view whenever the composer
+        // store closes (Esc, scrim click, or a successful commit) — every
+        // close path funnels through `SessionComposerStore.isOpen`, so this
+        // is the single place the subview teardown needs to live (Phase 3).
+        SessionComposerStore.shared.$isOpen
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isOpen in
+                guard !isOpen else { return }
+                self?.dismissComposerOverlayIfPresented()
+            }
+            .store(in: &cancellables)
+
         // Bind title label to the active session name.
         coordinator.$activeSessionId
             .combineLatest(WorkspaceStore.shared.$sessions)
@@ -1698,7 +1844,12 @@ extension WorkspaceViewContainer: NSTextFieldDelegate {
 /// Used for the sidebar so it's transparent in pinned mode — the window
 /// background shows through. The overlay NSVisualEffectView provides
 /// material only in hover mode.
-private class TransparentHostingView<Content: View>: NSHostingView<Content> {
+///
+/// Internal (not `private`) since Phase 3 of session-creation-unified hosts
+/// the session composer overlay through it too — kept in this file rather
+/// than moved, so the composer overlay's own view code stays out of this
+/// 85 KB file.
+class TransparentHostingView<Content: View>: NSHostingView<Content> {
     override var isOpaque: Bool { false }
 }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -496,6 +496,23 @@ class WorkspaceViewContainer: NSView {
             name: .workspaceSidebarViewModeChanged,
             object: nil
         )
+
+        // Blocker 3 (Phase 3 review round 3): the composer overlay's
+        // "dismiss on leaving the app" behavior now observes
+        // `NSApplication.didResignActiveNotification` directly, replacing
+        // the `NSApp.isActive` check that used to live inline in
+        // `windowDidResignKey()` — that check was asserted, not observed,
+        // to hold at the point a WINDOW resigns key, and a window resigning
+        // key is not the same event as the app deactivating. App-wide, not
+        // window-scoped, so registered once here rather than per-window in
+        // `viewDidMoveToWindow()`; `object: nil` is correct since there's
+        // only one `NSApp`.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidResignActive),
+            name: NSApplication.didResignActiveNotification,
+            object: nil
+        )
     }
 
     @available(*, unavailable)
@@ -1406,41 +1423,31 @@ class WorkspaceViewContainer: NSView {
         if sidebarMode == .overlay {
             transitionTo(.closed)
         }
-        // F5 (Phase 3 review): the Phase 2 popover auto-closes on blur (native
-        // `NSPopover` behavior); the centered overlay is a plain subview and
-        // survives app deactivation on its own. Two workspace windows can
-        // otherwise each hold an installed overlay sharing the one
-        // `SessionComposerStore` singleton's `searchText`/`selectedProjectId`,
-        // and a cancel in either dismisses both (every container's `$isOpen`
-        // sink honors the same `false`).
-        //
-        // R1 (Phase 3 review round 2): raw resign-key is NOT "the user left
-        // the app" — it also fires whenever a modal panel/sheet/alert OWNED
-        // BY THE COMPOSER takes key: "+ Add project…"'s `NSOpenPanel` via
-        // `panel.runModal()` (`WorkspaceStore.addProjectViaFolderPicker()`),
-        // the template edit `.sheet`, the delete confirmation `.alert`, and
-        // possibly the project dropdown `.popover`. Every one of those keeps
-        // `NSApp.isActive == true` (same app, just a different key window
-        // within it) — dismissing on raw resign-key reintroduced, one layer
-        // down at the AppKit window level, exactly the focus-loss
-        // auto-dismiss `SessionComposerPalette`'s own header comment
-        // documents deliberately removing (ship gate 2): a genuine
-        // app-deactivation (Cmd+Tab away, click another app) sets
-        // `NSApp.isActive` false; none of the composer's own child UI does.
-        // `window?.attachedSheet == nil` is defense-in-depth specifically
-        // for the `.sheet`/`.alert` case, in case `isActive` ever doesn't
-        // hold during a sheet transition.
-        //
-        // A per-container `SessionComposerStore` (instead of `.shared`)
-        // would solve this AND the two-window sharing note above together,
-        // but touches every call site across `SessionComposerPalette.swift`,
-        // `SessionComposerOverlay.swift`, `ProjectDisclosureRow.swift`, and
-        // this file, and would silo the RECENT/MRU state the store also
-        // persists — which is meant to be shared across windows. That's not
-        // a contained change; this gate is.
-        if !NSApp.isActive && window?.attachedSheet == nil {
-            dismissComposerOverlayIfPresented()
-        }
+        // Blocker 3 (Phase 3 review round 3): the composer-dismiss clause
+        // that used to live here is gone. Round 2's `NSApp.isActive` gate
+        // had two problems: (1) `SessionCoordinator`/this container is
+        // per-window, so gating a PER-WINDOW resign-key notification doesn't
+        // distinguish "another Ghostties window took key" (should NOT
+        // dismiss this window's overlay — no bug here, working as intended)
+        // from "the app itself was deactivated" (should dismiss, but this
+        // notification alone can't tell); and worse, with the gate in place
+        // clicking window B never dismissed window A's overlay either,
+        // reopening round 1's original two-window finding. (2) `NSApp
+        // .isActive` inside a window-resign-key handler is ASSERTED, not
+        // observed to actually be accurate at that point in AppKit's
+        // documented ordering (`willResignActive` -> window resigns key ->
+        // `didResignActive`) — if it still read `true` there, the gate was
+        // always false and dismiss-on-leave-app was silently dead code, a
+        // revert of F5 nobody would have noticed. Fixed by not inferring
+        // app-deactivation from a window notification at all — see
+        // `applicationDidResignActive()` below, which observes
+        // `NSApplication.didResignActiveNotification` directly, and the
+        // per-overlay `owningWindow` ownership check in
+        // `presentComposerOverlay`/`dismissComposerOverlayIfPresented` that
+        // makes each container ignore dismiss signals for an overlay it
+        // doesn't own — together these replace both halves of what this
+        // clause tried to do, correctly, without reintroducing the
+        // per-container-store refactor rejected in round 2 as too large.
         // Sidebar smart-sections freeze-on-focus (plan unit 4):
         // window blur is treated as the primary release trigger. The next time
         // the window becomes key we'll re-freeze with the (potentially changed)
@@ -1455,6 +1462,17 @@ class WorkspaceViewContainer: NSView {
         // any time the user is interacting with this window, the sidebar's
         // bucketing is frozen.
         WorkspaceStore.shared.releaseSnapshot()
+    }
+
+    /// Blocker 3 (Phase 3 review round 3): the genuine "user left the app"
+    /// dismiss for the composer overlay — see the registration comment in
+    /// `init` and the removed-clause comment in `windowDidResignKey()`
+    /// above for what this replaces and why. Every container independently
+    /// receives this (one `NSApp`, `object: nil`); `dismissComposerOverlayIfPresented()`
+    /// already self-guards on `superview != nil`, so only the window(s)
+    /// that actually have an installed overlay do anything.
+    @objc private func applicationDidResignActive() {
+        dismissComposerOverlayIfPresented()
     }
 
     @objc private func windowDidBecomeKey() {
@@ -1500,6 +1518,19 @@ class WorkspaceViewContainer: NSView {
     /// "+ New Session" button (`NewSessionToolbarButton`, which reaches this
     /// via `coordinator.containerView`).
     func presentComposerOverlay(projectBinding: SessionComposerRequest.ProjectBinding) {
+        // Blocker 3 (Phase 3 review round 3): if a DIFFERENT window
+        // currently owns an open composer, dismiss its overlay first — this
+        // window is about to become the sole owner of
+        // `SessionComposerStore.shared`'s state. Without this, two windows
+        // could each install their own overlay against the same shared
+        // store, each visibly showing whichever window opened last.
+        if let currentOwner = SessionComposerStore.shared.owningWindow,
+           currentOwner !== window,
+           let ownerContainer = currentOwner.contentView as? WorkspaceViewContainer {
+            ownerContainer.dismissComposerOverlayIfPresented()
+        }
+        SessionComposerStore.shared.owningWindow = window
+
         // F5 (Phase 3 review): single-presentation invariant — the centered
         // overlay always wins over any open per-row anchored popover, since
         // both share the one `SessionComposerStore` singleton's state and a
@@ -1509,19 +1540,35 @@ class WorkspaceViewContainer: NSView {
         NotificationCenter.default.post(name: .workspaceComposerOverlayWillPresent, object: window)
 
         // R2 (Phase 3 review round 2): the post above sets `showingTemplatePicker
-        // = false` synchronously in any open row, but SwiftUI tears the
-        // popover's CONTENT down — firing its `onChange(of: isPresented)` /
-        // `onDisappear`, both of which call `composerStore.cancel()` — on a
-        // LATER runloop turn, not this call stack. Opening/installing the
-        // overlay synchronously right after the post let that deferred
-        // teardown land AFTER us and immediately clobber `isOpen` back to
-        // `false`, killing the just-presented overlay one frame in (and,
-        // while both were briefly alive, leaving the old `.locked` popover
-        // visibly showing a `currentProjectBinding` this call had already
-        // overwritten — the wrong-project write F5 was supposed to close).
-        // Deferring this half to the next runloop turn lets the popover's
-        // teardown (and its `cancel()` calls) finish first, so nothing is
-        // left to clobber `isOpen` after we set it.
+        // = false` synchronously in any open row, but the popover's CONTENT
+        // teardown — firing its `onChange(of: isPresented)` / `onDisappear`,
+        // both of which call `composerStore.cancel()` — was NOT proven to
+        // run within this same call stack. Opening/installing the overlay
+        // synchronously right after the post let a `cancel()` from that
+        // teardown (whenever it actually lands) clobber `isOpen` back to
+        // `false` immediately after we set it, killing the just-presented
+        // overlay one frame in (and, while both were briefly alive, leaving
+        // the old `.locked` popover visibly showing a `currentProjectBinding`
+        // this call had already overwritten — the wrong-project write F5 was
+        // supposed to close).
+        //
+        // Blocker 1 (Phase 3 review round 3): deferring this half to the
+        // next runloop turn does NOT, by itself, guarantee the popover's
+        // deferred teardown (if it is in fact deferred — see the
+        // `$isOpen` sink's comment in `setup()`) lands BEFORE this block
+        // rather than after; the relative order of two independently
+        // GCD-queued `DispatchQueue.main.async` blocks competing with
+        // SwiftUI's own internal update scheduling is not something either
+        // system's public contract guarantees, and this repo could not
+        // resolve it empirically (see that same sink comment). The actual
+        // fix for the race is on the OTHER end: the `$isOpen` sink re-checks
+        // the LIVE `isOpen` value before dismissing, instead of trusting a
+        // possibly-stale emitted one, which makes the outcome correct
+        // regardless of which block runs first. This deferral is kept as
+        // belt-and-braces — it still avoids doing the open/install work
+        // inside the same call stack as the `.willPresent` post — but is
+        // NOT the mechanism that makes this race-safe; do not treat it as
+        // load-bearing on its own.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 
@@ -1566,9 +1613,22 @@ class WorkspaceViewContainer: NSView {
     ///
     /// Reads `widthModel.width` (the sidebar's live APPLIED width), not
     /// `currentSidebarWidth` (the user's stored preference) — same
-    /// distinction `resizableWidth` above already draws, so the offset
-    /// tracks what's actually on screen during a drag or transition
-    /// animation, not the target it's animating toward.
+    /// distinction `resizableWidth` above already draws.
+    ///
+    /// Follow-up correction (Phase 3 review round 3): during a live DRAG
+    /// this genuinely tracks what's on screen — `handleSidebarDrag` writes
+    /// `widthModel.width` and the frame together, in step. During a
+    /// `transitionTo`/`sidebarViewModeChanged` ANIMATION it does NOT:
+    /// `widthModel.width` is set via a plain assignment (jumps to the
+    /// target immediately) while the visual constraint animates smoothly
+    /// over 0.2s via `.animator()`, so the card currently jumps to its new
+    /// position instantly and the sidebar slides behind it for 200ms rather
+    /// than the two moving together. Recorded as a follow-up, not fixed
+    /// here — it's a polish gap, not a correctness one, and animating the
+    /// offset in step needs its own `.animator()`-equivalent for a plain
+    /// `@Published` value (e.g. a `CADisplayLink`-driven interpolation or
+    /// switching this model to read the constraint's presentation layer),
+    /// which is more than this pass's scope.
     private var terminalCardHorizontalOffset: CGFloat {
         sidebarMode == .pinned ? widthModel.width : 0
     }
@@ -1608,17 +1668,6 @@ class WorkspaceViewContainer: NSView {
         // — a fast dismiss-then-reopen can land here while a previous
         // dismiss's fade-out (see below) had it disabled.
         composerOverlayHostingView.isHitTestDisabled = false
-
-        guard composerOverlayHostingView.superview == nil else {
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = reduceMotion ? 0 : 0.2
-                composerOverlayHostingView.animator().alphaValue = 1
-            }
-            return
-        }
-
-        composerOverlayHostingView.alphaValue = 0
-        addSubview(composerOverlayHostingView)
         // R9 (Phase 3 review round 2): hide the sidebar and terminal from
         // VoiceOver navigation while the overlay is up. `NSView` conforms to
         // `NSAccessibilityProtocol` and exposes `setAccessibilityHidden(_:)`
@@ -1626,8 +1675,32 @@ class WorkspaceViewContainer: NSView {
         // a no-op here (the sidebar/terminal are separate `NSView`s in a
         // different hosting tree, so `.isModal` has nothing to hide),
         // confirmed by this round's reviewer, not "fixed" with it.
+        //
+        // Blocker 2 (Phase 3 review round 3): moved ABOVE the early-return
+        // guard below, matching `isHitTestDisabled` right above — both must
+        // apply on the "already installed, just re-animate to visible" path
+        // too (Escape immediately followed by Cmd+T, landing inside the
+        // fade window), or the sidebar/terminal are left VoiceOver-navigable
+        // behind a live modal with no correction. Restored unconditionally
+        // in `dismissComposerOverlayIfPresented()`, matching this call site.
         sidebarHostingView.setAccessibilityHidden(true)
         terminalShadowHost.setAccessibilityHidden(true)
+
+        guard composerOverlayHostingView.superview == nil else {
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = reduceMotion ? 0 : 0.2
+                composerOverlayHostingView.animator().alphaValue = 1
+            }, completionHandler: { [weak self] in
+                // Blocker 2: the early-return path used to skip this
+                // entirely, so VO focus never moved into the composer on a
+                // fast re-present even though it was visible on screen again.
+                self?.postComposerLayoutChanged()
+            })
+            return
+        }
+
+        composerOverlayHostingView.alphaValue = 0
+        addSubview(composerOverlayHostingView)
         NSLayoutConstraint.activate([
             composerOverlayHostingView.topAnchor.constraint(equalTo: topAnchor),
             composerOverlayHostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -1639,19 +1712,23 @@ class WorkspaceViewContainer: NSView {
             context.duration = reduceMotion ? 0 : 0.2
             composerOverlayHostingView.animator().alphaValue = 1
         }, completionHandler: { [weak self] in
-            // R9/F10 (Phase 3 review round 2): posting `.layoutChanged`
-            // before the fade-in and before SwiftUI has laid out the
-            // reassigned `rootView` announced a change without moving VO
-            // focus into the new content (no `NSAccessibilityUIElementsKey`)
-            // — deferred to the fade-in's completion, with the hosting view
-            // itself as the target element so VO actually moves there.
-            guard let self else { return }
-            NSAccessibility.post(
-                element: self.composerOverlayHostingView,
-                notification: .layoutChanged,
-                userInfo: [.uiElements: [self.composerOverlayHostingView as Any]]
-            )
+            self?.postComposerLayoutChanged()
         })
+    }
+
+    /// R9/F10 (Phase 3 review round 2, deduplicated in round 3 — both
+    /// `installComposerOverlayIfNeeded()` branches need it now, Blocker 2):
+    /// posting `.layoutChanged` before the fade-in and before SwiftUI has
+    /// laid out the reassigned `rootView` announced a change without moving
+    /// VO focus into the new content (no `NSAccessibilityUIElementsKey`) —
+    /// deferred to the fade-in's completion, with the hosting view itself
+    /// as the target element so VO actually moves there.
+    private func postComposerLayoutChanged() {
+        NSAccessibility.post(
+            element: composerOverlayHostingView,
+            notification: .layoutChanged,
+            userInfo: [.uiElements: [composerOverlayHostingView as Any]]
+        )
     }
 
     /// Removes the composer overlay hosting view. No-op if not installed.
@@ -1666,6 +1743,14 @@ class WorkspaceViewContainer: NSView {
     /// keyboard-dead until the user clicks it.
     private func dismissComposerOverlayIfPresented() {
         guard composerOverlayHostingView.superview != nil else { return }
+
+        // Blocker 3 (Phase 3 review round 3): clear ownership if this
+        // window was the owner, so the next `presentComposerOverlay` call
+        // (from any window) doesn't think a dismissed overlay is still live
+        // elsewhere.
+        if SessionComposerStore.shared.owningWindow === window {
+            SessionComposerStore.shared.owningWindow = nil
+        }
 
         // R3 (Phase 3 review round 2): disable hit-testing FIRST, before the
         // fade starts — `NSView.hitTest(_:)` skips HIDDEN views but does not
@@ -1994,11 +2079,43 @@ class WorkspaceViewContainer: NSView {
         // installed until the next `windowDidResignKey` (the only other
         // dismiss path) rather than closing when the user actually asked.
         // Do not add that guard.
+        //
+        // Blocker 1 (Phase 3 review round 3): `.receive(on: DispatchQueue.main)`
+        // is ALWAYS an async hop for Combine's `DispatchQueue` scheduler —
+        // it never runs inline even when already on the main thread — so
+        // this closure acts on a value EMITTED at some earlier moment, not
+        // necessarily the CURRENT one. `presentComposerOverlay`'s deferred
+        // install (see its own comment) races a dismiss enqueued by a
+        // teardown `cancel()` from the popover it's replacing; which of the
+        // two GCD-queued blocks actually runs first is not something either
+        // Combine's public contract or SwiftUI's internal update scheduling
+        // guarantees — SwiftUI doesn't document whether a state-driven
+        // `onChange`/`onDisappear` fires synchronously within the same call
+        // stack as the mutation that triggers it, or is deferred to a later
+        // run-loop pass relative to a plain `DispatchQueue.main.async` block,
+        // and this was not resolved empirically (a scratch popover-teardown
+        // probe was inconclusive — the popover never actually presented in
+        // a headless test process). Re-reading the LIVE value here instead
+        // of trusting the emitted one makes the outcome ordering-independent:
+        // if a stale `false` is processed after `presentComposerOverlay`
+        // already reopened the store, this now no-ops instead of tearing
+        // the fresh overlay back down.
         SessionComposerStore.shared.$isOpen
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isOpen in
-                guard !isOpen else { return }
-                self?.dismissComposerOverlayIfPresented()
+            .sink { [weak self] _ in
+                guard let self, !SessionComposerStore.shared.isOpen else { return }
+                // Blocker 3 (Phase 3 review round 3): only the window that
+                // currently owns the composer acts on a dismiss signal —
+                // otherwise a `cancel()` triggered by window B's activity
+                // (or a stale emission) could tear down window A's
+                // unrelated, still-open overlay. `dismissComposerOverlayIfPresented()`
+                // already self-guards on `superview != nil`, so this is
+                // largely redundant defense-in-depth, but explicit rather
+                // than relying on that guard alone to keep this correct.
+                guard SessionComposerStore.shared.owningWindow == nil
+                    || SessionComposerStore.shared.owningWindow === self.window
+                else { return }
+                self.dismissComposerOverlayIfPresented()
             }
             .store(in: &cancellables)
 

--- a/macos/Sources/Features/Settings/SettingsView.swift
+++ b/macos/Sources/Features/Settings/SettingsView.swift
@@ -27,13 +27,21 @@ struct SettingsView: View {
                 Text("(\"tip\" is the beta feed.)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                Text("defaults write com.seansmithdesign.ghostties ghostties.newSessionOpensComposer -bool false  (Cmd+T creates instantly instead of opening the composer)")
+                Text("New Session (Cmd+T) — composer (default) or instant:")
+                    .padding(.top, 6)
+                Text("defaults write com.seansmithdesign.ghostties ghostties.newSessionOpensComposer -bool false")
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
+                Text("defaults write com.seansmithdesign.ghostties ghostties.newSessionOpensComposer -bool true")
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                Text("(\"false\" makes Cmd+T create instantly instead of opening the composer — Cmd+Shift+T is always instant either way. Debug builds use com.seansmithdesign.ghostties.dev instead.)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding()
-        .frame(minWidth: 500, maxWidth: 500, minHeight: 172, maxHeight: 172)
+        .frame(minWidth: 500, maxWidth: 500)
     }
 }
 

--- a/macos/Sources/Features/Settings/SettingsView.swift
+++ b/macos/Sources/Features/Settings/SettingsView.swift
@@ -27,10 +27,13 @@ struct SettingsView: View {
                 Text("(\"tip\" is the beta feed.)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                Text("defaults write com.seansmithdesign.ghostties ghostties.newSessionOpensComposer -bool false  (Cmd+T creates instantly instead of opening the composer)")
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
             }
         }
         .padding()
-        .frame(minWidth: 500, maxWidth: 500, minHeight: 156, maxHeight: 156)
+        .frame(minWidth: 500, maxWidth: 500, minHeight: 172, maxHeight: 172)
     }
 }
 

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1339,6 +1339,15 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         NotificationCenter.default.post(name: .workspaceNewSession, object: window)
     }
 
+    /// "New Session (Instant)" — Cmd+Shift+T (Phase 3 of
+    /// session-creation-unified). Distinct from `newWorkspaceSession(_:)`
+    /// above: `WorkspaceViewContainer` always creates a session immediately
+    /// for this notification, regardless of the
+    /// `ghostties.newSessionOpensComposer` preference.
+    @IBAction func newWorkspaceSessionInstant(_ sender: Any?) {
+        NotificationCenter.default.post(name: .workspaceNewSessionInstant, object: window)
+    }
+
     /// Toggle the sidebar view mode between project-first (legacy) and
     /// task-first (Concept F). v0 feature toggle. Broadcasts a notification
     /// so every open WorkspaceViewContainer swaps its hosted sidebar.

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1774,6 +1774,18 @@ extension TerminalController {
             guard mode == "projectFirst" else { return false }
             return !WorkspaceStore.shared.flatProjectsInVisualOrder.isEmpty
 
+        // Both post a notification only `WorkspaceViewContainer` observes
+        // (Phase 3 review — lower-priority item: "New Session (Instant)"
+        // silently no-ops in a plain terminal window"). `newWorkspaceSession(_:)`
+        // had this bug already; `newWorkspaceSessionInstant(_:)` inherits it
+        // the moment this phase promoted its menu item from hidden to
+        // visible+enabled. Unlike "Next Session"/"Previous Session" above,
+        // this doesn't need a `SessionCoordinator` reference — just the
+        // window/`contentView` check already used elsewhere in this file.
+        case #selector(TerminalController.newWorkspaceSession(_:)),
+            #selector(TerminalController.newWorkspaceSessionInstant(_:)):
+            return window?.contentView is WorkspaceViewContainer
+
         case #selector(showProjectsView(_:)):
             let mode = UserDefaults.standard.string(forKey: "ghostties.sidebarViewMode") ?? "projectFirst"
             let tab = UserDefaults.standard.string(forKey: "ghostties.sidebarTab") ?? "projects"

--- a/macos/Tests/Ghostties/SessionComposerPhase3ReviewTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerPhase3ReviewTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import Ghostty
+
+/// Regression coverage for the Phase 3 review pass of session-creation-unified
+/// (F11). Two things are covered directly:
+///
+/// - `WorkspaceViewContainer.newSessionOpensComposer(in:)` — the exact
+///   absent/true/false resolution the review flagged as "precisely the
+///   class of bug this pass was chartered to find."
+/// - `SessionComposerStore.resolveCascadeProject(workspaceStore:)` — the
+///   smart-default cascade backing both instant-create paths
+///   (Cmd+Shift+T, and Cmd+T with the preference off).
+@MainActor
+struct SessionComposerPhase3ReviewTests {
+
+    // MARK: - Fixtures
+
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "ghostties.phase3review.test.\(UUID().uuidString)")!
+    }
+
+    private func makeProject(name: String = "Proj", lastActiveAt: Date? = nil) -> Project {
+        Project(name: name, rootPath: "/tmp/\(name)-\(UUID().uuidString)", lastActiveAt: lastActiveAt)
+    }
+
+    // MARK: - newSessionOpensComposer(in:)
+
+    @Test func newSessionOpensComposerDefaultsToComposerWhenAbsent() {
+        let defaults = makeDefaults()
+        #expect(WorkspaceViewContainer.newSessionOpensComposer(in: defaults) == true)
+    }
+
+    @Test func newSessionOpensComposerIsComposerWhenExplicitlyTrue() {
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: "ghostties.newSessionOpensComposer")
+        #expect(WorkspaceViewContainer.newSessionOpensComposer(in: defaults) == true)
+    }
+
+    @Test func newSessionOpensComposerIsInstantWhenExplicitlyFalse() {
+        let defaults = makeDefaults()
+        defaults.set(false, forKey: "ghostties.newSessionOpensComposer")
+        #expect(WorkspaceViewContainer.newSessionOpensComposer(in: defaults) == false)
+    }
+
+    // MARK: - SessionComposerStore.resolveCascadeProject
+
+    @Test func resolveCascadeProjectReturnsNilWithNoProjects() {
+        let store = WorkspaceStore(testingProjects: [], testingSessions: [])
+        let composerStore = SessionComposerStore(isolatedForTesting: ())
+
+        #expect(composerStore.resolveCascadeProject(workspaceStore: store) == nil)
+    }
+
+    /// No frontmost-terminal match (no key window in a test process) and no
+    /// recorded MRU — falls through to step 3, most-recently-touched.
+    @Test func resolveCascadeProjectFallsBackToMostRecentlyTouched() {
+        let older = makeProject(name: "Older", lastActiveAt: Date(timeIntervalSince1970: 100))
+        let newer = makeProject(name: "Newer", lastActiveAt: Date(timeIntervalSince1970: 200))
+        let store = WorkspaceStore(testingProjects: [older, newer], testingSessions: [])
+        let composerStore = SessionComposerStore(isolatedForTesting: ())
+
+        #expect(composerStore.resolveCascadeProject(workspaceStore: store) == newer.id)
+    }
+
+    /// A single project with no timestamp still resolves — the cascade's
+    /// last-resort `sorted.first` must not silently return nil just because
+    /// nothing has a `lastActiveAt` yet.
+    @Test func resolveCascadeProjectResolvesSingleProjectWithNoTimestamp() {
+        let onlyProject = makeProject(name: "Solo")
+        let store = WorkspaceStore(testingProjects: [onlyProject], testingSessions: [])
+        let composerStore = SessionComposerStore(isolatedForTesting: ())
+
+        #expect(composerStore.resolveCascadeProject(workspaceStore: store) == onlyProject.id)
+    }
+}

--- a/macos/Tests/Ghostties/SessionComposerPhase3ReviewTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerPhase3ReviewTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import AppKit
+import SwiftUI
 import Testing
 @testable import Ghostty
 
@@ -72,5 +74,124 @@ struct SessionComposerPhase3ReviewTests {
         let composerStore = SessionComposerStore(isolatedForTesting: ())
 
         #expect(composerStore.resolveCascadeProject(workspaceStore: store) == onlyProject.id)
+    }
+
+    // MARK: - open() idempotency (R10, F4's actual contract)
+
+    /// `WorkspaceViewContainer.presentComposerOverlay` calls `open()`
+    /// explicitly rather than relying on `onAppear` re-firing (F4). This
+    /// locks the contract that call depends on: a second `open()` while
+    /// already open resets `searchText`, sets `focusSearchFieldTrigger` (so
+    /// Cmd+T-while-open refocuses the field instead of doing nothing), and
+    /// updates `currentProjectBinding` to the new call's binding — fully
+    /// testable via the isolated store, no `WorkspaceViewContainer`
+    /// construction needed.
+    @Test func openWhileAlreadyOpenResetsSearchAndSetsFocusTrigger() {
+        let projectA = makeProject(name: "A")
+        let projectB = makeProject(name: "B")
+        let store = WorkspaceStore(testingProjects: [projectA, projectB], testingSessions: [])
+        let composerStore = SessionComposerStore(isolatedForTesting: ())
+
+        composerStore.open(projectBinding: .locked(projectA), workspaceStore: store)
+        #expect(composerStore.isOpen == true)
+        #expect(composerStore.focusSearchFieldTrigger == false)
+
+        composerStore.searchText = "abc"
+
+        composerStore.open(projectBinding: .locked(projectB), workspaceStore: store)
+
+        #expect(composerStore.isOpen == true)
+        #expect(composerStore.searchText == "")
+        #expect(composerStore.focusSearchFieldTrigger == true)
+        if case .locked(let project) = composerStore.currentProjectBinding {
+            #expect(project.id == projectB.id)
+        } else {
+            Issue.record("expected .locked(projectB) after the second open() call")
+        }
+    }
+
+    /// The FIRST open() (nothing was open before) must NOT set the refocus
+    /// trigger — that's specifically the "re-invoke while already open"
+    /// signal, not a general side effect of opening.
+    @Test func firstOpenDoesNotSetFocusTrigger() {
+        let project = makeProject(name: "Solo")
+        let store = WorkspaceStore(testingProjects: [project], testingSessions: [])
+        let composerStore = SessionComposerStore(isolatedForTesting: ())
+
+        composerStore.open(projectBinding: .locked(project), workspaceStore: store)
+
+        #expect(composerStore.focusSearchFieldTrigger == false)
+    }
+
+    // MARK: - AppKit accessibility-hidden round trip (R9)
+    //
+    // `WorkspaceViewContainer.sidebarHostingView`/`terminalShadowHost` are
+    // `private` NSViews on a class that needs a live `Ghostty.App` +
+    // `TerminalViewModel` to construct — no test in this codebase does that
+    // (confirmed by search). This locks the underlying AppKit contract
+    // `installComposerOverlayIfNeeded()`/`dismissComposerOverlayIfPresented()`
+    // rely on (`setAccessibilityHidden`/`isAccessibilityHidden` round-trip
+    // correctly on a plain `NSView`) rather than the exact call site.
+
+    @Test @MainActor func accessibilityHiddenRoundTripsOnPlainNSView() {
+        let view = NSView()
+        #expect(view.isAccessibilityHidden() == false)
+
+        view.setAccessibilityHidden(true)
+        #expect(view.isAccessibilityHidden() == true)
+
+        view.setAccessibilityHidden(false)
+        #expect(view.isAccessibilityHidden() == false)
+    }
+
+    // MARK: - TransparentHostingView.isHitTestDisabled (R3 verification)
+    //
+    // Direct, executed proof — not just reasoning from source — that a
+    // `TransparentHostingView` with `isHitTestDisabled = true` is actually
+    // excluded from hit-testing, and that the default (`false`) behaves
+    // exactly like a normal `NSHostingView` otherwise. This is the R3 fix's
+    // load-bearing mechanism: `dismissComposerOverlayIfPresented()` sets
+    // this flag before the fade-out starts, specifically because
+    // `alphaValue` fading does NOT affect hit-testing on its own.
+
+    @Test @MainActor func hitTestDisabledExcludesViewFromHitTesting() {
+        // `NSView.hitTest(_:)`'s point argument is in the SUPERVIEW's
+        // coordinate system (Apple's documented contract), and an
+        // `NSHostingView` needs an actual window + layout pass before its
+        // SwiftUI content establishes a real hit-testing region — a bare
+        // off-window instance reports no hit region at all regardless of
+        // `isHitTestDisabled`, which would make this test vacuously pass on
+        // the `false` branch too. A real (offscreen) window + forced layout
+        // is what makes this a genuine proof, matching the container's
+        // actual usage — `WorkspaceViewContainer` always has a live window
+        // by the time it calls `hitTest` on this view.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
+        window.contentView = container
+        window.orderFrontRegardless()
+
+        let view = TransparentHostingView(rootView: Color.red)
+        view.frame = container.bounds
+        container.addSubview(view)
+        view.layoutSubtreeIfNeeded()
+
+        let centerPoint = NSPoint(x: 50, y: 50)
+
+        // Default: behaves like any other view — the container's hitTest
+        // finds it at a point inside its bounds.
+        #expect(container.hitTest(centerPoint) === view)
+
+        view.isHitTestDisabled = true
+        #expect(container.hitTest(centerPoint) !== view)
+
+        view.isHitTestDisabled = false
+        #expect(container.hitTest(centerPoint) === view)
+
+        window.orderOut(nil)
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 of session-creation-unified (`docs/plans/session-creation-unified.html`) — Phases 1-2 shipped in #129/#130.

- New `SessionComposerOverlay.swift`: wraps `SessionComposerPalette` in a black-0.25 scrim, click-to-dismiss. Hosted via the now-`internal` `TransparentHostingView` (was `private`), added/removed as a subview of `WorkspaceViewContainer` on open/close — `layout()` is untouched.
- Cmd+T is now preference-driven: a new `ghostties.newSessionOpensComposer` flag (mirrors `ghostties.autoUpdateChannel`'s `UserDefaults.standard` pattern, documented in `SettingsView.swift`), defaulting to the composer. Handling moved from `WorkspaceSidebarView` into the container. The old "nothing selected" guard is gone — both the composer path and the instant path now resolve a project via the same smart-default cascade the composer already used (D1). `createNewSessionForSelectedProject()` is deleted.
- Cmd+Shift+T is promoted from a hidden alias to a visible "New Session (Instant)" menu item, wired to a distinct notification (`newWorkspaceSessionInstant`) that always creates immediately — it never checks the Cmd+T preference.
- The sidebar toolbar's 28-project `Menu` cascade (`NewSessionToolbarButton`) is replaced with a plain button that opens the centered overlay (D7).

**Correction to the original PR body:** the first commit claimed D2 was "isn't tied to one sidebar view mode" — that was an overstatement. Moving the `.workspaceNewSession` observer into the container only fixed the half of D2 where the SwiftUI sidebar view was the sole listener; `AppDelegate.setupNewSessionShortcut()`'s local event monitor still gated Cmd+T on `isProjectFirstWorkspaceWindow(_:)`, so it never reached the container at all in task-first mode. The review pass below fixes that second half (F2) — D2 is now genuinely fully fixed, both causes.

## Design note on the overlay's constraints (unchanged from original review, still holds)

The task spec called for the hosting view to use "centerX/centerY to the container, `.frame(width: 360)`, intrinsic height." Taken completely literally that would size the *hosting NSView* itself to a 360pt box — which can't render "a scrim across the container," since SwiftUI content can't paint outside its host's AppKit bounds. The hosting view is pinned to the container's full bounds instead; the card centers via ordinary SwiftUI layout. Confirmed sound by review.

## Review pass (two independent reviewers, consolidated fix list)

Locked design decisions:
- New "centered modal" typography/radius/shadow scale for the `.centered` presentation only (15pt query field @ 38pt height, 13pt row titles, 11pt subtitles, 8pt row padding, 12pt `.continuous` corner radius, 0.20/12/0 overlay shadow) — documented in `DESIGN.md` §3/§4/§6/§7 as a canonical surface class, not a one-off. `.anchored` (the Phase 2 sidebar popover) is untouched.
- The card now centers on the terminal card, not the whole window, via a live sidebar-width offset. Scrim stays full-bleed.

Confirmed defects, all fixed:
- **F1** — instant-create and composer-commit now post `.workspaceDidCreateSessionInProject`; the sidebar auto-expands the target project. Previously a session created via the cascade pick into a collapsed project spawned with no visible row anywhere.
- **F2** — Cmd+T now reaches the container in task-first workspace windows too (`AppDelegate.isWorkspaceWindow(_:)`, used only by the new-session shortcut monitor; Cmd+W/Cmd+1-9 stay on the project-first-only gate, which is correct for them).
- **F3** — dismissing the overlay restores first responder to the focused terminal surface (same fix already proven for the command palette and inline tab-title editing). Escape no longer leaves the terminal keyboard-dead.
- **F4** — `presentComposerOverlay` now calls `SessionComposerStore.open(...)` explicitly. **Observed, not assumed:** a scratch NSHostingView probe (built, run, then deleted — not part of the diff) confirmed `onAppear` reliably re-fires on a genuine remove+re-add of the hosting view, but does **not** re-fire when `rootView` is merely reassigned while the subview stays installed — exactly the "Cmd+T while the overlay is already open" case the review flagged as unreachable.
- **F5** — presenting the overlay posts `.workspaceComposerOverlayWillPresent`, which any open per-row popover observes and closes (single-presentation invariant, the narrower form the review pre-authorized). The overlay itself is dismissed on `windowDidResignKey`. Caveat, disclosed rather than silently left: `SessionComposerStore` is still one process-wide singleton, so a resign-key dismiss in window A can still cancel a concurrently-open overlay in window B via the shared store's `isOpen`. Fully isolating per-window composer state is a larger change than this fix — flagged, not silently expanded into.
- **F6** — settings copy split into a copy-safe mono command + separate prose line (matching the file's existing pattern), added the `-bool true` counterpart, noted the Debug-build bundle-id suffix, dropped the guessed fixed height in favor of natural sizing.
- **F7** — the scrim excludes the titlebar band (`WorkspaceLayout.titlebarSpacerHeight`) — traffic lights no longer render undimmed inside a dimmed band, and the window can still be dragged by its titlebar while the composer is open.
- **F8** — install/dismiss now fade (0.2s, reduce-motion respecting), matching this container's existing `transitionTo(_:)` convention. Guarded with a generation counter against a fast dismiss-then-reopen yanking the freshly re-presented overlay mid-animation.
- **F9** — stale "project-picker flyout" comment, dead `.disabled(store.projects.isEmpty)` (blocked the only path to "+ Add project…" with zero projects), silent `as?` cast failure now asserts in Debug, `composerOverlayHostingView.sizingOptions = []` to match the sidebar hosting view, and an explicit comment on the `$isOpen` Combine sink calling out that dismissal depends on `@Published` re-emitting on an unchanged assignment — do not add an equality guard there.
- **F10** — VoiceOver `layoutChanged` announcement on present, scrim gets an accessibility label + button trait. **Not attempted:** marking the overlay modal and hiding sidebar/terminal content from VoiceOver navigation. AppKit's informal `NSAccessibility` protocol doesn't have a primitive I could verify hides an entire NSView subtree from VO with confidence in this sandboxed environment (no VoiceOver available to test against), and shipping an unverified API call risked either a build break or a silently no-op "fix" — worse than reporting it honestly as remaining work.
- **F11** — new `SessionComposerPhase3ReviewTests.swift`: 3 tests lock the Cmd+T preference resolution (absent → composer, `true` → composer, `false` → instant) via an extracted `WorkspaceViewContainer.newSessionOpensComposer(in:)`, 3 more cover `SessionComposerStore.resolveCascadeProject` (no projects, single untimestamped project, most-recently-touched tiebreak). **Not covered:** install/dismiss idempotency as a live NSView integration test — `WorkspaceViewContainer` requires a real `Ghostty.App` + `TerminalViewModel` to construct, which no test in this codebase has ever done (confirmed by search); attempting it now, novel and unverified, felt like a worse trade than reporting the gap.

## Screen capture — still blocked

`screencapture` is still TCC-denied in this environment (`could not create image from display`). Stating this plainly rather than faking or omitting the requested recording.

## Test plan

- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild test` — 782 passed / 2 failed / 1 skipped (`xcresulttool get test-results summary`). The 2 failures are `ThrottleTrailingEdgeHypothesisTests` (untracked file from a sibling session, fails by design) — no third failure introduced. +6 tests from this review pass, all passing.
- [ ] Manual click-through in a running build — not done in this session (no screen capture, no synthetic input per hard rule)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


## Round 2 review (commit `e41d418b2`)

Six confirmed blockers — two introduced by the round-1 fix commit itself:

- **R1** — `windowDidResignKey` no longer dismisses the composer for its own child UI taking key. It reintroduced, one layer down at the AppKit window level, exactly the focus-loss auto-dismiss `SessionComposerPalette`'s header comment documents removing (the "+ Add project…" open panel, template edit sheet, delete alert, project dropdown popover all take key without the user leaving the app). Now gates on `NSApp.isActive == false && window?.attachedSheet == nil` instead of raw resign-key. **Chose the gate, not a per-container store**: converting `SessionComposerStore.shared` to per-window would also solve the two-window sharing note from round 1, but touches every call site across four files and would silo RECENT/MRU state that's meant to stay shared across windows — not a contained change.
- **R2** — `presentComposerOverlay` now defers `open()` + install to the next runloop turn. The previous ordering (post → open → install, all synchronous) let a popover's deferred SwiftUI teardown (`onChange`/`onDisappear` → `cancel()`) land *after* us and clobber the just-opened overlay one frame in — and, while both were briefly alive, left the old `.locked` popover visibly showing a `currentProjectBinding` already overwritten (the wrong-project-write round 1's F5 claimed to close but didn't).
- **R3** — dismiss now disables hit-testing (new `TransparentHostingView.isHitTestDisabled`, overriding `hitTest(_:)`) *before* the fade starts, not after. `alphaValue` fading alone doesn't affect `NSView.hitTest`, so the full-bounds scrim stayed fully clickable for the whole 200ms fade-out — a click into the terminal during that window landed on the invisible scrim instead (eating the click), and a fast double-click on a template row could fire `commit()` twice. **Verified, not assumed**: added `hitTestDisabledExcludesViewFromHitTesting()`, a real `hitTest()` assertion through a live (offscreen) window — first pass without a real window was a false-positive vacuous pass, corrected once I noticed `NSHostingView` needs an actual layout pass first. `SessionComposerStore.precommit` also gained an `isOpen` guard for the mouse path, which the keyboard-only double-Return guard didn't cover.
- **R4** — dismiss now only steals first responder back to the terminal when `window?.isKeyWindow == true`. Without the guard, every resign-key with the composer open called `makeFirstResponder` on a window that had just lost key status — via `BaseTerminalController`'s window-delegate `syncFocusToSurfaceTree()` (wired before this container's later `viewDidMoveToWindow` registration), this re-set `ghostty_surface_set_focus(surface, true)` on a non-key window: a blinking cursor in an inactive window, and with DECSET 1004 (Claude Code's TUI, vim, tmux), an inverted pty focus report that never self-corrects.
- **R5** — the card's terminal-centering offset is now a live `ObservableObject` (`ComposerCenteringModel`), synced on every sidebar transition, view-mode switch, and drag tick, instead of a `CGFloat` captured once at present-time and baked into `rootView`. Toggling the sidebar (Cmd+S) or switching view mode (Cmd+Shift+1/2) while the composer was open used to leave the card parked at its stale position.
- **R6/R7** — `DESIGN.md`'s new "centered modal" surface class corrected and rewritten: the composer's shadow does NOT actually reuse the Overlay sidebar's real code values (`0.2/6/(2,0)` vs. the composer's `0.20/12/0`) — stated plainly now instead of falsely claimed as a reuse, with the pre-existing table drift flagged as a Known Deviation, not silently propagated. §7's radius rule reverted to its absolute form ("One radius. One style. No exceptions"), with the anchored popover's 10pt exception moved to a "Known Deviations" section instead of softening the rule itself. §3/§4 rewritten to read as general rules ("any surface that floats free of the sidebar column...") with the composer named as the current example, not the definition.
- **R8** — `selectedIndex` now re-seeds off `composerStore.focusSearchFieldTrigger` going `true` (not `isOpen`, which SwiftUI's `.onChange` won't re-fire on since it stays `true` across a fast re-open). Fixes a dead Return key on a re-present landing inside R3's fade window, where `onAppear` doesn't reliably re-fire (F4's finding).
- **R9** — sidebar and terminal are hidden from VoiceOver navigation (`NSView.setAccessibilityHidden`) while the overlay is installed, restored on dismiss. Round 1's stated reason for skipping this ("no verified AppKit primitive") was wrong, per this round's reviewer — corrected, and verified with a passing round-trip test (`accessibilityHiddenRoundTripsOnPlainNSView`), not just compiled-and-hoped. `.layoutChanged` now posts after the fade-in completes, targeting the hosting view via `NSAccessibilityUIElementsKey`, instead of firing before layout with no target element.
- **R10** — round 1's "no test constructs `WorkspaceViewContainer`" claim was accurate but measured the wrong thing. Added two tests locking `open()`'s actual idempotency contract (`searchText` reset, `focusSearchFieldTrigger` set on re-open, `currentProjectBinding` updated) via the already-existing isolated store — no new infrastructure needed, unlike a full container construction.

**Lower-priority items, addressed:**
- `validateMenuItem` now gates "New Session"/"New Session (Instant)" on being in a workspace window — matches this file's own existing pattern for the identical "Next/Previous Session" silent-no-op case (see the comment right above it in `TerminalController.swift`).
- The scrim's titlebar-band exclusion collapses to 0 in fullscreen (no titlebar to protect there).

**Lower-priority, not fixed — reasoning:**
- The titlebar band is still click-through to the sidebar's own toolbar buttons (not just window-dragging) while the composer is open. Properly separating "let this click through for window-dragging" from "block this click, it's a sidebar button" isn't a simple hit-test primitive in AppKit/SwiftUI: I found no way to do it without either a bespoke per-view-type hit-test rule or risking a new regression, so I'm reporting it rather than guessing.
- `layout()`'s resize reclamp (`WorkspaceViewContainer.swift`) is one residual case `ComposerCenteringModel` doesn't cover live — a window resize (not a sidebar toggle/mode-switch/drag) while the composer is open in pinned mode near the resize-reclamp threshold could leave the offset stale until the next transition. Deliberately not touched — `layout()` stays off-limits per the original Phase 3 constraint, reconfirmed clean by two review rounds now.
- `ProjectDisclosureRow`'s new `.onReceive` observer (R2's popover-close signal) stays at the row level — R2's fix was about timing (defer to next runloop), not about where the observer lives; lifting it would need converting `showingTemplatePicker` from per-row `@State` to shared state threaded via binding, a larger change than this pass.

## Test plan (updated)

- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild test` — **786 passed / 2 failed / 1 skipped**. The 2 failures are `ThrottleTrailingEdgeHypothesisTests` (untracked, sibling session, fails by design). +4 tests from round 2 (open() idempotency ×2, accessibility round-trip, hitTest verification), all passing.


## Round 3 review (commit `d17b06a1e`)

Three blockers, ~15 lines each, all fixed:

- **Blocker 1** — the `$isOpen` sink now re-checks the LIVE `SessionComposerStore.shared.isOpen` value instead of trusting the emitted one. `.receive(on: DispatchQueue.main)` is always an async hop for Combine's `DispatchQueue` scheduler, so the sink was acting on a value that could be stale by the time its closure actually ran. This makes the dismiss outcome correct regardless of whether a popover's deferred teardown (`cancel()`) lands before or after `presentComposerOverlay`'s deferred install block — an ordering this repo could not prove empirically (see below). Rewrote both the sink's comment and `presentComposerOverlay`'s comment to state that uncertainty honestly instead of asserting a specific mechanism I hadn't verified.
- **Blocker 2** — `sidebarHostingView`/`terminalShadowHost`'s `setAccessibilityHidden(true)` calls moved above `installComposerOverlayIfNeeded`'s early-return guard, matching `isHitTestDisabled = false` right above them. A fast Escape-then-Cmd+T landing on the "already installed, just re-fade" branch used to skip both the accessibility hide and the `.layoutChanged` VO announcement — extracted the announcement into a shared `postComposerLayoutChanged()` helper called from both branches.
- **Blocker 3** — dropped the `NSApp.isActive` check inside `windowDidResignKey` entirely (it's asserted there, not observed to actually hold at that point in AppKit's `willResignActive` → window-resigns-key → `didResignActive` ordering) in favor of observing `NSApplication.didResignActiveNotification` directly (`applicationDidResignActive()`, registered once in `init`, app-wide not per-window). Added `SessionComposerStore.owningWindow` (`weak var`) — `presentComposerOverlay` dismisses another window's overlay before taking ownership, and the `$isOpen` sink ignores a dismiss signal for an overlay it doesn't own. Closes the two-window bug the round-2 gate had reopened, without the per-container-store refactor round 2 correctly rejected as too large.

**Manual check — could not observe.** The requested check ("row popover open → Cmd+T → does the composer stay up?") needs either synthetic keystrokes (forbidden) or a human clicking through the running app; `screencapture` remains TCC-denied in this environment (established in round 1, unchanged). I did not guess. Instead I built a scratch `.popover`-in-a-real-offscreen-window probe to try to determine the teardown timing empirically without synthetic input — it was **inconclusive**: the popover's `onChange`/`onDisappear` never fired at all within 0.3s of flipping the presenting binding, meaning the popover likely never actually presented in a headless test process (no real screen compositing / click-driven anchor). Deleted the probe rather than keep an inconclusive scratch test. Given I couldn't resolve the ordering question either way, Blocker 1's fix (re-check the live value) is deliberately ordering-independent so it's correct under both possible mechanisms — this is stated plainly in the code comment rather than asserting a mechanism I couldn't verify. Flagging for Sean to click through and confirm, as instructed.

**Follow-ups — read, confirmed, not built (per instruction):**
- Centering offset doesn't animate (jumps to target instantly on `transitionTo`, sidebar slides behind it for 200ms) — the misleading comment claiming it "tracks what's on screen during a transition animation" is now corrected to state this honestly as a known polish gap.
- A single `widthModel.$width` subscription in `setup()` would replace the four hand-placed sync calls and cover `layout()`'s reclamp without touching `layout()` — not built.
- `browserShadowHost` isn't hidden from VoiceOver alongside the other two — not built.
- Install's fade-in completion has no generation guard while dismiss's does — not built.
- "Full-bleed" is stale wording in three places after F7 (`DESIGN.md` §4, `SessionComposerOverlay.swift` in two places) — not built.
- Titlebar-band click-through to the sidebar's own toolbar buttons — round 2's "no safe AppKit primitive found" reasoning was wrong; `sidebarToggleButton.isEnabled = false` paired in install/dismiss is the primitive (per this round's reviewer). Not built — noted so the wrong reasoning doesn't get treated as settled.

## Test plan (updated)

- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild test` — **786 passed / 2 failed / 1 skipped**, same count as round 2 (no new tests this round; existing suite, including all round-2 additions, still green). The 2 failures are `ThrottleTrailingEdgeHypothesisTests` (untracked, sibling session, fails by design).
