### PR TITLE
Session composer Phase 4: project-creation convergence

### DIFF
--- a/macos/Sources/Features/Ghostties/OrphanTriageStore.swift
+++ b/macos/Sources/Features/Ghostties/OrphanTriageStore.swift
@@ -99,24 +99,15 @@ final class OrphanTriageStore: ObservableObject {
 
     // MARK: - D7 empty-projects flow
 
-    /// Present NSOpenPanel, insert the chosen path into `WorkspaceStore`, and
-    /// auto-select the new or existing project in the picker.
+    /// Delegates to `WorkspaceStore.addProjectViaFolderPicker`, keeping this
+    /// flow's task-specific panel message and its auto-select-by-path
+    /// behavior (Phase 4 convergence — see
+    /// `docs/plans/session-creation-unified.html`).
     func addProjectViaFolderPicker(workspaceStore: WorkspaceStore) {
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.message = "Choose a project folder to associate with this task"
-        panel.prompt = "Add Project"
-
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        workspaceStore.addProject(at: url)
-
-        // Auto-select the project we just added (or found by path if it already existed).
-        let stdPath = url.standardizedFileURL.path
-        if let match = workspaceStore.projects.first(where: { $0.rootPath == stdPath }) {
-            selectedProjectId = match.id
-        }
+        guard let newId = workspaceStore.addProjectViaFolderPicker(
+            message: "Choose a project folder to associate with this task"
+        ) else { return }
+        selectedProjectId = newId
     }
 
     // MARK: - Validation

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -220,10 +220,19 @@ struct WorkspaceSidebarView: View {
     // MARK: - Actions
 
     private func presentFolderPicker() {
-        if let id = store.addProjectViaFolderPicker() {
-            selectedProjectId = id
-            expandedProjectIds.insert(id)
+        guard let id = store.addProjectViaFolderPicker() else { return }
+        selectedProjectId = id
+        expandedProjectIds.insert(id)
+
+        // Phase 4: chain header add straight into the composer so adding a
+        // project from the header ends in a running session instead of
+        // dead-ending (see docs/plans/session-creation-unified.html).
+        guard let newProject = store.projects.first(where: { $0.id == id }) else { return }
+        guard let container = coordinator.containerView as? WorkspaceViewContainer else {
+            assertionFailure("presentFolderPicker: coordinator.containerView is not a WorkspaceViewContainer")
+            return
         }
+        container.presentComposerOverlay(projectBinding: .locked(newProject))
     }
 
     /// Move selection to the next or previous project in the flattened section

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -952,13 +952,22 @@ final class WorkspaceStore: ObservableObject {
     @AppStorage("ghostties.lastProjectPickerDirectory")
     private static var lastProjectPickerDirectoryPath: String = ""
 
+    #if DEBUG
+    /// Test-only accessor for `lastProjectPickerDirectoryPath`, exercising
+    /// the real `@AppStorage` wrapper from outside a SwiftUI view. Keeps the
+    /// production property `private` while still letting tests verify the
+    /// `@AppStorage`-on-a-static-property mechanic actually round-trips.
+    static var testLastProjectPickerDirectoryPath: String {
+        get { lastProjectPickerDirectoryPath }
+        set { lastProjectPickerDirectoryPath = newValue }
+    }
+    #endif
+
     /// Presents an NSOpenPanel and adds the selected directory as a project.
     /// This is the SINGLE picker entry point every call site (sidebar
     /// header, session composer, task composer, orphan triage) converges
     /// on — see `docs/plans/session-creation-unified.html` Phase 4.
     ///
-    /// - Parameter startingAt: Directory the panel opens to. Defaults to the
-    ///   last-used directory persisted via `@AppStorage`.
     /// - Parameter message: Panel message text. Defaults to the generic
     ///   copy; callers with task-specific context (e.g. `OrphanTriageStore`)
     ///   pass their own wording so convergence doesn't silently lose it.
@@ -966,7 +975,6 @@ final class WorkspaceStore: ObservableObject {
     /// Returns the new or existing project's ID, or nil if the user cancelled.
     @discardableResult
     func addProjectViaFolderPicker(
-        startingAt: URL? = nil,
         message: String = "Choose a project folder"
     ) -> UUID? {
         let panel = NSOpenPanel()
@@ -976,18 +984,23 @@ final class WorkspaceStore: ObservableObject {
         panel.title = "Add Project"
         panel.message = message
         panel.prompt = "Add Project"
-        if let startingAt {
-            panel.directoryURL = startingAt
-        } else if !Self.lastProjectPickerDirectoryPath.isEmpty {
-            panel.directoryURL = URL(fileURLWithPath: Self.lastProjectPickerDirectoryPath, isDirectory: true)
+        if !Self.lastProjectPickerDirectoryPath.isEmpty {
+            var isDirectory: ObjCBool = false
+            let path = Self.lastProjectPickerDirectoryPath
+            if FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue {
+                panel.directoryURL = URL(fileURLWithPath: path, isDirectory: true)
+            }
         }
 
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
-        Self.lastProjectPickerDirectoryPath = url.deletingLastPathComponent().path
         addProject(at: url)
-        return projects.first(where: {
+        let id = projects.first(where: {
             $0.rootPath == url.standardizedFileURL.path
         })?.id
+        if id != nil {
+            Self.lastProjectPickerDirectoryPath = url.deletingLastPathComponent().path
+        }
+        return id
     }
 
     // MARK: - Project Ghost Color

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -944,18 +944,46 @@ final class WorkspaceStore: ObservableObject {
 
     // MARK: - Folder Picker
 
+    /// Last directory a project-folder picker was pointed at, persisted so
+    /// the panel reopens where the user left off instead of always starting
+    /// at the default location (D10). Stores the CHOSEN project's PARENT
+    /// directory, not the project itself, so the next pick starts one level
+    /// up from the last add rather than re-suggesting the same folder.
+    @AppStorage("ghostties.lastProjectPickerDirectory")
+    private static var lastProjectPickerDirectoryPath: String = ""
+
     /// Presents an NSOpenPanel and adds the selected directory as a project.
+    /// This is the SINGLE picker entry point every call site (sidebar
+    /// header, session composer, task composer, orphan triage) converges
+    /// on — see `docs/plans/session-creation-unified.html` Phase 4.
+    ///
+    /// - Parameter startingAt: Directory the panel opens to. Defaults to the
+    ///   last-used directory persisted via `@AppStorage`.
+    /// - Parameter message: Panel message text. Defaults to the generic
+    ///   copy; callers with task-specific context (e.g. `OrphanTriageStore`)
+    ///   pass their own wording so convergence doesn't silently lose it.
+    ///
     /// Returns the new or existing project's ID, or nil if the user cancelled.
     @discardableResult
-    func addProjectViaFolderPicker() -> UUID? {
+    func addProjectViaFolderPicker(
+        startingAt: URL? = nil,
+        message: String = "Choose a project folder"
+    ) -> UUID? {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        panel.message = "Choose a project folder"
+        panel.title = "Add Project"
+        panel.message = message
         panel.prompt = "Add Project"
+        if let startingAt {
+            panel.directoryURL = startingAt
+        } else if !Self.lastProjectPickerDirectoryPath.isEmpty {
+            panel.directoryURL = URL(fileURLWithPath: Self.lastProjectPickerDirectoryPath, isDirectory: true)
+        }
 
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
+        Self.lastProjectPickerDirectoryPath = url.deletingLastPathComponent().path
         addProject(at: url)
         return projects.first(where: {
             $0.rootPath == url.standardizedFileURL.path

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -917,7 +917,11 @@ class WorkspaceViewContainer: NSView {
             if let manager = existingManager {
                 embedBrowserInPanel(manager)
                 animateBrowserPanel(visible: true)
-            } else if let project = WorkspaceStore.shared.projects.first {
+            } else if let projectId = SessionComposerStore.shared.resolveCascadeProject(workspaceStore: WorkspaceStore.shared),
+                      let project = WorkspaceStore.shared.projects.first(where: { $0.id == projectId }) {
+                // Phase 4: use the composer's smart-default cascade instead
+                // of an arbitrary `.first` pick (see
+                // docs/plans/session-creation-unified.html).
                 // Create a new browser session — this will call showBrowserContent,
                 // which embeds into the side panel and animates it open.
                 Task { @MainActor in

--- a/macos/Tests/Workspace/WorkspaceStoreProjectPickerTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreProjectPickerTests.swift
@@ -4,56 +4,39 @@ import Testing
 
 /// Tests for the Phase 4 project-picker convergence (D10 fix):
 /// `WorkspaceStore.addProjectViaFolderPicker` persists the last-used
-/// directory via `@AppStorage("ghostties.lastProjectPickerDirectory")` so
-/// the panel reopens where the user last was.
+/// directory via `@AppStorage("ghostties.lastProjectPickerDirectory")` on a
+/// `static` property, read and written entirely outside any SwiftUI view.
 ///
 /// `addProjectViaFolderPicker` itself calls `NSOpenPanel.runModal()`, which
-/// blocks on UI and cannot run in a unit test. What IS genuinely testable
-/// without UI is the persistence contract the fix depends on: the exact
-/// `UserDefaults.standard` key round-trips a directory path, and an empty
-/// value is treated as "no starting directory" (the store's `!isEmpty`
-/// guard). These tests exercise `UserDefaults.standard` directly under that
-/// key, saving and restoring the real value so the suite doesn't leak state
-/// into other tests or the developer's actual defaults.
+/// blocks on UI and cannot run in a unit test. What IS testable — and is
+/// the genuinely risky mechanic here — is whether `@AppStorage` on a static
+/// property actually persists through `UserDefaults.standard` under the
+/// key. This test writes through `WorkspaceStore`'s `#if DEBUG` accessor
+/// (exercising the real wrapper), then reads `UserDefaults.standard` under
+/// the key as a literal string, so a typo in the `@AppStorage` key in
+/// production would make this test fail. It saves and restores the real
+/// value so the suite doesn't leak state into other tests or the
+/// developer's actual defaults.
 struct WorkspaceStoreProjectPickerTests {
 
-    private static let key = "ghostties.lastProjectPickerDirectory"
-
-    @Test("Last-used picker directory round-trips through UserDefaults")
-    func lastPickerDirectoryRoundTrips() {
+    @Test("Last-used picker directory round-trips through the real @AppStorage-backed UserDefaults key")
+    @MainActor
+    func lastPickerDirectoryRoundTripsThroughAppStorage() {
+        let key = "ghostties.lastProjectPickerDirectory"
         let defaults = UserDefaults.standard
-        let saved = defaults.string(forKey: Self.key)
+        let saved = defaults.string(forKey: key)
         defer {
             if let saved {
-                defaults.set(saved, forKey: Self.key)
+                defaults.set(saved, forKey: key)
             } else {
-                defaults.removeObject(forKey: Self.key)
+                defaults.removeObject(forKey: key)
             }
         }
 
         let path = "/Users/example/Code/some-project"
-        defaults.set(path, forKey: Self.key)
+        WorkspaceStore.testLastProjectPickerDirectoryPath = path
 
-        #expect(defaults.string(forKey: Self.key) == path)
-    }
-
-    @Test("Absent last-used directory reads back as empty, the store's no-starting-directory sentinel")
-    func absentLastPickerDirectoryReadsEmpty() {
-        let defaults = UserDefaults.standard
-        let saved = defaults.string(forKey: Self.key)
-        defer {
-            if let saved {
-                defaults.set(saved, forKey: Self.key)
-            } else {
-                defaults.removeObject(forKey: Self.key)
-            }
-        }
-
-        defaults.removeObject(forKey: Self.key)
-
-        // @AppStorage's declared default is "" when the key is absent —
-        // this is the exact value `addProjectViaFolderPicker` checks with
-        // `!isEmpty` before setting `panel.directoryURL`.
-        #expect((defaults.string(forKey: Self.key) ?? "").isEmpty)
+        #expect(defaults.string(forKey: key) == path)
+        #expect(WorkspaceStore.testLastProjectPickerDirectoryPath == path)
     }
 }

--- a/macos/Tests/Workspace/WorkspaceStoreProjectPickerTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreProjectPickerTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import Ghostty
+
+/// Tests for the Phase 4 project-picker convergence (D10 fix):
+/// `WorkspaceStore.addProjectViaFolderPicker` persists the last-used
+/// directory via `@AppStorage("ghostties.lastProjectPickerDirectory")` so
+/// the panel reopens where the user last was.
+///
+/// `addProjectViaFolderPicker` itself calls `NSOpenPanel.runModal()`, which
+/// blocks on UI and cannot run in a unit test. What IS genuinely testable
+/// without UI is the persistence contract the fix depends on: the exact
+/// `UserDefaults.standard` key round-trips a directory path, and an empty
+/// value is treated as "no starting directory" (the store's `!isEmpty`
+/// guard). These tests exercise `UserDefaults.standard` directly under that
+/// key, saving and restoring the real value so the suite doesn't leak state
+/// into other tests or the developer's actual defaults.
+struct WorkspaceStoreProjectPickerTests {
+
+    private static let key = "ghostties.lastProjectPickerDirectory"
+
+    @Test("Last-used picker directory round-trips through UserDefaults")
+    func lastPickerDirectoryRoundTrips() {
+        let defaults = UserDefaults.standard
+        let saved = defaults.string(forKey: Self.key)
+        defer {
+            if let saved {
+                defaults.set(saved, forKey: Self.key)
+            } else {
+                defaults.removeObject(forKey: Self.key)
+            }
+        }
+
+        let path = "/Users/example/Code/some-project"
+        defaults.set(path, forKey: Self.key)
+
+        #expect(defaults.string(forKey: Self.key) == path)
+    }
+
+    @Test("Absent last-used directory reads back as empty, the store's no-starting-directory sentinel")
+    func absentLastPickerDirectoryReadsEmpty() {
+        let defaults = UserDefaults.standard
+        let saved = defaults.string(forKey: Self.key)
+        defer {
+            if let saved {
+                defaults.set(saved, forKey: Self.key)
+            } else {
+                defaults.removeObject(forKey: Self.key)
+            }
+        }
+
+        defaults.removeObject(forKey: Self.key)
+
+        // @AppStorage's declared default is "" when the key is absent —
+        // this is the exact value `addProjectViaFolderPicker` checks with
+        // `!isEmpty` before setting `panel.directoryURL`.
+        #expect((defaults.string(forKey: Self.key) ?? "").isEmpty)
+    }
+}


### PR DESCRIPTION
## ⚠️ UNVERIFIED — agent was stopped mid-run

The builder was killed at the moment it was about to open this PR. The commit
and push landed; **the build and test suite results were never reported**, and
**no review round has run**. Treat every claim below as unconfirmed until a
build + full suite + independent review say otherwise.

## What it does (Phase 4 of `docs/plans/session-creation-unified.html`)

- **One picker signature.** `WorkspaceStore.addProjectViaFolderPicker` gains
  `startingAt:` plus a defaulted `message:`, sets a real `panel.title`, and
  persists the last-used directory via `@AppStorage`
  (`ghostties.lastProjectPickerDirectory`). Fixes D10.
- **Convergence.** `OrphanTriageStore`'s duplicate `NSOpenPanel` now delegates,
  keeping its task-specific message. Only one project-folder panel remains in
  the tree (`TemplatePickerView`'s is an unrelated plain-text file picker).
- **Header add chains into the composer** at `.locked(newProject)`
  (`WorkspaceSidebarView.swift:235`).
- **Browser project pick** uses `SessionComposerStore.resolveCascadeProject`
  instead of `projects.first` (`WorkspaceViewContainer.swift:920`).

## Ship gate — needs a human at the keyboard

Not verified by any agent:

1. Adding a project from the header ends with a running terminal.
2. The picker reopens where you last were.
3. The browser opens in the project on screen.

## Note

`.locked` had zero call sites before this PR — this is what introduces it, so
the `.locked` guards in the composer get exercised for the first time here.

Stacked context: PR #132 also touches `WorkspaceViewContainer.swift`, in a
different region. Expected to merge cleanly, but worth watching.