### PR TITLE
feat(composer): command grammar slice 1 — ad-hoc commands from the composer

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,52 @@ Parked items that survive context resets. Prune at `/wrap`.
 
 > Reconciled 2026-07-29: the tracked `main` copy (07-17→07-22) and the untracked working-tree copy (07-26→07-28) had diverged. This file is the union. Only closed items were dropped (PR #48 merged as `3d2cefc57`).
 
+## 2026-08-22 — Composer command grammar slice 1 SHIPPED to branch; breadcrumb spec'd
+
+Slice 1 is complete and verified end-to-end. Branch `feat/composer-command-grammar-slice1`
+@ `f5ee65b8f` (code head `a13de1f16`), pushed, **no PR opened — Sean opens/merges**.
+Branched off `df0c1b8de`; `origin/main` has since advanced to `4d4b81003` (one docs commit),
+so a rebase may be wanted before the PR.
+
+All six acceptance criteria closed. Criterion 1 proven from disk, not a screenshot —
+`~/.ghostties/cache/launchers/<uuid>.sh` contained `exec 'cco' '-n' 'test'` under the
+`#!/bin/zsh -l` + `. ~/.zshrc` wrapper. Verified on two runs. Suite 770/0/1.
+Four review rounds; rounds 2 and 3 each found real defects the prior round missed
+(now **eight-for-eight** on the "never accept one review round on UI work here" rule).
+
+- [ ] **Open the PR for slice 1.** Sean's call — nothing merges unprompted. | app | carried
+- [ ] **Slice A — breadcrumb chips.** Spec at `docs/plans/composer-breadcrumb-spec.html`,
+  all four decisions settled 2026-08-22. Replaces the trailing project dropdown with inline
+  chips; retires the label-width squeeze rather than tuning it. Build chip pickers as an
+  **inline expansion inside the card, not a nested popover** — the project dropdown is already
+  a `.popover` nested in the composer's `.popover` and has never been verified.
+  **`⌘Z` chip-aware undo is new scope** — the composer has no undo stack; AppKit's text undo
+  knows nothing about chips. | app | new
+- [ ] **Slice B — branch segment resolving to a worktree.** Never `git checkout` in the project
+  dir (would yank the branch from under a parallel session). Enumerate existing worktrees first;
+  creation only behind an explicit `+ new worktree` row. Needs caching — shelling per keystroke
+  is not viable. Nothing in the composer path knows about worktrees today. | app | new
+
+**Parked — review findings deliberately not fixed in slice 1:**
+
+- [ ] **The project dropdown's checkmark disagrees with its label** about which project is
+  selected. Pre-existing, surfaced by review round 1. Slice A's one-source-of-truth kills it. | app | parked
+- [ ] **Row titles wrap ~3 chars sooner at the 204pt card** (they have no `lineLimit`, so they
+  wrap rather than truncate), costing one visible row. Adding a limit swaps wrapping for
+  truncation — a design choice, not a bug fix. | design | parked
+- [ ] **The locked/unlocked project label has no `layoutPriority` and no width cap**, so a long
+  name both truncates and halves the search field. Threshold dropped from ~26 to ~23 chars at
+  204pt. Closes the long-owed truncate-vs-wrap question: it **truncates**, never wraps. | design | parked
+- [ ] **`ghostties "" cco` produces no Run row** — an empty quoted first token splits to zero
+  words and returns nil even when valid tokens follow. Marginal input. | app | parked
+- [ ] **No test seam for the write-target rule.** The three `resolveCommitProjectId` tests are
+  rule coverage, not call-site coverage — swapping the two args at the call site leaves all
+  three green. A real seam exists in `SessionComposerStore.precommit`, but taking it would have
+  breached slice 1's scope fence. | quality | parked
+- [ ] **RECENT shows "Shell" after an ad-hoc run** (templateId is `AgentTemplate.shell.id` by
+  design), and `ComposerResultsTable` highlights against the full query while rows are filtered
+  by the remainder, so match highlighting disappears in command mode. | app | parked
+
 ## 2026-08-20 — Session state at bedtime wrap (carried)
 
 Two PRs open, neither merged. Sean merges; never merge unprompted.

--- a/docs/plans/composer-breadcrumb-spec.html
+++ b/docs/plans/composer-breadcrumb-spec.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Composer breadcrumb + optional branch</title>
+<link rel="stylesheet" href="http://localhost:4849/assets/plan.css">
+</head>
+<body>
+
+<h1>Composer breadcrumb + optional branch</h1>
+<p class="doc-meta">Ghostties · 2026-08-22 · spec, awaiting your comments · follows slice 1 (<code>a13de1f16</code>)</p>
+
+<h2>The grammar</h2>
+
+<p><strong>Every segment after the first is optional, and omitting one means "default."</strong></p>
+
+<pre><code>ghostties                        → scope to repo, nothing launched
+ghostties cco                    → repo + template, default branch
+ghostties &gt; main &gt; cco -n "test" → repo + branch + ad-hoc command</code></pre>
+
+<ul>
+<li><strong>Omitted branch means "wherever the project points right now"</strong> — not a remembered last-used branch. No hidden state, nothing to go stale, and it is exactly today's behavior.</li>
+<li><strong>The parser does not change.</strong> Slice 1 already tokenizes on whitespace at ≥2 tokens. <code>&gt;</code> is rendering, not syntax — which retires the "positional vs sigils" question from the original grammar spec.</li>
+<li><strong>Single token stays byte-identical</strong>, protecting the fast path exactly as slice 1 does.</li>
+</ul>
+
+<h2>Two slices, in this order</h2>
+
+<table>
+<thead><tr><th>Slice</th><th>What it does</th><th>Why this order</th></tr></thead>
+<tbody>
+<tr><td><strong>A — breadcrumb chips</strong></td><td>Resolved leading tokens render as inline chips with <code>&gt;</code> separators. Each chip is a picker. Replaces the trailing project dropdown.</td><td>Pure rendering. No new concepts, and it retires a live layout bug.</td></tr>
+<tr><td><strong>B — branch segment</strong></td><td>A branch chip resolving to a worktree, never a checkout.</td><td>Needs branch enumeration, caching, and a worktree-creation confirm path. Real feature, not a tweak.</td></tr>
+</tbody>
+</table>
+
+<h2>Slice A fixes a bug we are already carrying</h2>
+
+<p>The project label is a trailing control competing with the search field for width, with no <code>layoutPriority</code> and no cap on either. A long project name both truncates and halves the field. Moving the project <em>into</em> the field as a chip removes the second control entirely — the layout problem disappears rather than getting tuned.</p>
+
+<p>It also makes the parse visible. Today the only signal that token 1 resolved is a label changing in the corner.</p>
+
+<blockquote class="callout">
+<strong>Build the chip picker as an inline expansion inside the card, not a nested popover.</strong> The project dropdown is already a <code>.popover</code> nested inside the composer's own <code>.popover</code> — on the known-fragile list, never verified, and a child taking key can dismiss the parent. From a sidebar row, two chips means two chances to lose the composer. An inline expansion fixes the existing fragility instead of doubling it. Cmd+T is unaffected either way; the centered overlay is not a popover.
+</blockquote>
+
+<h2>Decisions you own</h2>
+
+<table>
+<thead><tr><th>#</th><th>Decision</th><th>Recommendation</th></tr></thead>
+<tbody>
+<tr><td>1</td><td>Chip separator glyph — <code>&gt;</code>, <code>/</code>, or <code>›</code></td><td><code>›</code> — reads as a breadcrumb, not a shell redirect or a path. <strong>You never type it.</strong> The app draws it between chips; you advance a segment with space or <code>&gt;</code> (decision 3). If you ever want the glyph by hand it is <kbd>⌥⇧4</kbd> on a US layout.</td></tr>
+<tr><td>2</td><td><strong>DECIDED</strong> — chip change cascades right</td><td>Changing a segment clears everything to its right, because the right depends on the left. <code>⌘Z</code> restores. Sean's call, 2026-08-22.</td></tr>
+<tr><td>3</td><td><strong>DECIDED</strong> — typable separator</td><td><code>&gt;</code> only, as a synonym for space. <strong><code>/</code> is reserved</strong> — it is the natural prefix for skills later, and a separator that also means "skill" is a collision we would have to unpick. Sean's call, 2026-08-22.</td></tr>
+<tr><td>4</td><td><strong>DECIDED</strong> — unmatched branch offers creation</td><td>Yes, behind an explicit <code>+ new worktree</code> row — never implicitly. Sean's call, 2026-08-22.</td></tr>
+</tbody>
+</table>
+
+<h2>The cascade rule</h2>
+
+<ul>
+<li><strong>Change the repo, and branch and command both clear.</strong> A branch name is meaningless in another repo, and templates can be repo-scoped, so keeping either would leave a stale selection pointing at the wrong thing.</li>
+<li><strong>Change the branch, and nothing clears.</strong> A command is branch-agnostic — <code>cco -n "xyz"</code> means the same thing on any branch.</li>
+<li><strong>Re-picking the same value is a no-op</strong>, not a clear. Clicking the repo chip and choosing the repo already selected must not wipe what you typed.</li>
+<li><strong><code>⌘Z</code> restores the cleared segments</strong> as one undo step, so a mis-click costs nothing.</li>
+</ul>
+
+<blockquote class="callout">
+<strong>Undo is new scope.</strong> The composer has no undo stack today — <code>⌘Z</code> in the field is AppKit's own text undo and knows nothing about chips. A chip-aware undo that restores a cleared branch and command as a single step has to be built. Small, but it is not free, and it is the one part of slice A that is not pure rendering.
+</blockquote>
+
+<details>
+<summary>Slice A — implementation detail</summary>
+<ul>
+<li><strong>Rendering:</strong> resolved leading tokens become chips; the remainder stays live editable text in the same field. Chips are not text — backspace at position 0 pops the last chip back to text.</li>
+<li><strong>Delete the trailing <code>projectControl</code></strong> (<code>SessionComposerPalette.swift</code>, the locked and unlocked branches both). The <code>.locked</code> case becomes a chip rendered without a picker affordance.</li>
+<li><strong>Reuse <code>ProjectDropdownView</code>'s list content</strong> (<code>:1283</code>) but present it inline, not via <code>.popover</code> at <code>:629</code>.</li>
+<li><strong>Fixes on the way through:</strong> the dropdown's checkmark currently disagrees with the label about which project is selected — one source of truth kills it.</li>
+<li><strong>Keyboard:</strong> left-arrow from field start focuses the previous chip; Return or Down opens its picker; Esc closes the picker without closing the composer.</li>
+</ul>
+</details>
+
+<details>
+<summary>Slice B — branch as worktree, and why not checkout</summary>
+<ul>
+<li><strong>Never <code>git checkout</code> in the project directory.</strong> You run 2–7 parallel sessions against shared trees; a checkout from a launcher would yank the branch out from under another session's uncommitted work. This is the whole reason branch resolves to a worktree.</li>
+<li><strong>Resolve to an existing worktree first.</strong> Enumerate via <code>git worktree list --porcelain</code>; the branch chip lists what already exists before it offers to make anything.</li>
+<li><strong>Creation is explicit</strong> — a <code>+ new worktree</code> row, never an implicit side effect of typing a name that does not match.</li>
+<li><strong>Enumeration needs caching.</strong> Shelling out per keystroke is not viable. <code>SessionDraftStore.swift:291-300</code> already shells to <code>git rev-parse --abbrev-ref HEAD</code>, so the pattern exists — but it is one call at draft time, not a per-keystroke list.</li>
+<li><strong>Nothing in the composer path knows about worktrees today.</strong> Only <code>TaskModel</code>, <code>TaskStore</code>, and <code>OrphanTriageStore</code> mention them.</li>
+</ul>
+</details>
+
+<details>
+<summary>What slice 1 already settled, so this spec does not re-open it</summary>
+<ul>
+<li><strong>Session naming needs no rule.</strong> An unpinned session's sidebar name is the live terminal title, so <code>-n test</code> reaches the name by itself a few seconds after launch. Observed on two runs.</li>
+<li><strong>The remainder does not blanket-run</strong> — it filters that project's templates <em>and</em> appends a <code>Run "…"</code> row. Blanket-running would break <code>ghostties orchestrator</code>.</li>
+<li><strong>Ad-hoc commands need the login-shell wrapper.</strong> <code>exec 'cco' '-n' 'test'</code> verified on disk; <code>cco</code> is a zsh function and dies under <code>/bin/sh -c</code>.</li>
+<li><strong>Never claim <code>-n</code></strong> as an app flag — it is yours.</li>
+</ul>
+</details>
+
+</body>
+</html>

--- a/macos/Sources/Features/Ghostties/SessionComposerCommandParser.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerCommandParser.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Pure, testable command-grammar parsing for the session composer's
+/// text-forward command entry (command grammar slice 1). Neither type here
+/// touches SwiftUI or `@MainActor` state — see `SessionComposerRanking.swift`
+/// for the same discipline applied to relevance ranking.
+///
+/// Target: typing `ghostties cco -n "test"` resolves project=ghostties,
+/// tokenizes the remainder `cco -n test`, and offers a `Run "cco -n test"`
+/// row that spawns a real session running that command — without ever
+/// blanket-executing the remainder as a shell command (that would break
+/// `ghostties orchestrator`, which must still reach the Orchestrator
+/// template via the ordinary template-matching path).
+enum SessionComposerCommandParser {
+
+    /// The fixed identity of the composer's synthesized "Run" row.
+    /// `ComposerOption.id` is injectable specifically to avoid UUID churn on
+    /// every keystroke (see `SessionComposerPalette.ComposerOption`) — this
+    /// row's underlying command changes on every keystroke by design, so a
+    /// stable sentinel id (rather than deriving one from the command text)
+    /// is what keeps hover/scroll state settled while the label updates.
+    static let runRowId = UUID(uuidString: "89FA0000-0000-0000-0000-000000000001")!
+
+    /// Result of tokenizing a composer query against the known project
+    /// list. `projectId == nil` means "no command was recognized" — every
+    /// caller must fall through to the existing whole-string filter,
+    /// byte-identical, in that case.
+    struct ParseResult: Equatable {
+        let projectId: UUID?
+        let remainderTokens: [String]
+
+        /// The remainder tokens rejoined with single spaces, for display
+        /// (`Run "<remainderText>"`) and for scoping the project's own
+        /// template filter. Quote marks used only to keep a multi-word
+        /// argument as one token are not reconstructed — display never
+        /// needs to round-trip back into a query string.
+        var remainderText: String {
+            remainderTokens.joined(separator: " ")
+        }
+
+        static let none = ParseResult(projectId: nil, remainderTokens: [])
+    }
+
+    /// Split `input` on whitespace, honoring double quotes so a quoted
+    /// argument (`"ghostties website"`) survives as a single token instead
+    /// of splitting on its internal space. Quote characters themselves are
+    /// stripped from the resulting tokens.
+    static func tokenize(_ input: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var hasCurrent = false
+        var inQuotes = false
+
+        for char in input {
+            if char == "\"" {
+                inQuotes.toggle()
+                hasCurrent = true
+                continue
+            }
+            if char.isWhitespace, !inQuotes {
+                if hasCurrent {
+                    tokens.append(current)
+                    current = ""
+                    hasCurrent = false
+                }
+                continue
+            }
+            current.append(char)
+            hasCurrent = true
+        }
+        if hasCurrent {
+            tokens.append(current)
+        }
+        return tokens
+    }
+
+    /// Parse `query` for the `<project> <remainder...>` command grammar.
+    ///
+    /// Tokenizes ONLY when ALL of: there are ≥2 tokens, token 1 exactly
+    /// matches a project `name` or folder basename (case-insensitive), and
+    /// `isLocked` is false. Any other case returns `.none` — the caller
+    /// must treat that as "no command", not as an error, and keep filtering
+    /// the raw query exactly as it did before this parser existed.
+    static func parse(query: String, projects: [Project], isLocked: Bool) -> ParseResult {
+        guard !isLocked else { return .none }
+
+        let tokens = tokenize(query)
+        guard tokens.count >= 2 else { return .none }
+
+        guard let project = projects.first(where: { matches($0, token: tokens[0]) }) else {
+            return .none
+        }
+
+        return ParseResult(projectId: project.id, remainderTokens: Array(tokens.dropFirst()))
+    }
+
+    private static func matches(_ project: Project, token: String) -> Bool {
+        if project.name.caseInsensitiveCompare(token) == .orderedSame { return true }
+        let basename = (project.rootPath as NSString).lastPathComponent
+        return basename.caseInsensitiveCompare(token) == .orderedSame
+    }
+
+    /// Synthesize the ad-hoc template for a resolved command's remainder.
+    ///
+    /// Reuses `AgentTemplate.shell.id` (never mints a fresh UUID) so
+    /// `WorkspacePersistence.validate` doesn't delete the session on
+    /// relaunch — relaunching an ad-hoc session relaunches plain Shell,
+    /// an accepted degradation. `agent:` is set purely to buy the
+    /// login-shell wrapper `SessionCoordinator.createSession` writes
+    /// whenever `template.launchBanner != nil` (i.e. `agent != nil`) —
+    /// `exec` inside that `#!/bin/zsh -l` wrapper resolves zsh functions
+    /// like `cco`, which a bare `/bin/sh -c` spawn never would.
+    ///
+    /// The remainder's first token becomes `command` (the only
+    /// single-quoted-whole carrier, `AgentTemplate.shellEscape`); every
+    /// token after it becomes `agent.additionalFlags`, the only
+    /// per-token-escaped carrier — splitting this way is what keeps
+    /// `cco -n test` from collapsing into one unrunnable argv word.
+    static func makeAdHocTemplate(remainderTokens: [String]) -> AgentTemplate? {
+        guard let first = remainderTokens.first else { return nil }
+        let rest = Array(remainderTokens.dropFirst())
+        return AgentTemplate(
+            id: AgentTemplate.shell.id,
+            name: first,
+            kind: .custom,
+            command: first,
+            agent: AgentTemplate.AgentConfig(additionalFlags: rest)
+        )
+    }
+}

--- a/macos/Sources/Features/Ghostties/SessionComposerCommandParser.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerCommandParser.swift
@@ -119,12 +119,40 @@ enum SessionComposerCommandParser {
     static func makeAdHocTemplate(remainderTokens: [String]) -> AgentTemplate? {
         guard let first = remainderTokens.first else { return nil }
         let rest = Array(remainderTokens.dropFirst())
+
+        // Blocker fix: a quoted first remainder token (`ghostties "npm run
+        // dev"`) survives `tokenize` as one token containing internal
+        // whitespace. Putting that whole into `command` reintroduces the
+        // `shellEscape` blocker verbatim — `buildCommand()` would quote it
+        // as a single argv word (`'npm run dev'`), which the shell can't
+        // resolve. Re-split the first token on whitespace: only its first
+        // word becomes `command`; every word after it flows into
+        // `additionalFlags` ahead of the rest of the remainder. This also
+        // covers an unbalanced-quote remainder (`ghostties "` tokenizes to
+        // `["ghostties", ""]`) — an empty or whitespace-only first token
+        // splits to zero words, so `command` guards below and this
+        // returns `nil` instead of committing a live `Run ""` row.
+        let firstWords = first.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        guard let command = firstWords.first else { return nil }
+        let flags = Array(firstWords.dropFirst()) + rest
+
         return AgentTemplate(
             id: AgentTemplate.shell.id,
-            name: first,
+            name: command,
             kind: .custom,
-            command: first,
-            agent: AgentTemplate.AgentConfig(additionalFlags: rest)
+            command: command,
+            agent: AgentTemplate.AgentConfig(additionalFlags: flags)
         )
+    }
+
+    /// Resolves which project a commit should land in: a resolved command
+    /// project (typed `<project> <remainder>`) takes precedence over
+    /// whatever project is currently selected in the dropdown. Pure/testable
+    /// extraction of the write-path polarity fixed by the "scopes list to
+    /// project A, commits into project B" blocker — `SessionComposerPalette`
+    /// itself has no testable seam for this (a SwiftUI `View` reading
+    /// `@EnvironmentObject` state), so this is the seam.
+    static func resolveCommitProjectId(commandProjectId: UUID?, selectedProjectId: UUID?) -> UUID? {
+        commandProjectId ?? selectedProjectId
     }
 }

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -49,13 +49,24 @@ struct SessionComposerPalette: View {
     // MARK: - No-match Enter feedback (command grammar slice 1)
 
     /// Drives `ShakeEffect` — 3 cycles / 6pt, animated over 0.25s. Bumped by
-    /// one on every no-match Return; the animation reads the delta, not the
-    /// absolute value, so back-to-back no-match Returns each restart a full
-    /// shake rather than compounding.
+    /// one on every no-match Return. `ShakeEffect.effectValue` reads the
+    /// ABSOLUTE value of `animatableData`, not a delta — bumping by whole
+    /// integers works cleanly anyway because `shakesPerUnit` is an integer,
+    /// so every whole increment lands the sine argument back on a
+    /// zero-crossing, letting back-to-back no-match Returns restart a clean
+    /// shake instead of visibly jumping mid-cycle.
     @State private var shakeTrigger: CGFloat = 0
     /// Reduce-motion fallback: a 400ms red border pulse instead of the
     /// shake, toggled true then back false after the duration.
     @State private var showNoMatchBorder = false
+    /// Guards `.submitNoMatch` against a same-turn double-fire from
+    /// `.onSubmit` + `Backport.onKeyPress` both firing on macOS 14+ (unlike
+    /// `.submit`, nothing here synchronously invalidates a second handler's
+    /// input — there's no list to swap out from under it). Set true
+    /// synchronously on the first fire, cleared on the next runloop turn, so
+    /// a second fire landing in the SAME turn is a no-op instead of driving
+    /// `shakeTrigger` 0→2 and doubling the shake to 6 cycles.
+    @State private var isHandlingNoMatchFeedback = false
 
     // MARK: - DESIGN.md scale (D11) — see `TemplatePickerView` for precedent.
     // `paletteWidth` pulls from `WorkspaceLayout` tokens (DESIGN.md §2
@@ -203,28 +214,15 @@ struct SessionComposerPalette: View {
               let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: commandParse.remainderTokens)
         else { return [] }
 
-        let projectId = commandProject.id
         return [
             ComposerOption(
                 id: SessionComposerCommandParser.runRowId,
                 title: "Run \"\(commandParse.remainderText)\"",
                 subtitle: commandProject.name,
                 leadingIcon: "terminal",
-                action: { commitCommand(projectId: projectId, template: template) }
+                action: { commit(template: template) }
             )
         ]
-    }
-
-    /// Commits the synthesized ad-hoc template into the RESOLVED command
-    /// project, which may differ from `composerStore.selectedProjectId`
-    /// (typing a command never changes the dropdown selection — see
-    /// `currentProject` above). Setting `selectedProjectId` directly here,
-    /// rather than via `selectProject(_:)`, is deliberate: `selectProject`
-    /// also clears `searchText`, which would blank the command that's
-    /// about to be committed out from under `commit(template:)`.
-    private func commitCommand(projectId: UUID, template: AgentTemplate) {
-        composerStore.selectedProjectId = projectId
-        commit(template: template)
     }
 
     // MARK: - Options
@@ -337,12 +335,16 @@ struct SessionComposerPalette: View {
         // resolves from the bound project, never `selectedProjectId`), so
         // letting a project row re-scope the list here would show project B
         // while `commit()` still creates in locked project A.
-        // A resolved command already scopes the list to one project (N3's
-        // own reasoning, extended here): showing project search results
-        // alongside a command's TEMPLATES/COMMAND rows would let a project
-        // row re-scope mid-command, contradicting the command that's
-        // already been typed.
-        guard !isProjectLocked, commandProject == nil, !query.isEmpty else { return [] }
+        //
+        // A resolved command does NOT suppress this section (reverted —
+        // that suppression was never in the brief and made a multi-word
+        // project name unreachable: with projects "ghostties" and
+        // "ghostties web", typing "ghostties web" resolves token 1 against
+        // the first project and, with PROJECTS hidden, offers only
+        // `Run "web"` — the project being named disappears from the list.
+        // A mis-parse must stay recoverable, so PROJECTS keeps ranking
+        // against the raw `query` exactly as it does with no command typed.
+        guard !isProjectLocked, !query.isEmpty else { return [] }
         let options = store.projects.map(makeOption)
         return SessionComposerRanking.sorted(options, query: query, title: { $0.title })
     }
@@ -382,10 +384,111 @@ struct SessionComposerPalette: View {
     // MARK: - Body
 
     var body: some View {
-        let backgroundColor = Color(nsColor: .windowBackgroundColor)
-        let scheme: ColorScheme = OSColor(backgroundColor).isLightColor ? .light : .dark
+        let scheme: ColorScheme = OSColor(Color(nsColor: .windowBackgroundColor)).isLightColor ? .light : .dark
 
-        VStack(alignment: .leading, spacing: 0) {
+        // Shake-clearance wrapper (finding: `.anchored` is an NSPopover
+        // sized exactly to its content — a shake applied to the composer's
+        // root, with no margin around it, clips or draws over the popover
+        // chrome). The card itself stays `paletteWidth` wide; this adds a
+        // 6pt-per-side clear inset AROUND it so the ±6pt lateral translation
+        // has room in both `.anchored` and `.centered`.
+        composerCard
+            .padding(.horizontal, 6)
+            // Overlay shadow (DESIGN.md §6, `.centered` only — Phase 3
+            // review fix, retuned in PR #132 (shadow-only elevation) now
+            // that the shadow carries the "on top of" read alone, with no
+            // scrim behind it). `.anchored` relies on the native NSPopover
+            // chrome/shadow instead; adding a second shadow there would
+            // double up.
+            .shadow(
+                color: request.presentation == .centered
+                    ? .black.opacity(WorkspaceLayout.composerModalShadowOpacity)
+                    : .clear,
+                radius: request.presentation == .centered ? WorkspaceLayout.composerModalShadowRadius : 0,
+                y: request.presentation == .centered ? WorkspaceLayout.composerModalShadowYOffset : 0
+            )
+            .environment(\.colorScheme, scheme)
+            .onAppear {
+                composerStore.open(projectBinding: request.projectBinding, workspaceStore: store)
+                // S5: row 0 is the project's default template (Phase 1's
+                // default-first ordering) and the legend reads "↵ start" —
+                // seed the selection so Return isn't a dead key on first
+                // open. `bestSelectionIndex` is index 0 here since the
+                // query is blank on first open (D1's cross-section ranking
+                // only applies once there's a query to rank against).
+                selectedIndex = bestSelectionIndex(in: flattenedOptions)
+            }
+            .onChange(of: isPresented) { presented in
+                if !presented {
+                    composerStore.cancel()
+                    isAddingTemplate = false
+                    newTemplateName = ""
+                }
+            }
+            .onDisappear {
+                // The only reliable teardown hook for popover content — the
+                // row hosting this popover can leave the hierarchy (project
+                // removed, sidebar view-mode switch, `windowDidResignKey` /
+                // `mouseExited` closing the popover) without
+                // `onChange(of: isPresented)` ever firing, which otherwise
+                // latches `SessionComposerStore.isOpen` true forever (B3).
+                composerStore.cancel()
+            }
+            .onChange(of: query) { _ in reselectBestMatch() }
+            .onChange(of: composerStore.selectedProjectId) { _ in
+                // N5: changing the project via the dropdown or a project row
+                // changes `flattenedOptions.count` with `query` unchanged, so
+                // the query-only clamp above never ran — `selectedOption`
+                // fell back to `options.last` and the highlight silently
+                // jumped to the bottom of the list.
+                clampSelectedIndex()
+            }
+            .onChange(of: composerStore.focusSearchFieldTrigger) { triggered in
+                // R8 (Phase 3 review round 2): mirrors the S5 seed in
+                // `onAppear` for the "re-open while already installed" path
+                // (F4) — `onAppear` doesn't reliably re-fire there (observed,
+                // see F4's comment in
+                // `WorkspaceViewContainer.presentComposerOverlay`), so a
+                // `selectedIndex` left `nil` by a just-completed commit
+                // (S1's reset) never gets re-seeded, and Return goes dead on
+                // a fast re-present. `focusSearchFieldTrigger` is exactly
+                // `open()`'s "already open" signal (S7) — unlike `isOpen`
+                // itself, which SwiftUI's `.onChange` won't re-fire on since
+                // it stays `true` across the whole re-open.
+                guard triggered else { return }
+                clampSelectedIndex()
+            }
+            .sheet(item: $newTemplateToEdit) { template in
+                TemplateEditForm(template: template)
+            }
+            .alert(
+                "Delete Template?",
+                isPresented: $showDeleteConfirmation,
+                presenting: templateToDelete
+            ) { template in
+                Button("Cancel", role: .cancel) {}
+                Button("Delete", role: .destructive) {
+                    store.removeTemplate(id: template.id)
+                }
+            } message: { template in
+                if store.templateInUse(id: template.id) {
+                    Text("Sessions using \"\(template.name)\" will keep their current configuration but won't be relaunchable with this template.")
+                } else {
+                    Text("This will permanently remove \"\(template.name)\".")
+                }
+            }
+    }
+
+    /// The composer's visible card — background, clip shape, border, the
+    /// no-match feedback overlays, and the shake itself. Kept separate from
+    /// `body` so the shake-clearance inset (`body`'s `.padding(.horizontal,
+    /// 6)`) wraps it rather than the shake living on the true root, which
+    /// left no room to translate inside an `.anchored` NSPopover sized
+    /// exactly to its content.
+    private var composerCard: some View {
+        let backgroundColor = Color(nsColor: .windowBackgroundColor)
+
+        return VStack(alignment: .leading, spacing: 0) {
             queryRow
 
             Divider()
@@ -456,87 +559,6 @@ struct SessionComposerPalette: View {
                 .opacity(showNoMatchBorder ? 1 : 0)
         )
         .modifier(ShakeEffect(animatableData: shakeTrigger))
-        // Overlay shadow (DESIGN.md §6, `.centered` only — Phase 3 review
-        // fix, retuned in PR #132 (shadow-only elevation) now that the shadow
-        // carries the "on top of" read alone, with no scrim behind it).
-        // `.anchored` relies on the native NSPopover chrome/shadow instead;
-        // adding a second shadow there would double up.
-        .shadow(
-            color: request.presentation == .centered
-                ? .black.opacity(WorkspaceLayout.composerModalShadowOpacity)
-                : .clear,
-            radius: request.presentation == .centered ? WorkspaceLayout.composerModalShadowRadius : 0,
-            y: request.presentation == .centered ? WorkspaceLayout.composerModalShadowYOffset : 0
-        )
-        .environment(\.colorScheme, scheme)
-        .onAppear {
-            composerStore.open(projectBinding: request.projectBinding, workspaceStore: store)
-            // S5: row 0 is the project's default template (Phase 1's
-            // default-first ordering) and the legend reads "↵ start" — seed
-            // the selection so Return isn't a dead key on first open.
-            // `bestSelectionIndex` is index 0 here since the query is blank
-            // on first open (D1's cross-section ranking only applies once
-            // there's a query to rank against).
-            selectedIndex = bestSelectionIndex(in: flattenedOptions)
-        }
-        .onChange(of: isPresented) { presented in
-            if !presented {
-                composerStore.cancel()
-                isAddingTemplate = false
-                newTemplateName = ""
-            }
-        }
-        .onDisappear {
-            // The only reliable teardown hook for popover content — the row
-            // hosting this popover can leave the hierarchy (project
-            // removed, sidebar view-mode switch, `windowDidResignKey` /
-            // `mouseExited` closing the popover) without
-            // `onChange(of: isPresented)` ever firing, which otherwise
-            // latches `SessionComposerStore.isOpen` true forever (B3).
-            composerStore.cancel()
-        }
-        .onChange(of: query) { _ in reselectBestMatch() }
-        .onChange(of: composerStore.selectedProjectId) { _ in
-            // N5: changing the project via the dropdown or a project row
-            // changes `flattenedOptions.count` with `query` unchanged, so
-            // the query-only clamp above never ran — `selectedOption` fell
-            // back to `options.last` and the highlight silently jumped to
-            // the bottom of the list.
-            clampSelectedIndex()
-        }
-        .onChange(of: composerStore.focusSearchFieldTrigger) { triggered in
-            // R8 (Phase 3 review round 2): mirrors the S5 seed in `onAppear`
-            // for the "re-open while already installed" path (F4) —
-            // `onAppear` doesn't reliably re-fire there (observed, see F4's
-            // comment in `WorkspaceViewContainer.presentComposerOverlay`),
-            // so a `selectedIndex` left `nil` by a just-completed commit
-            // (S1's reset) never gets re-seeded, and Return goes dead on a
-            // fast re-present. `focusSearchFieldTrigger` is exactly
-            // `open()`'s "already open" signal (S7) — unlike `isOpen`
-            // itself, which SwiftUI's `.onChange` won't re-fire on since it
-            // stays `true` across the whole re-open.
-            guard triggered else { return }
-            clampSelectedIndex()
-        }
-        .sheet(item: $newTemplateToEdit) { template in
-            TemplateEditForm(template: template)
-        }
-        .alert(
-            "Delete Template?",
-            isPresented: $showDeleteConfirmation,
-            presenting: templateToDelete
-        ) { template in
-            Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
-                store.removeTemplate(id: template.id)
-            }
-        } message: { template in
-            if store.templateInUse(id: template.id) {
-                Text("Sessions using \"\(template.name)\" will keep their current configuration but won't be relaunchable with this template.")
-            } else {
-                Text("This will permanently remove \"\(template.name)\".")
-            }
-        }
     }
 
     // MARK: - Query row (search field + trailing project control)
@@ -755,6 +777,22 @@ struct SessionComposerPalette: View {
         // these two do).
         selectedIndex = nil
 
+        // BLOCKER fix (command grammar slice 1): a resolved command project
+        // must win over whatever `selectedProjectId` still reads, for EVERY
+        // row that reaches `commit(template:)` — not just the synthesized
+        // Run row. Before this, `precommit` resolved the write target from
+        // `composerStore.selectedProjectId`, which typing a command never
+        // changes (see `currentProject`), so a `.exactPrefix` template row
+        // auto-selected under a command like `ghostties orchestrator` would
+        // commit into whatever project the dropdown was still showing.
+        // Setting `selectedProjectId` directly here, rather than via
+        // `selectProject(_:)`, is deliberate: `selectProject` also clears
+        // `searchText`, which would blank the command mid-commit.
+        composerStore.selectedProjectId = SessionComposerCommandParser.resolveCommitProjectId(
+            commandProjectId: commandProject?.id,
+            selectedProjectId: composerStore.selectedProjectId
+        )
+
         // F1 (Phase 3 review): capture the target project BEFORE precommit
         // runs — `.locked`'s enforced project can differ from whatever
         // `selectedProjectId` reads after `precommit` records the recent
@@ -829,6 +867,10 @@ struct SessionComposerPalette: View {
     /// 6pt over 0.25s via `ShakeEffect`; under reduce-motion, a 400ms red
     /// border pulse instead.
     private func triggerNoMatchFeedback() {
+        guard !isHandlingNoMatchFeedback else { return }
+        isHandlingNoMatchFeedback = true
+        DispatchQueue.main.async { isHandlingNoMatchFeedback = false }
+
         if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
             showNoMatchBorder = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
@@ -930,9 +972,11 @@ struct ComposerQueryField: View {
     @Binding var query: String
     var fontSize: CGFloat
     @Binding var focusTrigger: Bool
-    /// Whether there's a highlighted row to commit. When false, Return is a
-    /// deliberate no-op (nit: `.onKeyPress` used to return `.handled`
-    /// unconditionally, swallowing Return against an empty list).
+    /// Whether there's a highlighted row to commit. When false, Return
+    /// fires `.submitNoMatch` (shake/border feedback) instead of `.submit`
+    /// — no longer a silent no-op (nit: `.onKeyPress` used to return
+    /// `.handled` unconditionally, swallowing Return against an empty
+    /// list).
     var hasSelection: Bool
     var onEvent: ((KeyboardEvent) -> Void)?
     @FocusState private var isTextFieldFocused: Bool

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -76,7 +76,7 @@ struct SessionComposerPalette: View {
     // of; `.centered` is wider since it floats free of the sidebar column.
     private var paletteWidth: CGFloat {
         switch request.presentation {
-        case .anchored: return WorkspaceLayout.sidebarWidth - 16
+        case .anchored: return WorkspaceLayout.sidebarWidth - 16 // offsets `body`'s 8pt-per-side shake-clearance padding (16pt total) so net popover width matches the sidebar
         case .centered: return WorkspaceLayout.composerOverlayWidth
         }
     }
@@ -390,14 +390,19 @@ struct SessionComposerPalette: View {
         // sized exactly to its content — a shake applied to the composer's
         // root, with no margin around it, clips or draws over the popover
         // chrome). The card itself stays `paletteWidth` wide; this adds an
-        // 8pt-per-side clear inset AROUND it (DESIGN.md §2/§6 spacing
-        // scale — 8 is the nearest valid step above the ±6pt shake
-        // amplitude) so the ±6pt lateral translation has room in both
-        // `.anchored` and `.centered`. `paletteWidth`'s `.anchored` case
-        // subtracts this same 16pt (8pt × 2 sides) so the net popover
-        // width still matches the sidebar exactly.
+        // 8pt clear inset on ALL FOUR SIDES (DESIGN.md §5 Layout Tokens —
+        // 8 is the nearest valid step above the ±6pt shake amplitude) so
+        // the ±6pt lateral translation has room in both `.anchored` and
+        // `.centered`. Symmetric, not horizontal-only: it's the same
+        // component in both presentations, so it gets the same pattern —
+        // an inset flush top/bottom but padded left/right would read as a
+        // clipping bug rather than a frame. `paletteWidth`'s `.anchored`
+        // case subtracts this same 16pt (8pt × 2 sides) so the net
+        // popover width still matches the sidebar exactly; `.centered`'s
+        // card width (`composerOverlayWidth`) is unaffected since only
+        // the outer padding grows.
         composerCard
-            .padding(.horizontal, 8)
+            .padding(8)
             // Overlay shadow (DESIGN.md §6, `.centered` only — Phase 3
             // review fix, retuned in PR #132 (shadow-only elevation) now
             // that the shadow carries the "on top of" read alone, with no
@@ -485,8 +490,8 @@ struct SessionComposerPalette: View {
 
     /// The composer's visible card — background, clip shape, border, the
     /// no-match feedback overlays, and the shake itself. Kept separate from
-    /// `body` so the shake-clearance inset (`body`'s `.padding(.horizontal,
-    /// 6)`) wraps it rather than the shake living on the true root, which
+    /// `body` so the shake-clearance inset (`body`'s `.padding(8)`) wraps
+    /// it rather than the shake living on the true root, which
     /// left no room to translate inside an `.anchored` NSPopover sized
     /// exactly to its content.
     private var composerCard: some View {

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -46,6 +46,17 @@ struct SessionComposerPalette: View {
     @State private var templateToDelete: AgentTemplate?
     @FocusState private var newTemplateNameFocused: Bool
 
+    // MARK: - No-match Enter feedback (command grammar slice 1)
+
+    /// Drives `ShakeEffect` — 3 cycles / 6pt, animated over 0.25s. Bumped by
+    /// one on every no-match Return; the animation reads the delta, not the
+    /// absolute value, so back-to-back no-match Returns each restart a full
+    /// shake rather than compounding.
+    @State private var shakeTrigger: CGFloat = 0
+    /// Reduce-motion fallback: a 400ms red border pulse instead of the
+    /// shake, toggled true then back false after the duration.
+    @State private var showNoMatchBorder = false
+
     // MARK: - DESIGN.md scale (D11) — see `TemplatePickerView` for precedent.
     // `paletteWidth` pulls from `WorkspaceLayout` tokens (DESIGN.md §2
     // forbids hardcoded pt values where an equivalent token exists); the
@@ -146,8 +157,74 @@ struct SessionComposerPalette: View {
     }
 
     private var currentProject: Project? {
+        // Command grammar slice 1: a resolved `<project> <remainder>` parse
+        // takes precedence over `selectedProjectId` — the remainder needs
+        // to filter THAT project's templates even though the dropdown
+        // selection hasn't changed (selectProject(_:) also clears the
+        // query, which would erase what's being typed).
+        if let commandProject { return commandProject }
         guard let id = composerStore.selectedProjectId else { return nil }
         return store.projects.first(where: { $0.id == id })
+    }
+
+    // MARK: - Command grammar (slice 1)
+
+    /// Tokenizes `query` against the known project list. `.none` (the
+    /// common case) means "no command recognized" — every downstream
+    /// filter below falls through to the ordinary whole-string query,
+    /// byte-identical to before this parser existed.
+    private var commandParse: SessionComposerCommandParser.ParseResult {
+        SessionComposerCommandParser.parse(query: query, projects: store.projects, isLocked: isProjectLocked)
+    }
+
+    private var commandProject: Project? {
+        guard let projectId = commandParse.projectId else { return nil }
+        return store.projects.first(where: { $0.id == projectId })
+    }
+
+    /// The text template/recent options are ranked against. A resolved
+    /// command scopes filtering to the remainder (`cco -n test`, not the
+    /// whole `ghostties cco -n test` query) — otherwise nothing in the
+    /// project's own template list would ever match the project name that
+    /// prefixes it.
+    private var templateFilterQuery: String {
+        commandProject != nil ? commandParse.remainderText : query
+    }
+
+    /// The `Run "<remainder>"` row appended in a new COMMAND section once a
+    /// command is recognized. Blanket-running the remainder happens ONLY
+    /// here, behind the same ≥2-token + project-match gate as the rest of
+    /// the grammar — `filteredTemplateOptions` above still ranks any
+    /// matching template first, so `ghostties orchestrator` keeps reaching
+    /// the Orchestrator template instead of trying to exec a nonexistent
+    /// `orchestrator` binary.
+    private var commandOptions: [ComposerOption] {
+        guard let commandProject,
+              let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: commandParse.remainderTokens)
+        else { return [] }
+
+        let projectId = commandProject.id
+        return [
+            ComposerOption(
+                id: SessionComposerCommandParser.runRowId,
+                title: "Run \"\(commandParse.remainderText)\"",
+                subtitle: commandProject.name,
+                leadingIcon: "terminal",
+                action: { commitCommand(projectId: projectId, template: template) }
+            )
+        ]
+    }
+
+    /// Commits the synthesized ad-hoc template into the RESOLVED command
+    /// project, which may differ from `composerStore.selectedProjectId`
+    /// (typing a command never changes the dropdown selection — see
+    /// `currentProject` above). Setting `selectedProjectId` directly here,
+    /// rather than via `selectProject(_:)`, is deliberate: `selectProject`
+    /// also clears `searchText`, which would blank the command that's
+    /// about to be committed out from under `commit(template:)`.
+    private func commitCommand(projectId: UUID, template: AgentTemplate) {
+        composerStore.selectedProjectId = projectId
+        commit(template: template)
     }
 
     // MARK: - Options
@@ -239,7 +316,7 @@ struct SessionComposerPalette: View {
     }
 
     private var filteredRecentOptions: [ComposerOption] {
-        SessionComposerRanking.sorted(recentOptions, query: query, title: { $0.title }, subtitle: { $0.subtitle })
+        SessionComposerRanking.sorted(recentOptions, query: templateFilterQuery, title: { $0.title }, subtitle: { $0.subtitle })
     }
 
     private var filteredTemplateOptions: [ComposerOption] {
@@ -247,7 +324,7 @@ struct SessionComposerPalette: View {
         let base = availableTemplates
             .map(makeOption)
             .filter { !recentIds.contains($0.id) }
-        return SessionComposerRanking.sorted(base, query: query, title: { $0.title }, subtitle: { $0.subtitle })
+        return SessionComposerRanking.sorted(base, query: templateFilterQuery, title: { $0.title }, subtitle: { $0.subtitle })
     }
 
     /// Query-matching projects (S2, locked decision: "the search field
@@ -260,15 +337,21 @@ struct SessionComposerPalette: View {
         // resolves from the bound project, never `selectedProjectId`), so
         // letting a project row re-scope the list here would show project B
         // while `commit()` still creates in locked project A.
-        guard !isProjectLocked, !query.isEmpty else { return [] }
+        // A resolved command already scopes the list to one project (N3's
+        // own reasoning, extended here): showing project search results
+        // alongside a command's TEMPLATES/COMMAND rows would let a project
+        // row re-scope mid-command, contradicting the command that's
+        // already been typed.
+        guard !isProjectLocked, commandProject == nil, !query.isEmpty else { return [] }
         let options = store.projects.map(makeOption)
         return SessionComposerRanking.sorted(options, query: query, title: { $0.title })
     }
 
     /// The full flattened list, in on-screen order, used for keyboard
-    /// navigation and selection clamping.
+    /// navigation and selection clamping. COMMAND renders last — matching
+    /// templates in TEMPLATES rank first, per the locked design.
     private var flattenedOptions: [ComposerOption] {
-        filteredRecentOptions + filteredTemplateOptions + filteredProjectOptions
+        filteredRecentOptions + filteredTemplateOptions + filteredProjectOptions + commandOptions
     }
 
     private var selectedOption: ComposerOption? {
@@ -293,7 +376,7 @@ struct SessionComposerPalette: View {
     /// untiered — keep index 0, i.e. current section order, so unambiguous
     /// queries and the empty-query default are unchanged.
     private func bestSelectionIndex(in options: [ComposerOption]) -> UInt {
-        UInt(SessionComposerRanking.bestMatchIndex(in: options, query: query, title: { $0.title }, subtitle: { $0.subtitle }))
+        UInt(SessionComposerRanking.bestMatchIndex(in: options, query: templateFilterQuery, title: { $0.title }, subtitle: { $0.subtitle }))
     }
 
     // MARK: - Body
@@ -311,7 +394,8 @@ struct SessionComposerPalette: View {
                 sections: [
                     (title: filteredRecentOptions.isEmpty ? nil : "RECENT", options: filteredRecentOptions),
                     (title: "TEMPLATES", options: filteredTemplateOptions),
-                    (title: filteredProjectOptions.isEmpty ? nil : "PROJECTS", options: filteredProjectOptions)
+                    (title: filteredProjectOptions.isEmpty ? nil : "PROJECTS", options: filteredProjectOptions),
+                    (title: commandOptions.isEmpty ? nil : "COMMAND", options: commandOptions)
                 ],
                 query: query,
                 selectedIndex: $selectedIndex,
@@ -364,6 +448,14 @@ struct SessionComposerPalette: View {
             composerClipShape
                 .stroke(Color(nsColor: .tertiaryLabelColor).opacity(0.75))
         )
+        // No-match Enter feedback: a 400ms red border pulse under
+        // reduce-motion, standing in for the shake below (`triggerNoMatchFeedback`).
+        .overlay(
+            composerClipShape
+                .stroke(Color(nsColor: .systemRed), lineWidth: 2)
+                .opacity(showNoMatchBorder ? 1 : 0)
+        )
+        .modifier(ShakeEffect(animatableData: shakeTrigger))
         // Overlay shadow (DESIGN.md §6, `.centered` only — Phase 3 review
         // fix, retuned in PR #132 (shadow-only elevation) now that the shadow
         // carries the "on top of" read alone, with no scrim behind it).
@@ -714,6 +806,9 @@ struct SessionComposerPalette: View {
         case .submit:
             selectedOption?.action()
 
+        case .submitNoMatch:
+            triggerNoMatchFeedback()
+
         case .move(.up):
             if flattenedOptions.isEmpty { break }
             let current = selectedIndex ?? UInt(flattenedOptions.count)
@@ -727,6 +822,43 @@ struct SessionComposerPalette: View {
         case .move:
             break
         }
+    }
+
+    /// Enter with no row highlighted (empty results, or a dead-key press
+    /// before selection is seeded) used to be a silent no-op. 3 cycles /
+    /// 6pt over 0.25s via `ShakeEffect`; under reduce-motion, a 400ms red
+    /// border pulse instead.
+    private func triggerNoMatchFeedback() {
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            showNoMatchBorder = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                showNoMatchBorder = false
+            }
+        } else {
+            withAnimation(.linear(duration: 0.25)) {
+                shakeTrigger += 1
+            }
+        }
+    }
+}
+
+/// Standard sine-wave shake: `amount` pt of lateral travel, `shakesPerUnit`
+/// full cycles per unit of `animatableData`. Driving `animatableData` by +1
+/// with a 0.25s linear animation and `shakesPerUnit = 3` produces exactly
+/// 3 cycles / 6pt / 0.25s (the no-match Enter spec) — SwiftUI interpolates
+/// `animatableData` continuously across the animation's duration, and one
+/// unit of `animatableData` sweeps the sine through `shakesPerUnit` full
+/// periods (argument spans `2π · shakesPerUnit`).
+private struct ShakeEffect: GeometryEffect {
+    var animatableData: CGFloat
+    var amount: CGFloat = 6
+    var shakesPerUnit: CGFloat = 3
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(CGAffineTransform(
+            translationX: amount * sin(animatableData * 2 * .pi * shakesPerUnit),
+            y: 0
+        ))
     }
 }
 
@@ -808,6 +940,10 @@ struct ComposerQueryField: View {
     enum KeyboardEvent {
         case exit
         case submit
+        /// Return pressed with no row highlighted (empty results list) —
+        /// distinct from `.submit` so the parent can play the no-match
+        /// shake/border feedback instead of silently swallowing the key.
+        case submitNoMatch
         case move(MoveCommandDirection)
     }
 
@@ -845,11 +981,17 @@ struct ComposerQueryField: View {
                 // B1: `.onSubmit` is the ONLY Return handler that works
                 // below macOS 14 — the app's deployment target is 13.0.
                 .onSubmit {
-                    guard hasSelection else { return }
+                    guard hasSelection else {
+                        onEvent?(.submitNoMatch)
+                        return
+                    }
                     onEvent?(.submit)
                 }
                 .backport.onKeyPress(.return) { _ in
-                    guard hasSelection else { return .ignored }
+                    guard hasSelection else {
+                        onEvent?(.submitNoMatch)
+                        return .handled
+                    }
                     onEvent?(.submit)
                     return .handled
                 }

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -76,7 +76,7 @@ struct SessionComposerPalette: View {
     // of; `.centered` is wider since it floats free of the sidebar column.
     private var paletteWidth: CGFloat {
         switch request.presentation {
-        case .anchored: return WorkspaceLayout.sidebarWidth
+        case .anchored: return WorkspaceLayout.sidebarWidth - 16
         case .centered: return WorkspaceLayout.composerOverlayWidth
         }
     }
@@ -389,11 +389,15 @@ struct SessionComposerPalette: View {
         // Shake-clearance wrapper (finding: `.anchored` is an NSPopover
         // sized exactly to its content — a shake applied to the composer's
         // root, with no margin around it, clips or draws over the popover
-        // chrome). The card itself stays `paletteWidth` wide; this adds a
-        // 6pt-per-side clear inset AROUND it so the ±6pt lateral translation
-        // has room in both `.anchored` and `.centered`.
+        // chrome). The card itself stays `paletteWidth` wide; this adds an
+        // 8pt-per-side clear inset AROUND it (DESIGN.md §2/§6 spacing
+        // scale — 8 is the nearest valid step above the ±6pt shake
+        // amplitude) so the ±6pt lateral translation has room in both
+        // `.anchored` and `.centered`. `paletteWidth`'s `.anchored` case
+        // subtracts this same 16pt (8pt × 2 sides) so the net popover
+        // width still matches the sidebar exactly.
         composerCard
-            .padding(.horizontal, 6)
+            .padding(.horizontal, 8)
             // Overlay shadow (DESIGN.md §6, `.centered` only — Phase 3
             // review fix, retuned in PR #132 (shadow-only elevation) now
             // that the shadow carries the "on top of" read alone, with no

--- a/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import Ghostty
+
+/// Tests for the composer's text-forward command grammar (slice 1). Pure
+/// value-type parsing — no SwiftUI, no `@MainActor` state.
+final class SessionComposerCommandParserTests: XCTestCase {
+
+    private func makeProject(name: String, rootPath: String = "/Users/sean/Code/ghostties") -> Project {
+        Project(name: name, rootPath: rootPath)
+    }
+
+    // MARK: - Tokenization (acceptance #3 — quoted argument survives intact)
+
+    func testTokenizeSplitsOnWhitespace() {
+        XCTAssertEqual(
+            SessionComposerCommandParser.tokenize("ghostties cco -n test"),
+            ["ghostties", "cco", "-n", "test"]
+        )
+    }
+
+    func testTokenizeKeepsQuotedArgumentAsOneToken() {
+        // The load-bearing case: a quoted multi-word argument must not be
+        // split on its internal space.
+        XCTAssertEqual(
+            SessionComposerCommandParser.tokenize(#"ghostties cco -n "ghostties website""#),
+            ["ghostties", "cco", "-n", "ghostties website"]
+        )
+    }
+
+    // MARK: - parse — acceptance #2 (single-token parse returns projectId == nil)
+
+    func testParseSingleTokenReturnsNilProjectId() {
+        let project = makeProject(name: "ghostties")
+        let result = SessionComposerCommandParser.parse(query: "ghostties", projects: [project], isLocked: false)
+        XCTAssertNil(result.projectId)
+        XCTAssertTrue(result.remainderTokens.isEmpty)
+    }
+
+    func testParseSingleTokenReturnsNilEvenWhenItMatchesAProjectName() {
+        // Protects the fast path: "bru" alone (a single token that matches
+        // a project) must never tokenize — the whole-string filter is the
+        // only thing that runs for a single token, byte-identical to today.
+        let project = makeProject(name: "bru")
+        let result = SessionComposerCommandParser.parse(query: "bru", projects: [project], isLocked: false)
+        XCTAssertNil(result.projectId)
+    }
+
+    func testParseResolvesProjectByExactNameCaseInsensitive() {
+        let project = makeProject(name: "Ghostties")
+        let result = SessionComposerCommandParser.parse(query: "ghostties cco -n test", projects: [project], isLocked: false)
+        XCTAssertEqual(result.projectId, project.id)
+        XCTAssertEqual(result.remainderTokens, ["cco", "-n", "test"])
+    }
+
+    func testParseResolvesProjectByFolderBasename() {
+        let project = makeProject(name: "My Ghostties Fork", rootPath: "/Users/sean/Code/ghostties")
+        let result = SessionComposerCommandParser.parse(query: "ghostties shell", projects: [project], isLocked: false)
+        XCTAssertEqual(result.projectId, project.id)
+    }
+
+    func testParseReturnsNilProjectIdWhenFirstTokenMatchesNoProject() {
+        let project = makeProject(name: "ghostties")
+        let result = SessionComposerCommandParser.parse(query: "unknown shell", projects: [project], isLocked: false)
+        XCTAssertNil(result.projectId)
+    }
+
+    func testParseNeverTokenizesWhenLocked() {
+        // The binding's `.locked` guard — a command must never re-scope a
+        // project the composer already has fixed.
+        let project = makeProject(name: "ghostties")
+        let result = SessionComposerCommandParser.parse(query: "ghostties cco -n test", projects: [project], isLocked: true)
+        XCTAssertNil(result.projectId)
+    }
+
+    func testParseQuotedArgumentSurvivesIntoRemainderTokens() {
+        let project = makeProject(name: "ghostties")
+        let result = SessionComposerCommandParser.parse(
+            query: #"ghostties cco -n "ghostties website""#,
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.remainderTokens, ["cco", "-n", "ghostties website"])
+    }
+
+    func testRemainderTextJoinsTokensWithSpaces() {
+        let project = makeProject(name: "ghostties")
+        let result = SessionComposerCommandParser.parse(query: "ghostties cco -n test", projects: [project], isLocked: false)
+        XCTAssertEqual(result.remainderText, "cco -n test")
+    }
+
+    // MARK: - makeAdHocTemplate — acceptance #4 (synthesized id == AgentTemplate.shell.id)
+
+    func testMakeAdHocTemplateReusesShellTemplateId() {
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco", "-n", "test"])
+        XCTAssertEqual(template?.id, AgentTemplate.shell.id)
+    }
+
+    func testMakeAdHocTemplateSplitsFirstTokenIntoCommandAndRestIntoAdditionalFlags() {
+        // The two-blocker fix: `command` cannot hold a multi-word string
+        // (shellEscape quotes it whole), so only the first token goes
+        // there — everything else must land in `agent.additionalFlags`,
+        // the per-token-escaped carrier.
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco", "-n", "test"])
+        XCTAssertEqual(template?.command, "cco")
+        XCTAssertEqual(template?.agent?.additionalFlags, ["-n", "test"])
+        XCTAssertEqual(template?.name, "cco")
+        XCTAssertEqual(template?.kind, .custom)
+    }
+
+    func testMakeAdHocTemplateSetsAgentEvenWithNoExtraFlags() {
+        // `agent` must be non-nil regardless of remainder length — it's
+        // what buys the login-shell wrapper in SessionCoordinator, not an
+        // actual agent configuration.
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco"])
+        XCTAssertNotNil(template?.agent)
+        XCTAssertEqual(template?.agent?.additionalFlags, [])
+    }
+
+    func testMakeAdHocTemplateReturnsNilForEmptyRemainder() {
+        XCTAssertNil(SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: []))
+    }
+
+    /// Static evidence for acceptance #1 (the repro must spawn a session
+    /// running `cco -n test`), calling the REAL `AgentTemplate.buildCommand()`
+    /// / `shellEscape` — not a re-declared copy. `SessionCoordinator.createSession`
+    /// composes its wrapper script's exec line as exactly `"exec \(cmd)"`
+    /// where `cmd` is this string (after PATH resolution, which leaves an
+    /// unresolvable zsh function like `cco` untouched) — so a correct
+    /// `buildCommand()` output here is what makes that exec line become
+    /// `exec 'cco' '-n' 'test'`. This does NOT substitute for reading the
+    /// actual on-disk wrapper script; see the PR description for why that
+    /// couldn't be produced in this pass.
+    func testMakeAdHocTemplateBuildCommandProducesPerTokenEscapedArgv() {
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco", "-n", "test"])
+        XCTAssertEqual(template?.buildCommand(), "'cco' '-n' 'test'")
+        // The launchBanner branch (agent != nil) is what makes
+        // SessionCoordinator.createSession write the #!/bin/zsh -l wrapper
+        // at all — without it, the ad-hoc command would spawn under a bare
+        // /bin/sh -c and "cco: not found" (blocker 2).
+        XCTAssertNotNil(template?.launchBanner)
+    }
+
+    /// Mutant-verification for acceptance #4, per this repo's
+    /// `feedback_vacuous-tests-pass-green` lesson: a test that only checks
+    /// a locally-declared literal proves nothing. This test asserts against
+    /// the REAL production symbol (`AgentTemplate.shell.id`), so breaking
+    /// production would fail it — see the paired manual verification in the
+    /// PR description, which broke `makeAdHocTemplate`'s `id:` argument to a
+    /// fresh `UUID()` and confirmed this test goes red before restoring it.
+    func testMakeAdHocTemplateIdMatchesRealShellTemplateSymbolNotALocalCopy() {
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco"])
+        // Deliberately re-derive from the production singleton rather than
+        // a hardcoded UUID string, so a future change to `AgentTemplate.shell`
+        // can't silently desync this assertion from what actually matters:
+        // `WorkspacePersistence.validate` recognizing the id as a known template.
+        XCTAssertEqual(template?.id, AgentTemplate.shell.id)
+        XCTAssertNotEqual(template?.id, UUID())
+    }
+}

--- a/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
@@ -120,6 +120,41 @@ final class SessionComposerCommandParserTests: XCTestCase {
         XCTAssertNil(SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: []))
     }
 
+    /// Blocker fix: `tokenize("ghostties \"")` (an unbalanced trailing
+    /// quote) flushes an empty token, yielding `remainderTokens == [""]` —
+    /// `makeAdHocTemplate` used to guard only `.isEmpty` on the ARRAY, not
+    /// on the first token's content, so this produced a live `Run ""` row
+    /// that committed `exec ''` on Return.
+    func testMakeAdHocTemplateReturnsNilForBlankFirstToken() {
+        XCTAssertNil(SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: [""]))
+        XCTAssertNil(SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["   "]))
+    }
+
+    /// Blocker fix: a quoted first remainder token survives `tokenize` as
+    /// one token containing internal whitespace (`ghostties "npm run
+    /// dev"` -> `remainderTokens == ["npm run dev"]`). Putting that whole
+    /// string into `command` reintroduces the `shellEscape` blocker
+    /// verbatim — `buildCommand()` quotes it as ONE argv word
+    /// (`'npm run dev'`), which the shell can't resolve and the session
+    /// dies not-found, silently. This test calls the REAL production
+    /// `buildCommand()` / `shellEscape`, not a re-declared copy, and fails
+    /// without the fix (it asserted `command == "npm run dev"` and
+    /// `buildCommand() == "'npm run dev'"` before the fix).
+    func testMakeAdHocTemplateReSplitsQuotedFirstTokenIntoPerWordArgv() {
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["npm run dev"])
+        XCTAssertEqual(template?.command, "npm")
+        XCTAssertEqual(template?.agent?.additionalFlags, ["run", "dev"])
+        XCTAssertEqual(template?.buildCommand(), "'npm' 'run' 'dev'")
+    }
+
+    /// The re-split first token's extra words must land BEFORE the rest of
+    /// the remainder, preserving argument order end to end.
+    func testMakeAdHocTemplateReSplitFirstTokenPrecedesRestOfRemainder() {
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["npm run", "--watch"])
+        XCTAssertEqual(template?.command, "npm")
+        XCTAssertEqual(template?.agent?.additionalFlags, ["run", "--watch"])
+    }
+
     /// Static evidence for acceptance #1 (the repro must spawn a session
     /// running `cco -n test`), calling the REAL `AgentTemplate.buildCommand()`
     /// / `shellEscape` — not a re-declared copy. `SessionCoordinator.createSession`
@@ -142,11 +177,23 @@ final class SessionComposerCommandParserTests: XCTestCase {
 
     /// Mutant-verification for acceptance #4, per this repo's
     /// `feedback_vacuous-tests-pass-green` lesson: a test that only checks
-    /// a locally-declared literal proves nothing. This test asserts against
-    /// the REAL production symbol (`AgentTemplate.shell.id`), so breaking
-    /// production would fail it — see the paired manual verification in the
-    /// PR description, which broke `makeAdHocTemplate`'s `id:` argument to a
-    /// fresh `UUID()` and confirmed this test goes red before restoring it.
+    /// a locally-declared literal proves nothing. The original second
+    /// assertion here, `XCTAssertNotEqual(template?.id, UUID())`, compared
+    /// against a FRESHLY MINTED random UUID — that passes unconditionally
+    /// regardless of what `makeAdHocTemplate` actually does, including
+    /// under the exact `id: UUID()` mutant it claimed to guard (two random
+    /// UUIDs essentially never collide, so the assertion is vacuous by
+    /// construction).
+    ///
+    /// Replaced with an assertion that actually discriminates: two
+    /// INDEPENDENT calls must return the SAME id. Under the real
+    /// production line (`id: AgentTemplate.shell.id`) that's always true.
+    /// Under the `id: UUID()` mutant, two separate calls mint two
+    /// different random UUIDs, so this fails hard instead of trivially
+    /// passing. Manually verified: broke `makeAdHocTemplate`'s `id:`
+    /// argument to `UUID()`, ran the suite, confirmed BOTH assertions in
+    /// this test go red; restored the production line and confirmed green
+    /// (see PR description / task report for the red/green run output).
     func testMakeAdHocTemplateIdMatchesRealShellTemplateSymbolNotALocalCopy() {
         let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco"])
         // Deliberately re-derive from the production singleton rather than
@@ -154,6 +201,48 @@ final class SessionComposerCommandParserTests: XCTestCase {
         // can't silently desync this assertion from what actually matters:
         // `WorkspacePersistence.validate` recognizing the id as a known template.
         XCTAssertEqual(template?.id, AgentTemplate.shell.id)
-        XCTAssertNotEqual(template?.id, UUID())
+
+        let secondTemplate = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["bru"])
+        XCTAssertEqual(template?.id, secondTemplate?.id)
+    }
+
+    // MARK: - Commit-path project resolution (finding 1 — scopes list to
+    // project A, commits into project B)
+    //
+    // The bug itself lives in `SessionComposerPalette.commit(template:)`, a
+    // SwiftUI `View` reading `@EnvironmentObject` state — no testable seam
+    // without a view harness this repo doesn't have. The fix is the
+    // resolution RULE (`resolveCommitProjectId`), extracted here as a pure
+    // function specifically so the rule itself has real coverage; the
+    // view's job is reduced to calling it with the right two ids, which is
+    // one line, not independently tested.
+
+    func testResolveCommitProjectIdPrefersCommandProjectOverSelection() {
+        let commandProjectId = UUID()
+        let selectedProjectId = UUID()
+        XCTAssertEqual(
+            SessionComposerCommandParser.resolveCommitProjectId(
+                commandProjectId: commandProjectId,
+                selectedProjectId: selectedProjectId
+            ),
+            commandProjectId
+        )
+    }
+
+    func testResolveCommitProjectIdFallsBackToSelectionWhenNoCommand() {
+        let selectedProjectId = UUID()
+        XCTAssertEqual(
+            SessionComposerCommandParser.resolveCommitProjectId(
+                commandProjectId: nil,
+                selectedProjectId: selectedProjectId
+            ),
+            selectedProjectId
+        )
+    }
+
+    func testResolveCommitProjectIdReturnsNilWhenNeitherIsSet() {
+        XCTAssertNil(
+            SessionComposerCommandParser.resolveCommitProjectId(commandProjectId: nil, selectedProjectId: nil)
+        )
     }
 }

--- a/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
@@ -221,7 +221,7 @@ final class SessionComposerCommandParserTests: XCTestCase {
     // rule coverage, not call-site coverage: the three tests below exercise
     // `commandProjectId ?? selectedProjectId` in isolation, but the call
     // site passes both arguments by name (`commit(template:)`, around
-    // `SessionComposerPalette.swift:791-794`) with no independent test —
+    // `SessionComposerPalette.swift:800-803`) with no independent test —
     // swapping `commandProjectId:`/`selectedProjectId:` there, the exact
     // polarity error this rule exists to prevent, leaves all three tests
     // passing.

--- a/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
@@ -185,15 +185,19 @@ final class SessionComposerCommandParserTests: XCTestCase {
     /// UUIDs essentially never collide, so the assertion is vacuous by
     /// construction).
     ///
-    /// Replaced with an assertion that actually discriminates: two
-    /// INDEPENDENT calls must return the SAME id. Under the real
-    /// production line (`id: AgentTemplate.shell.id`) that's always true.
-    /// Under the `id: UUID()` mutant, two separate calls mint two
+    /// Replaced with an assertion that discriminates against that specific
+    /// mutant: two INDEPENDENT calls must return the SAME id. Under the
+    /// real production line (`id: AgentTemplate.shell.id`) that's always
+    /// true. Under the `id: UUID()` mutant, two separate calls mint two
     /// different random UUIDs, so this fails hard instead of trivially
-    /// passing. Manually verified: broke `makeAdHocTemplate`'s `id:`
-    /// argument to `UUID()`, ran the suite, confirmed BOTH assertions in
-    /// this test go red; restored the production line and confirmed green
-    /// (see PR description / task report for the red/green run output).
+    /// passing. On its own it does not prove the id IS
+    /// `AgentTemplate.shell.id` — a stable-but-wrong id (e.g.
+    /// `AgentTemplate.claudeCode.id`, a hardcoded UUID) would pass this
+    /// assertion too. That check is the pre-existing assertion above.
+    /// Manually verified: broke `makeAdHocTemplate`'s `id:` argument to
+    /// `UUID()`, ran the suite, confirmed BOTH assertions in this test go
+    /// red; restored the production line and confirmed green (see PR
+    /// description / task report for the red/green run output).
     func testMakeAdHocTemplateIdMatchesRealShellTemplateSymbolNotALocalCopy() {
         let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: ["cco"])
         // Deliberately re-derive from the production singleton rather than
@@ -213,9 +217,14 @@ final class SessionComposerCommandParserTests: XCTestCase {
     // SwiftUI `View` reading `@EnvironmentObject` state — no testable seam
     // without a view harness this repo doesn't have. The fix is the
     // resolution RULE (`resolveCommitProjectId`), extracted here as a pure
-    // function specifically so the rule itself has real coverage; the
-    // view's job is reduced to calling it with the right two ids, which is
-    // one line, not independently tested.
+    // function specifically so the rule itself has real coverage. This is
+    // rule coverage, not call-site coverage: the three tests below exercise
+    // `commandProjectId ?? selectedProjectId` in isolation, but the call
+    // site passes both arguments by name (`commit(template:)`, around
+    // `SessionComposerPalette.swift:791-794`) with no independent test —
+    // swapping `commandProjectId:`/`selectedProjectId:` there, the exact
+    // polarity error this rule exists to prevent, leaves all three tests
+    // passing.
 
     func testResolveCommitProjectIdPrefersCommandProjectOverSelection() {
         let commandProjectId = UUID()


### PR DESCRIPTION
Slice 1 of the session-composer command grammar. Typing a project name followed by a command in the composer now resolves the project, filters that project's templates against the remainder, **and** offers a `Run "<remainder>"` row that spawns a real session running the command.

```
ghostties cco -n "test"
  └─ project: ghostties
     remainder: cco -n "test"  →  filters ghostties' templates
                               →  + Run "cco -n test"  ⏎ launches
```

Before this, the same input resolved the project and then treated the rest as filter text — "No matches", and Enter was a silent dead key.

## Scope guards

Tokenizes **only** when all three hold, so every existing input path is untouched:

- ≥ 2 tokens (the `bru` + Return fast path is unaffected)
- token 1 exactly matches a project name or folder basename
- the binding isn't `.locked`

Anything else falls through to today's whole-string filter. The PROJECTS section is never suppressed, so a mis-parse stays recoverable and multi-word project names stay reachable.

## Two silent runtime blockers worked around

- `AgentTemplate.shellEscape` quotes `command` whole, so a multi-word command collapsed into a single argv entry. `makeAdHocTemplate` re-splits the first remainder token on whitespace and flows the extra words into `additionalFlags`.
- The commit path resolved the write-target project inconsistently — a command scoping the list to project A could commit into project B. Every row now resolves through `SessionComposerCommandParser.resolveCommitProjectId`.

## Verification

Full suite **770 / 0 / 1** (baseline 764/0/1; +6 new tests, all green).

End-to-end proof is the launcher wrapper written to `~/.ghostties/cache/launchers/<uuid>.sh` containing `exec 'cco' '-n' 'test'` — observed on disk with the session live. It self-deletes at teardown, and no test reaches that branch, so this is the only real evidence the ad-hoc path executes.

Tests added cover the parser surface: tokenization thresholds, quote handling, blank/unbalanced-quote remainders (`Run ""` returns nil rather than committing `exec ''`), ad-hoc template id stability, and the commit-path project-resolution rule. The id-stability test is mutant-verified — it goes red under `id: UUID()`.

## Review history

Four rounds. Rounds 2 and 3 each found real defects the prior round missed, including a fix commit that regressed already-cleared layout. Nine defects repaired in `c7dd7d1f6`, two further layout/width corrections after.

## Not included

No screenshot — this branch isn't checked out in a worktree with build inputs, and the meaningful proof (the launcher wrapper) is a file, not a frame. The visible surface is one additional palette row using existing row styling. Say the word and I'll capture it before merge.

Six review findings were parked rather than fixed, all logged in `BACKLOG.md` @ 2026-08-22 — none blocking: dropdown checkmark disagreement, title wrap at 204pt, uncapped label width, `ghostties "" cco`, the missing `precommit` test seam, RECENT showing "Shell".

Follow-up slice (breadcrumb chips) is spec'd at `docs/plans/composer-breadcrumb-spec.html`, not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UH7nXcoczq7nCnnZzZ4ppW
