### PR TITLE
Session composer Phase 5: pin on explicit add, never on auto-register

### DIFF
--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -493,14 +493,16 @@ final class SessionCoordinator: ObservableObject {
         let store = WorkspaceStore.shared
 
         // 1/2. Resolve or register the project. `addProject(at:)` handles
-        // duplicate-path detection and promotes an existing record's pin
-        // status without clobbering its `rootPath` or ghost character.
+        // duplicate-path detection without clobbering an existing record's
+        // `rootPath` or ghost character.
         let project: Project = {
             if let existing = store.projects.first(where: { $0.name == name }) {
                 return existing
             }
-            // Register as a pinned project so it shows up in the legacy
-            // sidebar too. `addProject(at:)` does the standardization.
+            // Auto-register unpinned — this is a background/implicit
+            // registration, not an explicit user "add project" action, so it
+            // must not force the project into the pinned sidebar section.
+            // `addProject(at:)` does the standardization.
             let url = URL(fileURLWithPath: rootPath, isDirectory: true)
             store.addProject(at: url)
             // Re-fetch by path (name may diverge — URL.lastPathComponent

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -464,7 +464,9 @@ final class SessionCoordinator: ObservableObject {
     /// Resolution order:
     ///   1. If a `Project` already exists in `WorkspaceStore` with `name`,
     ///      reuse it (its `rootPath` wins — don't clobber the user's setup).
-    ///   2. Otherwise register a new pinned `Project(name:, rootPath:)`.
+    ///   2. Otherwise auto-register a new, unpinned `Project(name:, rootPath:)`
+    ///      — this is a background registration, not an explicit "add
+    ///      project" action, so it must not force the pinned section.
     ///   3. If that project already has a live session, focus it (same path as
     ///      `focusLastSession(forProject:)`).
     ///   4. Else spawn a new Shell session via `createQuickSession`. The

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -650,10 +650,14 @@ final class WorkspaceStore: ObservableObject {
 
     // MARK: - Project Actions
 
-    func addProject(at url: URL) {
+    func addProject(at url: URL, pinned: Bool = false) {
         let path = url.standardizedFileURL.path
         // Don't add duplicates (same path).
         if let index = projects.firstIndex(where: { $0.rootPath == path }) {
+            // Only re-pin on an explicit pinned add, and only when it actually
+            // changes something. Never unpin an existing pinned project just
+            // because it was silently auto-registered again.
+            guard pinned, !projects[index].isPinned else { return }
             projects[index].isPinned = true
             // Re-pinning is a structural change — release any held freeze snapshot
             // so the sidebar re-buckets immediately.
@@ -665,7 +669,7 @@ final class WorkspaceStore: ObservableObject {
         let project = Project(
             name: url.lastPathComponent,
             rootPath: path,
-            isPinned: true,
+            isPinned: pinned,
             ghostCharacter: GhostCharacter.randomUnused(excluding: allAssignedGhosts())
         )
         projects.append(project)
@@ -993,7 +997,7 @@ final class WorkspaceStore: ObservableObject {
         }
 
         guard panel.runModal() == .OK, let url = panel.url else { return nil }
-        addProject(at: url)
+        addProject(at: url, pinned: true)
         let id = projects.first(where: {
             $0.rootPath == url.standardizedFileURL.path
         })?.id

--- a/macos/Tests/Workspace/WorkspacePersistenceTests.swift
+++ b/macos/Tests/Workspace/WorkspacePersistenceTests.swift
@@ -148,8 +148,8 @@ struct WorkspacePersistenceTests {
 
     @Test func projectMemberwiseInitDefaultsIsPinnedToFalse() {
         // New semantics: a project constructed without specifying isPinned is NOT pinned.
-        // The explicit `isPinned: true` at WorkspaceStore.addProject(at:) remains intact;
-        // only the struct's default changes.
+        // WorkspaceStore.addProject(at:pinned:) now defaults to unpinned too —
+        // only the picker path opts in with `pinned: true`.
         let project = Project(name: "Unpinned", rootPath: "/tmp/Unpinned")
         #expect(project.isPinned == false)
     }

--- a/macos/Tests/Workspace/WorkspaceStoreFreezeTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreFreezeTests.swift
@@ -90,10 +90,11 @@ struct WorkspaceStoreFreezeTests {
         store.freezeSnapshot()
         #expect(ids(in: .pinned, of: store.sectionedProjects) == [existing.id])
 
-        // Use a real URL — addProject pins it and assigns a ghost.
+        // Use a real URL, pinned explicitly — addProject only pins on an
+        // explicit request now, and assigns a ghost.
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("workspace-freeze-test-\(UUID().uuidString)", isDirectory: true)
-        store.addProject(at: tmp)
+        store.addProject(at: tmp, pinned: true)
 
         // Snapshot must have been released — both projects visible in `.pinned`.
         let pinnedNames = store.sectionedProjects.first(where: { $0.0 == .pinned })?.1.map(\.name) ?? []

--- a/macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import Ghostty
+
+/// Tests for Session Composer Phase 5: `WorkspaceStore.addProject(at:pinned:)`
+/// must pin only on an explicit request, never as a side effect of
+/// auto-registration (e.g. from `SessionCoordinator` spawning a new task).
+///
+/// Each test calls the real production `addProject(at:pinned:)` and asserts
+/// on the real `Project.isPinned`, per the standing rule against vacuous
+/// tests (see `feedback_vacuous-tests-pass-green.md`).
+@MainActor
+struct WorkspaceStorePinOnAddTests {
+
+    private func tmpURL(_ name: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("workspace-pin-on-add-\(name)-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @Test func addProjectWithDefaultArgsRegistersUnpinned() {
+        let store = WorkspaceStore(testingProjects: [], testingSessions: [])
+        let url = tmpURL("auto")
+
+        store.addProject(at: url)
+
+        let project = store.projects.first(where: { $0.rootPath == url.standardizedFileURL.path })
+        #expect(project != nil)
+        #expect(project?.isPinned == false)
+    }
+
+    @Test func addProjectWithPinnedTrueRegistersPinned() {
+        let store = WorkspaceStore(testingProjects: [], testingSessions: [])
+        let url = tmpURL("explicit")
+
+        store.addProject(at: url, pinned: true)
+
+        let project = store.projects.first(where: { $0.rootPath == url.standardizedFileURL.path })
+        #expect(project != nil)
+        #expect(project?.isPinned == true)
+    }
+
+    @Test func reAddingUnpinnedProjectWithPinnedTruePinsIt() {
+        let url = tmpURL("repin")
+        let path = url.standardizedFileURL.path
+        let existing = Project(name: "Repin", rootPath: path, isPinned: false)
+        let store = WorkspaceStore(testingProjects: [existing], testingSessions: [])
+
+        store.addProject(at: url, pinned: true)
+
+        let project = store.projects.first(where: { $0.rootPath == path })
+        #expect(project?.isPinned == true)
+    }
+
+    @Test func reAddingPinnedProjectWithDefaultArgsDoesNotUnpinIt() {
+        let url = tmpURL("keep-pinned")
+        let path = url.standardizedFileURL.path
+        let existing = Project(name: "KeepPinned", rootPath: path, isPinned: true)
+        let store = WorkspaceStore(testingProjects: [existing], testingSessions: [])
+
+        // Simulates auto-registration (e.g. SessionCoordinator) rediscovering
+        // an already-pinned project. Must be a pure no-op on pin state.
+        store.addProject(at: url)
+
+        let project = store.projects.first(where: { $0.rootPath == path })
+        #expect(project?.isPinned == true)
+    }
+}

--- a/macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift
@@ -64,4 +64,83 @@ struct WorkspaceStorePinOnAddTests {
         let project = store.projects.first(where: { $0.rootPath == path })
         #expect(project?.isPinned == true)
     }
+
+    // MARK: - Freeze-snapshot no-op (the actual duplicate-path fix)
+    //
+    // `isPinned == true` alone doesn't discriminate old vs. new behavior on
+    // the re-add-existing branch: the OLD code also force-set `isPinned =
+    // true` on an already-pinned project, so that assertion passes either
+    // way. What Phase 5 actually changes is whether the early-return path
+    // calls `releaseSnapshot()` + `persist()` at all.
+    //
+    // `sectionSignature` alone is NOT a reliable witness here: a pinned
+    // project's section membership never changes regardless of activity
+    // (see `computeSectionedProjects` — `isPinned` short-circuits straight
+    // to `.pinned`), so releasing-vs-not-releasing the snapshot can produce
+    // an identical signature even when release genuinely happened. The real
+    // witness is `persistCallCount` (`#if DEBUG`, exists precisely to let
+    // tests assert "this path never even attempted to persist" — see the
+    // doc comment on the property). Both assertions are kept for belt and
+    // suspenders, but `persistCallCount` is the one that actually
+    // discriminates: verified by temporarily relaxing the production guard
+    // from `guard pinned, !projects[index].isPinned else { return }` to
+    // `guard pinned else { return }` and re-running this file — the relaxed
+    // guard makes `reAddingAlreadyPinnedProjectWithPinnedTrueIsAPureNoOp`
+    // fail (persistCallCount increments) while `sectionSignature` alone
+    // stayed equal and would have missed the regression.
+
+    @Test func reAddingUnpinnedProjectWithDefaultArgsIsAPureNoOp() {
+        let url = tmpURL("noop-unpinned")
+        let path = url.standardizedFileURL.path
+        let existing = Project(name: "NoopUnpinned", rootPath: path, isPinned: false)
+        let store = WorkspaceStore(testingProjects: [existing], testingSessions: [])
+
+        store.freezeSnapshot()
+        let frozenSignature = store.sectionSignature
+        let persistCountBefore = store.persistCallCount
+
+        // Auto-registration rediscovering an unpinned project. Must not
+        // release the snapshot or persist — nothing structurally changed.
+        store.addProject(at: url)
+
+        #expect(store.sectionSignature == frozenSignature)
+        #expect(store.persistCallCount == persistCountBefore)
+    }
+
+    @Test func reAddingAlreadyPinnedProjectWithPinnedTrueIsAPureNoOp() {
+        let url = tmpURL("noop-pinned")
+        let path = url.standardizedFileURL.path
+        let existing = Project(name: "NoopPinned", rootPath: path, isPinned: true)
+        let store = WorkspaceStore(testingProjects: [existing], testingSessions: [])
+
+        store.freezeSnapshot()
+        let frozenSignature = store.sectionSignature
+        let persistCountBefore = store.persistCallCount
+
+        // Explicit re-add of an already-pinned project (e.g. picking the same
+        // folder twice). No pin-state change, so this must also be a no-op —
+        // it must NOT call releaseSnapshot()/persist() just because `pinned`
+        // was passed as true.
+        store.addProject(at: url, pinned: true)
+
+        #expect(store.sectionSignature == frozenSignature)
+        #expect(store.persistCallCount == persistCountBefore)
+    }
+
+    @Test func addingNewUnpinnedProjectStillReleasesFrozenSnapshot() {
+        // The auto-register path (default args) creating a genuinely NEW
+        // project is a structural change and must still drop the snapshot,
+        // same as the existing pinned-picker-add coverage in
+        // WorkspaceStoreFreezeTests.
+        let existing = Project(name: "Existing", rootPath: "/tmp/Existing", isPinned: true)
+        let store = WorkspaceStore(testingProjects: [existing], testingSessions: [])
+
+        store.freezeSnapshot()
+        let frozenSignature = store.sectionSignature
+
+        let url = tmpURL("new-unpinned")
+        store.addProject(at: url)
+
+        #expect(store.sectionSignature != frozenSignature)
+    }
 }


### PR DESCRIPTION
## Summary

- `WorkspaceStore.addProject(at:pinned:)` gains a `pinned: Bool = false` parameter. New-project construction uses `isPinned: pinned` instead of the hardcoded `true`.
- The duplicate/re-add path now only re-pins when `pinned == true` AND the project isn't already pinned. With default args it's a pure no-op — no `isPinned` write, no `releaseSnapshot()`, no `persist()` — so silent auto-registration (e.g. `SessionCoordinator` re-registering a project on session spawn) can never unpin a project the user deliberately pinned.
- `addProjectViaFolderPicker` — the single convergence point for all four UI "add project" paths — now calls `addProject(at: url, pinned: true)`.
- `SessionCoordinator`'s auto-register call site (`SessionCoordinator.swift:509`) is unchanged and inherits the new `pinned: false` default, which is the actual fix: auto-registered projects no longer force-pin into the sidebar. Updated the doc-comment resolution list and two inline comments there that described the old always-pin behavior.

Why the duplicate-path no-op matters: before this change, any code path that called `addProject(at:)` on a path that already existed as a project — pinned or not — would force `isPinned = true`. That meant a background auto-register (which happens on every new agent-spawn against an existing project) silently re-pinned projects the user had explicitly unpinned, and there was no way to keep a project registered-but-unpinned. Now pin state only ever moves in the direction the caller explicitly asks for.

`WorkspacePersistence.migratePinSemanticsIfNeeded` already covers the upgrade-reorder concern (existing installs where old semantics wrote `isPinned: true` broadly) — not touched, not re-triggered by this change.

**Migration end state:** for existing users, `migratePinSemanticsIfNeeded` already unpinned everything on first launch of the prior release. After this change, the "Pinned" sidebar section will be **empty** until the user pins something manually — picker-add (`addProjectViaFolderPicker`) and the context-menu `togglePin` are now the only two paths that set `isPinned = true`. That emptiness is the intended end state of the migration, not a regression: pin now means "the user asked for this," not "this project exists."

**Latent bug this also fixes:** `SessionCoordinator.startOrFocusSession` resolves an existing project by **name** (`store.projects.first(where: { $0.name == name })`), but `addProject(at:)` dedupes by **path**. Under the old code, if a project had been renamed since it was first registered, every task-row click would fail the name lookup, fall through to `addProject(at:)`, find the path match, and force `isPinned = true` again — so a renamed project got silently re-pinned on every single click. The new guard (`pinned && !isPinned`) makes that a no-op when the project is already pinned, and leaves it correctly unpinned when it isn't.

## Tests

Added `macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift`, calling the real `WorkspaceStore.addProject(at:pinned:)` and asserting on real `Project.isPinned` / `sectionSignature` / `persistCallCount`:

1. Default args → new project registers unpinned.
2. `pinned: true` → new project registers pinned.
3. Re-add with `pinned: true` on an existing unpinned project → pins it.
4. Re-add with default `pinned: false` on an existing pinned project → `isPinned` stays `true`.
5. Re-add with default args on an existing **unpinned** project → pure no-op (`sectionSignature` and `persistCallCount` unchanged).
6. Re-add with `pinned: true` on an existing **already-pinned** project → pure no-op (`sectionSignature` and `persistCallCount` unchanged).
7. Adding a genuinely new unpinned project (the auto-register path) still releases a frozen snapshot — the structural-mutation path stays intact.

Non-vacuous check, corrected: **of tests 1–4, only test 1 discriminates old vs. new production code cleanly** (tests 5–6 below also discriminate — test 5 fails against the pre-Phase-5 duplicate branch, which unconditionally released and persisted) — it exercises the exact line that changed (`isPinned: pinned` replacing the hardcoded `isPinned: true`), and would fail under the prior signature. Tests 2–4 are regression guards for behavior that was already partly true or is now explicit, not proof of the fix by themselves — `isPinned == true` on an already-pinned re-add passes under *both* old and new code, since old code also force-set it to `true`.

The real discriminating coverage for the re-add no-op is tests 5–6, which assert on `persistCallCount` (a `#if DEBUG` counter that exists precisely so tests can prove a path never attempted to persist) rather than `isPinned`. `sectionSignature` alone is not sufficient here — a pinned project's section membership never changes regardless of activity state (`computeSectionedProjects` short-circuits `isPinned` straight to `.pinned`), so release-vs-no-release can produce an identical signature even when release genuinely happened.

**Verified test 6 actually discriminates:** temporarily relaxed the production guard from `guard pinned, !projects[index].isPinned else { return }` to `guard pinned else { return }` and reran the suite — `reAddingAlreadyPinnedProjectWithPinnedTrueIsAPureNoOp` failed (persistCallCount incremented) under the relaxed guard and passed against the real one. Guard reverted before committing; `git diff` on `WorkspaceStore.swift` is empty for this round.

Also updated `WorkspaceStoreFreezeTests.addProjectWhileFrozenDropsSnapshotAndShowsNewProject` to pass `pinned: true` explicitly, since it asserts the new project lands in the `.pinned` section and previously relied on the old always-pin default.

**Full unfiltered suite, this worktree, after the review-round fix commit:**
```
xcodebuild test -project macos/Ghostties.xcodeproj -scheme Ghostties -derivedDataPath macos/build ONLY_ACTIVE_ARCH=YES ARCHS=arm64
```
`xcrun xcresulttool get test-results summary` → **0 failed, 748 passed, 1 skipped, 749 total** (top-level count; device-level 798 includes dynamic-parameter test expansions). `"result": "Passed"`.

## Call-site inventory

Verbatim `grep -rn "addProject(at" macos/` output at `885c62863` (16 lines — test files and comments included):

```
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:5:/// Tests for Session Composer Phase 5: `WorkspaceStore.addProject(at:pinned:)`
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:9:/// Each test calls the real production `addProject(at:pinned:)` and asserts
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:24:        store.addProject(at: url)
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:35:        store.addProject(at: url, pinned: true)
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:48:        store.addProject(at: url, pinned: true)
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:62:        store.addProject(at: url)
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:104:        store.addProject(at: url)
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:124:        store.addProject(at: url, pinned: true)
macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift:142:        store.addProject(at: url)
macos/Tests/Workspace/WorkspaceStoreFreezeTests.swift:97:        store.addProject(at: tmp, pinned: true)
macos/Tests/Workspace/WorkspacePersistenceTests.swift:151:        // WorkspaceStore.addProject(at:pinned:) now defaults to unpinned too —
macos/Sources/Features/Ghostties/WorkspaceStore.swift:653:    func addProject(at url: URL, pinned: Bool = false) {
macos/Sources/Features/Ghostties/WorkspaceStore.swift:1000:        addProject(at: url, pinned: true)
macos/Sources/Features/Ghostties/SessionCoordinator.swift:497:        // 1/2. Resolve or register the project. `addProject(at:)` handles
macos/Sources/Features/Ghostties/SessionCoordinator.swift:507:            // `addProject(at:)` does the standardization.
macos/Sources/Features/Ghostties/SessionCoordinator.swift:509:            store.addProject(at: url)
```

Two direct production call sites confirmed: the picker (`WorkspaceStore.swift:1000`, `pinned: true`) and `SessionCoordinator` auto-register (`SessionCoordinator.swift:509`, default, unpinned). No other production callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jM5TrryJytAHa9WgkEQYm

