### PR TITLE
Drop the Sidebar section — it duplicated the hero

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -83,24 +83,11 @@
         </figure>
       </section>
 
-      <!-- ============================================================
-           02 — SIDEBAR (real captures, theme-aware)
-           ============================================================ -->
-      <section id="sidebar">
-        <h2 class="h-l">The Sidebar</h2>
-        <p class="lead">Every session in one window. The single strongest thing the app does.</p>
-        <div class="projects-figure">
-          <picture data-app-state="projects" data-app-theme="light" class="theme-light-only">
-            <source srcset="/assets/app-projects-light@2x.webp" type="image/webp">
-            <img src="/assets/app-projects-light@2x.png" alt="Ghostties sidebar in Projects mode, sessions grouped under the project they belong to, light mode" width="1280" height="705" loading="lazy">
-          </picture>
-          <picture data-app-state="projects" data-app-theme="dark" class="theme-dark-only">
-            <source srcset="/assets/app-projects-dark@2x.webp" type="image/webp">
-            <img src="/assets/app-projects-dark@2x.png" alt="Ghostties sidebar in Projects mode, sessions grouped under the project they belong to, dark mode" width="1280" height="705" loading="lazy">
-          </picture>
-        </div>
-        <p class="projects-caption">grouped by project, with live status on every row</p>
-      </section>
+      <!-- 02 — SIDEBAR: removed 2026-08-27. The Projects capture read as a duplicate
+           of the hero's Sessions capture — same window, same sidebar, different tab.
+           Hidden until there is a genuinely different thing to show (the hero film,
+           or a capture of a different surface). Restore from git history, not a
+           rewrite: this block was removed whole. -->
 
       <!-- ============================================================
            03 — STILL GHOSTTY (adapted from v2, trimmed to one paragraph)


### PR DESCRIPTION
The hero shows the Sessions capture; "The Sidebar" showed the Projects capture. Same window, same sidebar, one tab apart — it read as the same screenshot twice.

Sean's call: hide it for now. Removed whole (not `display:none`) with a comment naming the restore condition — a genuinely different surface to show, i.e. the hero film or a capture of something other than the sidebar.

Page is now hero / Still Ghostty / Get Started. Merging deploys production.