### PR TITLE
feat(sidebar): session-id env stamp + Claude Code status hook (session-row status, Phases 0+1)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,6 +16,7 @@ Parked items that survive context resets. Prune at `/wrap`.
 - [x] DECIDE — plain number if glyph gate fails? Answered 2026-08-27: yes. | app | done
 - [ ] **DECIDE — Phase 3 second-line source.** Main thread has no TodoWrite/Task* tool in 2.1.248; candidates (a) subagent TodoWrite via hook, (b) Stop.last_assistant_message, (c) Stop.background_tasks, (d) re-enable the harness task list (~/.claude/tasks). Evidence: gate-evidence.md §E1. | design | needs-Sean
 - [ ] Global permissions: `ask: Bash(gh pr create:*)` is swallowed by `allow: Bash(*)` — observed 2026-08-27, never prompts. Sean's config, not app code. | ops | needs-Sean
+- [ ] Phase 2 review: sleep/wake can re-arm the false `.longRunning` for one turn (`ContinuousClock` advances across system sleep), self-healing at the next `Stop`; needs previous-state tracking this phase doesn't have. | app | open
 
 ## 2026-08-25 — composer UI 11.1/11.2 BUILT overnight, on `feat/composer-ui-11`
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,19 @@ Parked items that survive context resets. Prune at `/wrap`.
 
 > Reconciled 2026-07-29: the tracked `main` copy (07-17→07-22) and the untracked working-tree copy (07-26→07-28) had diverged. This file is the union. Only closed items were dropped (PR #48 merged as `3d2cefc57`).
 
+## 2026-08-26 — Session-row status
+
+- [x] Phase 0 + Phase 1 built, 3 review rounds, on `feat/session-row-status` (585b0bb93…833e8f30c), 971 tests / 0 new failures, gate evidence in docs/plans/session-row-status/gate-evidence.md | app | done
+- [ ] Phase 2 (ClaudeStateStore → indicatorState, both caches, 30-min false-orange fix) | app | next
+- [ ] Phase 3 (Sessions row second line) — BLOCKED on the source decision below | app | open
+- [ ] Phase 4 (Approve + guard; identity = preceding PreToolUse.tool_use_id) | app | open
+- [ ] Phase 5 (Projects badge; no floor needed per E2 rate) | app | open
+- [x] DECIDE — hook registered in `~/.claude/settings.json`? Answered 2026-08-27: yes (installed). | app | done
+- [x] DECIDE — second line replaces `projectName`? Answered 2026-08-27: yes. | app | done
+- [x] DECIDE — plain number if glyph gate fails? Answered 2026-08-27: yes. | app | done
+- [ ] **DECIDE — Phase 3 second-line source.** Main thread has no TodoWrite/Task* tool in 2.1.248; candidates (a) subagent TodoWrite via hook, (b) Stop.last_assistant_message, (c) Stop.background_tasks, (d) re-enable the harness task list (~/.claude/tasks). Evidence: gate-evidence.md §E1. | design | needs-Sean
+- [ ] Global permissions: `ask: Bash(gh pr create:*)` is swallowed by `allow: Bash(*)` — observed 2026-08-27, never prompts. Sean's config, not app code. | ops | needs-Sean
+
 ## 2026-08-25 — composer UI 11.1/11.2 BUILT overnight, on `feat/composer-ui-11`
 
 Branch `feat/composer-ui-11` @ `d4bd0afde`, 24 commits off `a1daa6608`, +4,290/-268 across

--- a/docs/plans/session-row-status/gate-evidence.md
+++ b/docs/plans/session-row-status/gate-evidence.md
@@ -1,0 +1,61 @@
+# Session-row status — Phase 0+1 gate evidence (2026-08-27)
+
+Build plan: `docs/session-row-status-spec` branch, `docs/plans/session-row-status/plan.md`, section 3 — three build-time experiments (E1 TodoWrite payload, E2 permission prompt, E3 env reaches the hook). Measured live from Claude Code 2.1.247/2.1.248 with the hook registered in `~/.claude/settings.json` and a temporary probe line appending every payload to a log (since removed).
+
+## E3 — PASS
+
+7 sessions across 3 Dev-build launches reported their sidebar row's `GHOSTTIES_SESSION_ID` to the hook, all matched to rows in the Dev build's `workspace.json`.
+
+- Agent template → `cco` → `claude()` shell function → worktree-isolated `claude`: rows `995A94F8` "Testing task lists", `1DF97DC2`, `EC115AB1`
+- Plain shell template → `claude` typed by hand: `BD5CB38E` "Create d.txt with hi", `59D161DF` "Create f.txt with hi"
+- Plain shell `echo $GHOSTTIES_SESSION_ID` printed `B6813E5E…` = row "Shell 40" (Phase 0 shell-template acceptance)
+
+Phase 1 installer: on first launch of the build carrying `seedVersion = 2`, `~/.ghostties/hooks/.seed-version` went 1→2 and the seeded script was replaced by the bundle copy (md5 identical to source) — the app-owned overwrite path runs.
+
+## E2 — measured, with one change to the plan
+
+`PermissionRequest` fires and is the immediate signal (same second as the `PreToolUse` for the gated tool).
+
+| Event | Keys | Timing | Notes |
+|---|---|---|---|
+| `PermissionRequest` | `cwd, effort, hook_event_name, permission_mode, permission_suggestions, prompt_id, session_id, tool_input, tool_name, transcript_path` | immediate | no `tool_use_id` |
+| preceding `PreToolUse` | same + `tool_use_id` | immediate | same session, same `tool_name` |
+| `Notification/permission_prompt` | `cwd, hook_event_name, message, notification_type, prompt_id, session_id, transcript_path` | ~6s later | no `tool_use_id`; did NOT fire when the prompt was answered within ~4s |
+| `Notification/idle_prompt` | — | ~60s idle | — |
+
+Consequence for Phase 2: `needsPermission` comes from `PermissionRequest` primarily, `Notification` secondarily; the identity for Phase 4's guard is the preceding `PreToolUse.tool_use_id` paired by `tool_name`, not a field on the request itself.
+
+Rate: Sean's mode is `permission_mode: auto` with `Bash(*)` and `WebFetch(*)` allowed, so prompts occur only on classifier blocks or non-allowlisted tools (`Write` in default mode prompted; Bash never did). Over ~90 minutes of test sessions, 3 prompts, all deliberately provoked — no badge floor needed (plan §7 decision 5: no floor).
+
+Side finding: the `ask: Bash(gh pr create:*)` rule never prompted — `gh pr create --help` ran unasked in default mode; `allow: Bash(*)` appears to swallow it.
+
+## E1 — FAIL as specified; source must change
+
+- `TodoWrite` is not in the main thread's tool list (a session did `ToolSearch select:TodoWrite` + a semantic search, found nothing, and fell back to Bash).
+- `TaskCreate/TaskUpdate/TaskGet/TaskList` exist in the 2.1.247 binary but are not offered to the main thread either (confirmed from inside a live session).
+- `~/.claude/tasks/` was last written 2026-08-15; `~/.claude/todos/` last written 2026-03-01.
+- `TodoWrite` IS granted to subagents (`implementer`, `planner`).
+
+Candidate sources for the Phase 3 second line, none yet chosen — **DECIDE, Sean**:
+
+| Candidate | Description | Caveat |
+|---|---|---|
+| (a) | Subagent `TodoWrite` via the `PostToolUse` hook — a subagent inherits the env, so its payload would land in `<uuid>.todos.json` | unverified; it is the subagent's list, not the thread's |
+| (b) | `Stop.last_assistant_message` | present on every Stop |
+| (c) | `Stop.background_tasks` | array, present; empty in all observed Stops |
+| (d) | Re-enable `~/.claude/tasks/<claude session_id>/<n>.json` | schema `{id, subject, description, activeForm, status, blocks, blockedBy}`, one file per task, rewritten in place (no rename), `.lock` + `.highwatermark` beside them; hook payload's `session_id` is the join key |
+
+## Other measured payload facts for Phase 2's decoder
+
+| Event | Keys |
+|---|---|
+| `UserPromptSubmit` | `cwd, hook_event_name, permission_mode, prompt, prompt_id, session_id, transcript_path` |
+| `PreToolUse` | adds `effort, tool_input, tool_name, tool_use_id` |
+| `Stop` | `background_tasks, cwd, effort, hook_event_name, last_assistant_message, permission_mode, prompt_id, session_crons, session_id, stop_hook_active, transcript_path`; fires only at end of turn (verified: not while a permission prompt is pending) |
+| `SessionEnd` | `cwd, hook_event_name, prompt_id, reason, session_id, transcript_path` (`reason: other` observed) |
+
+Every payload carries Claude's own `session_id` and `cwd`. State files are last-event-wins per session; `.todos.json` is only written for `PostToolUse` + `TodoWrite`.
+
+## Dev-only gotcha
+
+Launching the Dev build with `open` from inside a Claude Code session passes that session's env to the app; its sessions then inherit `CLAUDE_CODE_CHILD_SESSION` ("Transcript saving is off"). Launch with `env -i HOME=… PATH=… open …` for realistic tests.

--- a/macos/Ghostties.xcodeproj/project.pbxproj
+++ b/macos/Ghostties.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		B0A55AC22F72F4C100018CBF /* pair-programmer.md in Resources */ = {isa = PBXBuildFile; fileRef = B0A55ABB2F72F4C100018CBF /* pair-programmer.md */; };
 		B0A55AC32F72F4C100018CBF /* orchestrator.md in Resources */ = {isa = PBXBuildFile; fileRef = B0A55ABA2F72F4C100018CBF /* orchestrator.md */; };
 		B0E55A022F80000000000002 /* presets in Resources */ = {isa = PBXBuildFile; fileRef = B0E55A012F80000000000001 /* presets */; };
+		B0E55A042F80000000000004 /* hooks in Resources */ = {isa = PBXBuildFile; fileRef = B0E55A032F80000000000003 /* hooks */; };
 		FC5218FA2D10FFCE004C93E0 /* zsh in Resources */ = {isa = PBXBuildFile; fileRef = FC5218F92D10FFC7004C93E0 /* zsh */; };
 		FC9ABA9C2D0F53F80020D4C8 /* bash-completion in Resources */ = {isa = PBXBuildFile; fileRef = FC9ABA9B2D0F538D0020D4C8 /* bash-completion */; };
 /* End PBXBuildFile section */
@@ -108,6 +109,7 @@
 		B0A55ABC2F72F4C100018CBF /* test-writer.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "test-writer.md"; sourceTree = "<group>"; };
 		B0A55ADB2F7313F500018CBF /* Chromium Embedded Framework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "Chromium Embedded Framework.framework"; path = "../vendor/cef/Release/Chromium Embedded Framework.framework"; sourceTree = SOURCE_ROOT; };
 		B0E55A012F80000000000001 /* presets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = presets; path = Resources/presets; sourceTree = "<group>"; };
+		B0E55A032F80000000000003 /* hooks */ = {isa = PBXFileReference; lastKnownFileType = folder; name = hooks; path = Resources/hooks; sourceTree = "<group>"; };
 		FC5218F92D10FFC7004C93E0 /* zsh */ = {isa = PBXFileReference; lastKnownFileType = folder; name = zsh; path = "../zig-out/share/zsh"; sourceTree = "<group>"; };
 		FC9ABA9B2D0F538D0020D4C8 /* bash-completion */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "bash-completion"; path = "../zig-out/share/bash-completion"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -342,6 +344,7 @@
 				B0E55A902F80000000000090 /* THIRD-PARTY-NOTICES.md */,
 				B0A55ABD2F72F4C100018CBF /* Presets */,
 				B0E55A012F80000000000001 /* presets */,
+				B0E55A032F80000000000003 /* hooks */,
 				FC9ABA9B2D0F538D0020D4C8 /* bash-completion */,
 				29C15B1C2CDC3B2000520DD4 /* bat */,
 				A586167B2B7703CC009BDB1D /* fish */,
@@ -632,6 +635,7 @@
 				FC5218FA2D10FFCE004C93E0 /* zsh in Resources */,
 				A5B30539299BEAAB0047F10C /* Assets.xcassets in Resources */,
 				B0E55A022F80000000000002 /* presets in Resources */,
+				B0E55A042F80000000000004 /* hooks in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/Resources/hooks/ghostties-status.sh
+++ b/macos/Resources/hooks/ghostties-status.sh
@@ -14,7 +14,7 @@
 # or fail a Claude Code hook, so every exit path is 0.
 #
 # ~/.claude/settings.json snippet — one entry per event, all identical
-# except PostToolUse (matcher "TodoWrite") and the "async": true placement:
+# except PostToolUse (matcher "TodoWrite"):
 #
 #   {
 #     "hooks": {
@@ -78,7 +78,9 @@ esac
 payload=""
 while IFS= read -r line || [ -n "$line" ]; do
     payload="$payload$line"
-done
+done 2>/dev/null
+
+[ -z "$payload" ] && exit 0
 
 state_dir="$HOME/.ghostties/state"
 mkdir -p "$state_dir" || exit 0
@@ -95,14 +97,8 @@ esac
 
 tmp="$dest.$$.tmp"
 
-if [ -z "$payload" ]; then
-    hook_json=null
-else
-    hook_json=$payload
-fi
-
 printf '{"ghosttiesSessionId":"%s","updatedAt":%s,"hook":%s}' \
-    "$GHOSTTIES_SESSION_ID" "$(date +%s)" "$hook_json" > "$tmp" || exit 0
+    "$GHOSTTIES_SESSION_ID" "$(date +%s)" "$payload" > "$tmp" || exit 0
 
 mv -f "$tmp" "$dest" || { rm -f "$tmp"; exit 0; }
 

--- a/macos/Resources/hooks/ghostties-status.sh
+++ b/macos/Resources/hooks/ghostties-status.sh
@@ -67,11 +67,18 @@ esac
 
 [ -t 0 ] && exit 0
 
-# Use the `read` builtin rather than `payload=$(cat)`: command substitution
-# forks a subshell, and on this platform's bash-as-sh a closed stdin (0<&-)
-# makes that subshell reacquire the controlling terminal and hang. `read`
-# runs in-process and fails fast on a closed/bad fd instead.
-IFS= read -r payload
+# Use an in-process read loop rather than `payload=$(cat)`: command
+# substitution forks a subshell, and on this platform's bash-as-sh a closed
+# stdin (0<&-) makes that subshell reacquire the controlling terminal and
+# hang. A single `read` avoids the hang but only captures the first line,
+# truncating any multi-line (pretty-printed) JSON payload; loop over every
+# line instead, including a final line with no trailing newline, and
+# concatenate them. Dropping the newlines is safe: outside JSON strings
+# they are insignificant whitespace, and inside strings they are escaped.
+payload=""
+while IFS= read -r line || [ -n "$line" ]; do
+    payload="$payload$line"
+done
 
 state_dir="$HOME/.ghostties/state"
 mkdir -p "$state_dir" || exit 0

--- a/macos/Resources/hooks/ghostties-status.sh
+++ b/macos/Resources/hooks/ghostties-status.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# ghostties-status.sh — Claude Code hook that publishes session status to
+# ~/.ghostties/state/ for Ghostties to read.
+#
+# This script is APP-OWNED: it is seeded to ~/.ghostties/hooks/ by
+# HookInstaller.swift and OVERWRITTEN whenever the app bumps
+# HookInstaller.seedVersion. Any local edits to the seeded copy will be
+# lost on the next version bump — edit this source file instead.
+#
+# Sean registers this script per-event in ~/.claude/settings.json with
+# "async": true on every event (UserPromptSubmit, PreToolUse, PostToolUse,
+# Stop, Notification, PermissionRequest, SessionEnd). It must never block
+# or fail a Claude Code hook, so every exit path is 0.
+#
+# Behaviour:
+#   1. No-op if GHOSTTIES_SESSION_ID is unset/empty, or contains anything
+#      other than [A-Za-z0-9-] (it becomes part of a filename).
+#   2. Reads the hook JSON payload from stdin.
+#   3. Writes {"ghosttiesSessionId","updatedAt","hook"} to
+#      ~/.ghostties/state/<id>.json (or <id>.todos.json for a
+#      PostToolUse/TodoWrite payload), via a same-directory temp file +
+#      rename so directory watchers see a real rename(2), not an in-place
+#      write.
+
+trap 'exit 0' EXIT
+
+[ -z "$GHOSTTIES_SESSION_ID" ] && exit 0
+
+case "$GHOSTTIES_SESSION_ID" in
+    *[!A-Za-z0-9-]*) exit 0 ;;
+esac
+
+payload=$(cat)
+
+state_dir="$HOME/.ghostties/state"
+mkdir -p "$state_dir" || exit 0
+chmod 700 "$state_dir" || exit 0
+
+case "$payload" in
+    *'"tool_name":"TodoWrite"'*|*'"tool_name": "TodoWrite"'*)
+        dest="$state_dir/$GHOSTTIES_SESSION_ID.todos.json"
+        ;;
+    *)
+        dest="$state_dir/$GHOSTTIES_SESSION_ID.json"
+        ;;
+esac
+
+tmp="$dest.$$.tmp"
+
+if [ -z "$payload" ]; then
+    hook_json=null
+else
+    hook_json=$payload
+fi
+
+printf '{"ghosttiesSessionId":"%s","updatedAt":%s,"hook":%s}' \
+    "$GHOSTTIES_SESSION_ID" "$(date +%s)" "$hook_json" > "$tmp" || exit 0
+
+mv -f "$tmp" "$dest" || exit 0
+
+exit 0

--- a/macos/Resources/hooks/ghostties-status.sh
+++ b/macos/Resources/hooks/ghostties-status.sh
@@ -13,6 +13,38 @@
 # Stop, Notification, PermissionRequest, SessionEnd). It must never block
 # or fail a Claude Code hook, so every exit path is 0.
 #
+# ~/.claude/settings.json snippet — one entry per event, all identical
+# except PostToolUse (matcher "TodoWrite") and the "async": true placement:
+#
+#   {
+#     "hooks": {
+#       "UserPromptSubmit": [
+#         {"matcher": "", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ],
+#       "PreToolUse": [
+#         {"matcher": "", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ],
+#       "PostToolUse": [
+#         {"matcher": "TodoWrite", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ],
+#       "Stop": [
+#         {"matcher": "", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ],
+#       "Notification": [
+#         {"matcher": "", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ],
+#       "PermissionRequest": [
+#         {"matcher": "", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ],
+#       "SessionEnd": [
+#         {"matcher": "", "hooks": [{"type": "command", "command": "\"$HOME\"/.ghostties/hooks/ghostties-status.sh", "async": true}]}
+#       ]
+#     }
+#   }
+#
+# "async": true on PermissionRequest is what makes the hook structurally
+# unable to alter a permission decision.
+#
 # Behaviour:
 #   1. No-op if GHOSTTIES_SESSION_ID is unset/empty, or contains anything
 #      other than [A-Za-z0-9-] (it becomes part of a filename).
@@ -31,14 +63,22 @@ case "$GHOSTTIES_SESSION_ID" in
     *[!A-Za-z0-9-]*) exit 0 ;;
 esac
 
-payload=$(cat)
+[ -z "$HOME" ] && exit 0
+
+[ -t 0 ] && exit 0
+
+# Use the `read` builtin rather than `payload=$(cat)`: command substitution
+# forks a subshell, and on this platform's bash-as-sh a closed stdin (0<&-)
+# makes that subshell reacquire the controlling terminal and hang. `read`
+# runs in-process and fails fast on a closed/bad fd instead.
+IFS= read -r payload
 
 state_dir="$HOME/.ghostties/state"
 mkdir -p "$state_dir" || exit 0
 chmod 700 "$state_dir" || exit 0
 
 case "$payload" in
-    *'"tool_name":"TodoWrite"'*|*'"tool_name": "TodoWrite"'*)
+    *'"tool_name":"TodoWrite"'*'"hook_event_name":"PostToolUse"'*|*'"tool_name": "TodoWrite"'*'"hook_event_name": "PostToolUse"'*|*'"hook_event_name":"PostToolUse"'*'"tool_name":"TodoWrite"'*|*'"hook_event_name": "PostToolUse"'*'"tool_name": "TodoWrite"'*)
         dest="$state_dir/$GHOSTTIES_SESSION_ID.todos.json"
         ;;
     *)
@@ -57,6 +97,6 @@ fi
 printf '{"ghosttiesSessionId":"%s","updatedAt":%s,"hook":%s}' \
     "$GHOSTTIES_SESSION_ID" "$(date +%s)" "$hook_json" > "$tmp" || exit 0
 
-mv -f "$tmp" "$dest" || exit 0
+mv -f "$tmp" "$dest" || { rm -f "$tmp"; exit 0; }
 
 exit 0

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -263,6 +263,7 @@ class AppDelegate: NSObject,
         // script can carry session context, so they shouldn't accumulate.
         DispatchQueue.global(qos: .utility).async {
             SessionCoordinator.sweepStaleLauncherScripts()
+            ClaudeStateStore.sweepStale()
         }
 
         // Check if secure input was enabled when we last quit.

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -266,6 +266,17 @@ class AppDelegate: NSObject,
             ClaudeStateStore.sweepStale()
         }
 
+        // Warm `ClaudeStateStore.shared` here, at launch, so its filesystem
+        // setup (mkdir/stat/chmod) and `DispatchSource` creation happen
+        // before any render — not on the first sidebar paint, which calls
+        // `ProjectDisclosureRow` → `SessionCoordinator.indicatorState(for:)`
+        // → `ClaudeStateStore.shared` before the 1Hz activity timer's first
+        // tick. `ClaudeStateStore` is `@MainActor`; hop explicitly rather
+        // than relying on this delegate callback's (unannotated) isolation.
+        Task { @MainActor in
+            _ = ClaudeStateStore.shared
+        }
+
         // Check if secure input was enabled when we last quit.
         if UserDefaults.ghostty.bool(forKey: "SecureInput") != SecureInput.shared.enabled {
             toggleSecureInput(self)

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -567,6 +567,16 @@ class AppDelegate: NSObject,
     }
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
+        // This callback runs before `applicationDidFinishLaunching` (see that
+        // function's comment), so its own `ClaudeStateStore.shared` warm
+        // Task hasn't been enqueued yet. Enqueue ours here, before any
+        // `TerminalController.newWindow`/`newTab` call below schedules its
+        // presentation via `DispatchQueue.main.async` — main-queue FIFO then
+        // guarantees the store is warm before the first sidebar paint.
+        Task { @MainActor in
+            _ = ClaudeStateStore.shared
+        }
+
         // Ghostty will validate as well but we can avoid creating an entirely new
         // surface by doing our own validation here. We can also show a useful error
         // this way.

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -567,9 +567,10 @@ class AppDelegate: NSObject,
     }
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
-        // This callback runs before `applicationDidFinishLaunching` (see that
-        // function's comment), so its own `ClaudeStateStore.shared` warm
-        // Task hasn't been enqueued yet. Enqueue ours here, before any
+        // AppKit can invoke this callback (e.g. opening a file at launch)
+        // before `applicationDidFinishLaunching` runs, so that function's
+        // `ClaudeStateStore.shared` warm Task hasn't been enqueued yet.
+        // Enqueue ours here, before any
         // `TerminalController.newWindow`/`newTab` call below schedules its
         // presentation via `DispatchQueue.main.async` — main-queue FIFO then
         // guarantees the store is warm before the first sidebar paint.

--- a/macos/Sources/Features/Ghostties/ClaudeStateStore.swift
+++ b/macos/Sources/Features/Ghostties/ClaudeStateStore.swift
@@ -1,0 +1,299 @@
+import Foundation
+
+/// Raw on-disk shape written by `ghostties-status.sh` to
+/// `~/.ghostties/state/<GHOSTTIES_SESSION_ID>.json`: `{"ghosttiesSessionId",
+/// "updatedAt","hook"}`, where `hook` is the Claude Code hook payload
+/// verbatim. `updatedAt` is unix seconds (`date +%s`).
+struct ClaudeHookWrapper: Decodable {
+    let ghosttiesSessionId: String
+    let updatedAt: Double
+    let hook: ClaudeHookPayload
+}
+
+/// The union of hook payload keys `ClaudeStateStore.derive(from:)` cares
+/// about, across every event Sean's `~/.claude/settings.json` registers
+/// (`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `Notification`,
+/// `PermissionRequest`, `SessionEnd`). Unlisted keys in the real payload
+/// (e.g. `tool_input`, `background_tasks`) are ignored by `Decodable`, not
+/// an error. Measured shapes: `docs/plans/session-row-status/gate-evidence.md`.
+struct ClaudeHookPayload: Decodable {
+    let hookEventName: String
+    let toolName: String?
+    let notificationType: String?
+    let sessionId: String?
+    let cwd: String?
+
+    enum CodingKeys: String, CodingKey {
+        case hookEventName = "hook_event_name"
+        case toolName = "tool_name"
+        case notificationType = "notification_type"
+        case sessionId = "session_id"
+        case cwd
+    }
+}
+
+/// A permission or tool-use identity carried by a `needsPermission` state.
+///
+/// `toolUseId` is `String?`, not `String`, because `PermissionRequest`
+/// carries no `tool_use_id` of its own (gate-evidence E2), and because the
+/// state file is last-event-wins, the preceding `PreToolUse`'s id has
+/// already been overwritten by the time this event lands on disk. Pairing
+/// a permission prompt back to its triggering tool call is a Phase 4
+/// concern (in-memory PreToolUse tracking), not this phase's.
+struct StructuredPrompt: Equatable {
+    let toolName: String
+    let toolUseId: String?
+}
+
+/// Decoded, derived state for one Ghostties session, keyed by
+/// `ghosttiesSessionId` (== `AgentSession.id` == `GHOSTTIES_SESSION_ID`).
+struct ClaudeState: Equatable {
+    enum Kind: Equatable {
+        case busy
+        case idle
+        case needsInput
+        case needsPermission
+        case ended
+    }
+
+    let ghosttiesSessionId: UUID
+    let claudeSessionId: String
+    let cwd: String
+    let state: Kind
+    let structuredPrompt: StructuredPrompt?
+    let updatedAt: Date
+}
+
+/// A row-facing summary of why a session needs the user's attention.
+/// `ClaudeStateStore.attention(for:)` is what Phases 3-5 will consume;
+/// nothing reads it yet in this phase.
+enum AttentionPayload: Equatable {
+    case freeform
+    case permission(toolName: String, toolUseId: String?)
+}
+
+/// Reads Claude Code's own idea of session state from
+/// `~/.ghostties/state/<id>.json`, written by the `ghostties-status.sh`
+/// hook (seeded by `HookInstaller`), and exposes it as a small in-memory
+/// map so `SessionCoordinator.indicatorState(for:)` can consult it as a
+/// pure dictionary lookup — no filesystem access on the render path.
+///
+/// One instance is global (`.shared`), not per-window, because
+/// `~/.ghostties/state/` is a single global directory regardless of how
+/// many `SessionCoordinator`s (one per window) are alive.
+@MainActor
+final class ClaudeStateStore {
+    static let shared = ClaudeStateStore(directoryURL: ClaudeStateStore.defaultDirectoryURL)
+
+    /// How stale a state file can be before `state(for:)`/`attention(for:)`
+    /// stop trusting it and fall back to today's output-based heuristics.
+    /// A crashed or force-quit Claude process leaves its last hook event on
+    /// disk forever otherwise.
+    private static let staleInterval: TimeInterval = 30 * 60
+
+    private let directoryURL: URL
+    private var states: [UUID: ClaudeState] = [:]
+    private var watcher: TaskFileWatcher?
+
+    nonisolated static var defaultDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ghostties", isDirectory: true)
+            .appendingPathComponent("state", isDirectory: true)
+    }
+
+    init(directoryURL: URL) {
+        self.directoryURL = directoryURL
+        ensureDirectory()
+        let watcher = TaskFileWatcher(url: directoryURL) { [weak self] in
+            self?.refresh()
+        }
+        self.watcher = watcher
+        watcher.start()
+    }
+
+    // MARK: - Reads (pure, in-memory)
+
+    /// The most recent Claude-derived state for a session, or nil if there is
+    /// none, it has gone terminal (`.ended`), or it is stale (older than
+    /// `staleInterval`). Callers fall through to today's heuristics on nil.
+    func state(for id: UUID) -> ClaudeState? {
+        guard let state = states[id] else { return nil }
+        if state.state == .ended { return nil }
+        guard Date().timeIntervalSince(state.updatedAt) <= Self.staleInterval else { return nil }
+        return state
+    }
+
+    /// Attention payload for a session, or nil unless the session's current
+    /// state is `needsInput`/`needsPermission`. Not consumed anywhere yet —
+    /// Phases 3-5 read this to render the second row line / Approve button.
+    func attention(for id: UUID) -> AttentionPayload? {
+        guard let state = state(for: id) else { return nil }
+        switch state.state {
+        case .needsInput:
+            return .freeform
+        case .needsPermission:
+            guard let prompt = state.structuredPrompt else {
+                return .permission(toolName: "", toolUseId: nil)
+            }
+            return .permission(toolName: prompt.toolName, toolUseId: prompt.toolUseId)
+        case .busy, .idle, .ended:
+            return nil
+        }
+    }
+
+    // MARK: - Writes
+
+    /// Delete both state files for a session. Called from `SessionCoordinator
+    /// .setStatus(_:for:)`'s terminal branch, the same seam that already
+    /// clears both indicator caches, so a closed session's Claude state
+    /// cannot outlive the session that owned it.
+    func removeState(for id: UUID) {
+        states.removeValue(forKey: id)
+        let fm = FileManager.default
+        try? fm.removeItem(at: directoryURL.appendingPathComponent("\(id.uuidString).json"))
+        try? fm.removeItem(at: directoryURL.appendingPathComponent("\(id.uuidString).todos.json"))
+    }
+
+    /// Delete `*.json` state files older than 24h, catching any left behind
+    /// by a Claude process that crashed or was force-quit without a
+    /// `SessionEnd` hook firing. Scoped to exactly this directory and this
+    /// extension; symlink-aware stat so a planted symlink can't redirect the
+    /// deletion outside it. Mirrors
+    /// `SessionCoordinator.sweepStaleLauncherScripts()`.
+    nonisolated static func sweepStale() {
+        let fm = FileManager.default
+        let dir = defaultDirectoryURL.path
+        guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { return }
+
+        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+        for name in entries {
+            guard name.hasSuffix(".json") else { continue }
+            let path = (dir as NSString).appendingPathComponent(name)
+
+            guard let attrs = try? fm.attributesOfItem(atPath: path),
+                  attrs[.type] as? FileAttributeType == .typeRegular,
+                  let modified = attrs[.modificationDate] as? Date,
+                  modified < cutoff else { continue }
+
+            try? fm.removeItem(atPath: path)
+        }
+    }
+
+    // MARK: - Refresh (watcher callback only — never on the render path)
+
+    /// Rebuild `states` from scratch by listing `directoryURL` and decoding
+    /// every `<uuid>.json` file (never `*.todos.json`, which is out of
+    /// scope this phase). One bad file is skipped, not fatal to the whole
+    /// refresh. Full rebuild (not an incremental merge) is deliberate: the
+    /// hook overwrites its one file per session on every event, and a
+    /// rebuild is also how a deleted file's session naturally drops out.
+    private func refresh() {
+        ensureDirectory()
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: nil
+        ) else {
+            return
+        }
+
+        var newStates: [UUID: ClaudeState] = [:]
+        for url in entries {
+            let name = url.lastPathComponent
+            guard name.hasSuffix(".json"), !name.hasSuffix(".todos.json") else { continue }
+            let stem = String(name.dropLast(".json".count))
+            guard UUID(uuidString: stem) != nil else { continue }
+            guard let data = try? Data(contentsOf: url) else { continue }
+            guard let wrapper = try? JSONDecoder().decode(ClaudeHookWrapper.self, from: data) else { continue }
+            guard let state = Self.derive(from: wrapper) else { continue }
+            newStates[state.ghosttiesSessionId] = state
+        }
+        states = newStates
+    }
+
+    /// Create `directoryURL` at `0o700` if absent; enforce `0o700` on an
+    /// existing one. These files carry tool names and per-session context —
+    /// the same class of leak `SessionCoordinator.launcherScriptDir`'s
+    /// comment warns about.
+    private func ensureDirectory() {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        if fm.fileExists(atPath: directoryURL.path, isDirectory: &isDir), isDir.boolValue {
+            try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
+        } else {
+            try? fm.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+        }
+    }
+
+    // MARK: - Pure mapping (no filesystem — testable directly)
+
+    /// Map one decoded hook payload to a `ClaudeState`, or nil if the event
+    /// is not one this phase acts on. Pure function: no filesystem, no
+    /// `self` access, so tests call it directly against fixtures built from
+    /// the measured payload key sets in `gate-evidence.md`.
+    static func derive(from wrapper: ClaudeHookWrapper) -> ClaudeState? {
+        guard let ghosttiesSessionId = UUID(uuidString: wrapper.ghosttiesSessionId) else { return nil }
+        let hook = wrapper.hook
+
+        let kind: ClaudeState.Kind
+        var structuredPrompt: StructuredPrompt?
+
+        switch hook.hookEventName {
+        case "UserPromptSubmit", "PreToolUse", "PostToolUse":
+            kind = .busy
+        case "Stop":
+            kind = .idle
+        case "PermissionRequest":
+            kind = .needsPermission
+            // toolUseId is nil — see StructuredPrompt's doc comment above.
+            structuredPrompt = StructuredPrompt(toolName: hook.toolName ?? "", toolUseId: nil)
+        case "Notification":
+            switch hook.notificationType {
+            case "permission_prompt":
+                kind = .needsPermission
+            case "idle_prompt", "elicitation_dialog", "elicitation_url_dialog", "agent_needs_input":
+                kind = .needsInput
+            default:
+                return nil
+            }
+        case "SessionEnd":
+            kind = .ended
+        default:
+            return nil
+        }
+
+        return ClaudeState(
+            ghosttiesSessionId: ghosttiesSessionId,
+            claudeSessionId: hook.sessionId ?? "",
+            cwd: hook.cwd ?? "",
+            state: kind,
+            structuredPrompt: structuredPrompt,
+            updatedAt: Date(timeIntervalSince1970: wrapper.updatedAt)
+        )
+    }
+
+#if DEBUG
+    /// Test-only: force a synchronous refresh from `directoryURL`, bypassing
+    /// the watcher's 150ms debounce. Never used in production.
+    func refreshForTesting() {
+        refresh()
+    }
+
+    /// Test-only: seed an in-memory state directly on `.shared` without
+    /// touching any filesystem, so `SessionCoordinator` tests can exercise
+    /// the read path without ever writing to the real
+    /// `~/.ghostties/state/`. Never used in production.
+    func seedStateForTesting(_ state: ClaudeState) {
+        states[state.ghosttiesSessionId] = state
+    }
+
+    /// Test-only: remove a seeded state so tests don't leak into each other
+    /// via the `.shared` singleton. Never used in production.
+    func clearStateForTesting(id: UUID) {
+        states.removeValue(forKey: id)
+    }
+#endif
+}

--- a/macos/Sources/Features/Ghostties/ClaudeStateStore.swift
+++ b/macos/Sources/Features/Ghostties/ClaudeStateStore.swift
@@ -154,12 +154,16 @@ final class ClaudeStateStore {
         try? fm.removeItem(at: directoryURL.appendingPathComponent("\(id.uuidString).todos.json"))
     }
 
-    /// Delete `*.json` state files older than 24h, catching any left behind
-    /// by a Claude process that crashed or was force-quit without a
-    /// `SessionEnd` hook firing. Scoped to exactly this directory and this
-    /// extension; symlink-aware stat so a planted symlink can't redirect the
-    /// deletion outside it. Mirrors
-    /// `SessionCoordinator.sweepStaleLauncherScripts()`.
+    /// Delete `*.json` state files, and orphaned `*.tmp` files, older than
+    /// 24h. `*.json` catches state left behind by a Claude process that
+    /// crashed or was force-quit without a `SessionEnd` hook firing. `*.tmp`
+    /// catches `ghostties-status.sh`'s `<dest>.<pid>.tmp` if the process dies
+    /// between its `printf` and `mv -f` — `refresh()` and this sweep both
+    /// filter on `.json`, so a `.tmp` is otherwise never noticed, let alone
+    /// deleted, and it carries the same tool-name/prompt-text content as the
+    /// state file it was about to become. Scoped to exactly this directory;
+    /// symlink-aware stat so a planted symlink can't redirect the deletion
+    /// outside it. Mirrors `SessionCoordinator.sweepStaleLauncherScripts()`.
     nonisolated static func sweepStale() {
         let fm = FileManager.default
         let dir = defaultDirectoryURL.path
@@ -167,7 +171,7 @@ final class ClaudeStateStore {
 
         let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
         for name in entries {
-            guard name.hasSuffix(".json") else { continue }
+            guard name.hasSuffix(".json") || name.hasSuffix(".tmp") else { continue }
             let path = (dir as NSString).appendingPathComponent(name)
 
             guard let attrs = try? fm.attributesOfItem(atPath: path),
@@ -188,11 +192,17 @@ final class ClaudeStateStore {
     /// hook overwrites its one file per session on every event, and a
     /// rebuild is also how a deleted file's session naturally drops out.
     private func refresh() {
-        ensureDirectory()
+        // Do NOT call `ensureDirectory()` here. Its existing-directory branch
+        // does a `chmod`, and `TaskFileWatcher`'s event mask includes
+        // `.attrib`, so a `chmod` on the watched directory fires another
+        // `refresh()` ~150ms later — forever. The directory is already
+        // ensured in `init`, and `TaskFileWatcher` retries every 500ms until
+        // it exists, so a directory created later is picked up without help.
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: directoryURL,
             includingPropertiesForKeys: nil
         ) else {
+            states = [:]
             return
         }
 
@@ -214,11 +224,22 @@ final class ClaudeStateStore {
     /// existing one. These files carry tool names and per-session context —
     /// the same class of leak `SessionCoordinator.launcherScriptDir`'s
     /// comment warns about.
+    ///
+    /// The existing-directory branch only calls `setAttributes` when the
+    /// current mode isn't already `0o700`. `TaskFileWatcher` watches this
+    /// same directory with `.attrib` in its event mask, so an unconditional
+    /// `chmod` here — even a no-op one — fires another debounced `refresh()`.
+    /// `refresh()` no longer calls this method, so today that loop can't
+    /// happen through this path; this guard is defence in depth against a
+    /// future caller reintroducing it.
     private func ensureDirectory() {
         let fm = FileManager.default
         var isDir: ObjCBool = false
         if fm.fileExists(atPath: directoryURL.path, isDirectory: &isDir), isDir.boolValue {
-            try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
+            let currentMode = (try? fm.attributesOfItem(atPath: directoryURL.path))?[.posixPermissions] as? NSNumber
+            if currentMode?.uint16Value != 0o700 {
+                try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
+            }
         } else {
             try? fm.createDirectory(
                 at: directoryURL,

--- a/macos/Sources/Features/Ghostties/ClaudeStateStore.swift
+++ b/macos/Sources/Features/Ghostties/ClaudeStateStore.swift
@@ -192,16 +192,26 @@ final class ClaudeStateStore {
     /// hook overwrites its one file per session on every event, and a
     /// rebuild is also how a deleted file's session naturally drops out.
     private func refresh() {
-        // Do NOT call `ensureDirectory()` here. Its existing-directory branch
-        // does a `chmod`, and `TaskFileWatcher`'s event mask includes
-        // `.attrib`, so a `chmod` on the watched directory fires another
-        // `refresh()` ~150ms later — forever. The directory is already
-        // ensured in `init`, and `TaskFileWatcher` retries every 500ms until
-        // it exists, so a directory created later is picked up without help.
+        // Do NOT call `ensureDirectory()` unconditionally here. Its
+        // existing-directory branch does a `chmod`, and `TaskFileWatcher`'s
+        // event mask includes `.attrib`, so a `chmod` on the watched
+        // directory fires another `refresh()` ~150ms later. On the success
+        // path below the directory's mode is already fine (we just listed
+        // it), so calling it there would re-arm the watcher forever. On the
+        // failure path it is called at most once per failed listing — once
+        // `ensureDirectory()` repairs the mode, the *next* refresh (driven by
+        // the hook's own `chmod 700` in `ghostties-status.sh`, or this same
+        // repair's `.attrib` event) takes the success path above and stops
+        // calling it, so it cannot loop.
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: directoryURL,
             includingPropertiesForKeys: nil
         ) else {
+            // Self-heal a mode-drifted directory (e.g. `chmod 000` while
+            // running) so a permanent EACCES doesn't wipe `states` forever.
+            // `init`'s `ensureDirectory()` alone is not sufficient for this —
+            // it only ever runs once, at construction.
+            ensureDirectory()
             states = [:]
             return
         }
@@ -229,9 +239,11 @@ final class ClaudeStateStore {
     /// current mode isn't already `0o700`. `TaskFileWatcher` watches this
     /// same directory with `.attrib` in its event mask, so an unconditional
     /// `chmod` here — even a no-op one — fires another debounced `refresh()`.
-    /// `refresh()` no longer calls this method, so today that loop can't
-    /// happen through this path; this guard is defence in depth against a
-    /// future caller reintroducing it.
+    /// `refresh()` calls this only on its failure path (a mode-drifted
+    /// directory self-heal), never on success — this conditional-chmod guard
+    /// is what keeps that call from looping: once the mode is `0o700` it's a
+    /// no-op, so the retriggered `.attrib` refresh takes the success path
+    /// and stops calling this method at all.
     private func ensureDirectory() {
         let fm = FileManager.default
         var isDir: ObjCBool = false
@@ -309,12 +321,6 @@ final class ClaudeStateStore {
     /// `~/.ghostties/state/`. Never used in production.
     func seedStateForTesting(_ state: ClaudeState) {
         states[state.ghosttiesSessionId] = state
-    }
-
-    /// Test-only: remove a seeded state so tests don't leak into each other
-    /// via the `.shared` singleton. Never used in production.
-    func clearStateForTesting(id: UUID) {
-        states.removeValue(forKey: id)
     }
 #endif
 }

--- a/macos/Sources/Features/Ghostties/HookInstaller.swift
+++ b/macos/Sources/Features/Ghostties/HookInstaller.swift
@@ -104,8 +104,12 @@ struct HookInstaller {
 
         do {
             try fm.copyItem(at: sourceURL, to: URL(fileURLWithPath: tmpPath))
-            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: tmpPath)
-            _ = try fm.replaceItemAt(URL(fileURLWithPath: destPath), withItemAt: URL(fileURLWithPath: tmpPath))
+            if fm.fileExists(atPath: destPath) {
+                _ = try fm.replaceItemAt(URL(fileURLWithPath: destPath), withItemAt: URL(fileURLWithPath: tmpPath))
+            } else {
+                try fm.moveItem(atPath: tmpPath, toPath: destPath)
+            }
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: destPath)
         } catch {
             logger.error("Failed to seed hook script: \(error.localizedDescription)")
             try? fm.removeItem(atPath: tmpPath)

--- a/macos/Sources/Features/Ghostties/HookInstaller.swift
+++ b/macos/Sources/Features/Ghostties/HookInstaller.swift
@@ -1,0 +1,120 @@
+import Foundation
+import OSLog
+
+/// Seeds the `ghostties-status.sh` Claude Code hook script to
+/// `~/.ghostties/hooks/` so Sean can register it in `~/.claude/settings.json`.
+///
+/// Modeled on `PresetLoader.seedIfNeeded()`, with one deliberate divergence:
+/// `PresetLoader` never overwrites files that already exist, because preset
+/// files are user-editable content. This script is app-owned — Sean never
+/// hand-edits it — so on a version bump the seeded copy is OVERWRITTEN
+/// rather than left alone. That is required for a hook bugfix to ever reach
+/// an already-seeded machine.
+struct HookInstaller {
+    static let hooksDirectoryPath = ("~/.ghostties/hooks" as NSString).expandingTildeInPath
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.ghostties",
+        category: "HookInstaller"
+    )
+
+    // MARK: - Public API
+
+    /// Current seed version. Bump this when `ghostties-status.sh` changes to
+    /// trigger re-seeding (and overwrite any previously-seeded copy).
+    static let seedVersion = 1
+
+    /// Name of the bundled/seeded hook script.
+    static let scriptName = "ghostties-status.sh"
+
+    /// Full path to the seeded script at `~/.ghostties/hooks/ghostties-status.sh`.
+    static var scriptPath: String {
+        (hooksDirectoryPath as NSString).appendingPathComponent(scriptName)
+    }
+
+    /// Seed the bundled hook script to `~/.ghostties/hooks/` using versioned
+    /// seeding. Unlike `PresetLoader`, this OVERWRITES the destination when
+    /// the seed version advances, because the script is app-owned.
+    static func seedIfNeeded() {
+        let signpostState = Perf.signposter.beginInterval("hooks.seed")
+        defer { Perf.signposter.endInterval("hooks.seed", signpostState) }
+
+        guard let bundledScriptURL = Bundle.main.resourceURL?
+            .appendingPathComponent("hooks")
+            .appendingPathComponent(scriptName) else {
+            logger.warning("No bundled hooks directory found in app bundle")
+            return
+        }
+
+        _ = seed(from: bundledScriptURL, into: hooksDirectoryPath, version: seedVersion)
+    }
+
+    // MARK: - Seed Helpers
+
+    /// Seed `scriptName` from `sourceURL` into `directoryPath`, gated by a
+    /// `.seed-version` marker file. Returns `true` if a (re)seed occurred.
+    ///
+    /// Extracted from `seedIfNeeded()` so tests can exercise the real seeding
+    /// logic against a temp directory and a temp source file, without needing
+    /// `Bundle.main`.
+    @discardableResult
+    static func seed(from sourceURL: URL, into directoryPath: String, version: Int) -> Bool {
+        let fm = FileManager.default
+        let versionFilePath = (directoryPath as NSString).appendingPathComponent(".seed-version")
+
+        // Check the current seed version.
+        let currentVersion: Int
+        if let versionData = fm.contents(atPath: versionFilePath),
+           let versionString = String(data: versionData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let parsedVersion = Int(versionString) {
+            currentVersion = parsedVersion
+        } else {
+            currentVersion = 0
+        }
+
+        // Skip if already at or above the current seed version.
+        guard currentVersion < version else { return false }
+
+        // Create the destination directory if it doesn't exist.
+        if !fm.fileExists(atPath: directoryPath) {
+            do {
+                try fm.createDirectory(atPath: directoryPath, withIntermediateDirectories: true, attributes: [
+                    .posixPermissions: 0o700,
+                ])
+            } catch {
+                logger.error("Failed to create hooks directory: \(error.localizedDescription)")
+                return false
+            }
+        }
+
+        let destPath = (directoryPath as NSString).appendingPathComponent(sourceURL.lastPathComponent)
+
+        // App-owned: remove any existing copy so a version bump always wins,
+        // unlike PresetLoader's additive-only copy.
+        if fm.fileExists(atPath: destPath) {
+            do {
+                try fm.removeItem(atPath: destPath)
+            } catch {
+                logger.error("Failed to remove existing hook script: \(error.localizedDescription)")
+                return false
+            }
+        }
+
+        do {
+            try fm.copyItem(at: sourceURL, to: URL(fileURLWithPath: destPath))
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: destPath)
+        } catch {
+            logger.error("Failed to seed hook script: \(error.localizedDescription)")
+            return false
+        }
+
+        // Write the new seed version marker.
+        do {
+            try "\(version)".write(toFile: versionFilePath, atomically: true, encoding: .utf8)
+        } catch {
+            logger.error("Failed to write seed version marker: \(error.localizedDescription)")
+        }
+
+        return true
+    }
+}

--- a/macos/Sources/Features/Ghostties/HookInstaller.swift
+++ b/macos/Sources/Features/Ghostties/HookInstaller.swift
@@ -26,7 +26,7 @@ struct HookInstaller {
 
     /// Current seed version. Bump this when `ghostties-status.sh` changes to
     /// trigger re-seeding (and overwrite any previously-seeded copy).
-    static let seedVersion = 1
+    static let seedVersion = 2
 
     /// Name of the bundled/seeded hook script.
     static let scriptName = "ghostties-status.sh"
@@ -104,6 +104,7 @@ struct HookInstaller {
 
         do {
             try fm.copyItem(at: sourceURL, to: URL(fileURLWithPath: tmpPath))
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: tmpPath)
             if fm.fileExists(atPath: destPath) {
                 _ = try fm.replaceItemAt(URL(fileURLWithPath: destPath), withItemAt: URL(fileURLWithPath: tmpPath))
             } else {

--- a/macos/Sources/Features/Ghostties/HookInstaller.swift
+++ b/macos/Sources/Features/Ghostties/HookInstaller.swift
@@ -10,6 +10,10 @@ import OSLog
 /// hand-edits it — so on a version bump the seeded copy is OVERWRITTEN
 /// rather than left alone. That is required for a hook bugfix to ever reach
 /// an already-seeded machine.
+///
+/// Unlike `PresetLoader`, a missing bundle resource does NOT write the
+/// version marker, so seeding retries on every launch — deliberate, do not
+/// "fix" back.
 struct HookInstaller {
     static let hooksDirectoryPath = ("~/.ghostties/hooks" as NSString).expandingTildeInPath
 
@@ -51,7 +55,7 @@ struct HookInstaller {
 
     // MARK: - Seed Helpers
 
-    /// Seed `scriptName` from `sourceURL` into `directoryPath`, gated by a
+    /// Seed `sourceURL.lastPathComponent` into `directoryPath`, gated by a
     /// `.seed-version` marker file. Returns `true` if a (re)seed occurred.
     ///
     /// Extracted from `seedIfNeeded()` so tests can exercise the real seeding
@@ -72,8 +76,12 @@ struct HookInstaller {
             currentVersion = 0
         }
 
-        // Skip if already at or above the current seed version.
-        guard currentVersion < version else { return false }
+        let destPath = (directoryPath as NSString).appendingPathComponent(sourceURL.lastPathComponent)
+
+        // Skip if already at or above the current seed version — unless the
+        // seeded script itself has gone missing (e.g. deleted by hand), in
+        // which case we must reseed even at the same version.
+        guard currentVersion < version || !fm.fileExists(atPath: destPath) else { return false }
 
         // Create the destination directory if it doesn't exist.
         if !fm.fileExists(atPath: directoryPath) {
@@ -87,24 +95,20 @@ struct HookInstaller {
             }
         }
 
-        let destPath = (directoryPath as NSString).appendingPathComponent(sourceURL.lastPathComponent)
-
-        // App-owned: remove any existing copy so a version bump always wins,
-        // unlike PresetLoader's additive-only copy.
-        if fm.fileExists(atPath: destPath) {
-            do {
-                try fm.removeItem(atPath: destPath)
-            } catch {
-                logger.error("Failed to remove existing hook script: \(error.localizedDescription)")
-                return false
-            }
+        // App-owned: copy to a temp path first and replace atomically, so a
+        // failed copy never leaves the destination with no script at all.
+        let tmpPath = destPath + ".tmp"
+        if fm.fileExists(atPath: tmpPath) {
+            try? fm.removeItem(atPath: tmpPath)
         }
 
         do {
-            try fm.copyItem(at: sourceURL, to: URL(fileURLWithPath: destPath))
-            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: destPath)
+            try fm.copyItem(at: sourceURL, to: URL(fileURLWithPath: tmpPath))
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: tmpPath)
+            _ = try fm.replaceItemAt(URL(fileURLWithPath: destPath), withItemAt: URL(fileURLWithPath: tmpPath))
         } catch {
             logger.error("Failed to seed hook script: \(error.localizedDescription)")
+            try? fm.removeItem(atPath: tmpPath)
             return false
         }
 

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -101,7 +101,25 @@ final class SessionCoordinator: ObservableObject {
     /// an isolated `WorkspaceStore` instead of `WorkspaceStore.shared` (which
     /// persists to the real `workspace.json`). nil in production.
     var agentKindLookupStoreForTesting: WorkspaceStore?
+
+    /// Test-only override for `claudeStateStore`, so tests can point this
+    /// coordinator at a temp-directory `ClaudeStateStore` instead of
+    /// `.shared` (which reads/writes the real `~/.ghostties/state/`, where
+    /// live sessions are writing right now). nil in production.
+    var claudeStateStoreForTesting: ClaudeStateStore?
 #endif
+
+    /// The `ClaudeStateStore` this coordinator reads/writes. Always
+    /// `.shared` in production; overridable in DEBUG builds via
+    /// `claudeStateStoreForTesting` so tests never touch the real
+    /// `~/.ghostties/state/`.
+    private var claudeStateStore: ClaudeStateStore {
+#if DEBUG
+        claudeStateStoreForTesting ?? .shared
+#else
+        .shared
+#endif
+    }
 
     /// Per-session Combine subscription for Claude Code → sidebar name sync.
     /// Subscribes directly to `surface.$title` (see `subscribeNameSync`) —
@@ -1358,7 +1376,7 @@ final class SessionCoordinator: ObservableObject {
     /// since it is called directly from SwiftUI `body`.
     private func reconcileClaudeState() {
         for id in statuses.keys where statuses[id]?.isAlive == true {
-            if ClaudeStateStore.shared.state(for: id)?.state == .idle {
+            if claudeStateStore.state(for: id)?.state == .idle {
                 processingStartTimes.removeValue(forKey: id)
             }
         }
@@ -1388,11 +1406,14 @@ final class SessionCoordinator: ObservableObject {
 
         switch status {
         case .running:
-            // Pure in-memory dictionary lookup — no filesystem access on
-            // this render-path call. `ClaudeStateStore.state(for:)` already
+            // Pure in-memory dictionary lookup, steady-state — no filesystem
+            // access from this render-path call. (The *first* access of
+            // `ClaudeStateStore.shared` does touch the filesystem via its
+            // `init`; `AppDelegate` warms it at launch so that happens before
+            // any render, not here.) `ClaudeStateStore.state(for:)` already
             // filters out `.ended` and stale entries, so `.ended` never
             // reaches this switch; the case exists only for exhaustiveness.
-            if let claudeState = ClaudeStateStore.shared.state(for: sessionId) {
+            if let claudeState = claudeStateStore.state(for: sessionId) {
                 switch claudeState.state {
                 case .busy:
                     if let start = processingStartTimes[sessionId],
@@ -1533,7 +1554,7 @@ final class SessionCoordinator: ObservableObject {
         case .completed, .exited, .killed:
             cachedIndicatorStates?.removeValue(forKey: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
-            ClaudeStateStore.shared.removeState(for: id)
+            claudeStateStore.removeState(for: id)
         case .error:
             cachedIndicatorStates?[id] = .error
             WorkspaceStore.shared.updateIndicatorState(id: id, state: .error)

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -246,17 +246,13 @@ final class SessionCoordinator: ObservableObject {
         var config = Ghostty.SurfaceConfiguration()
         config.workingDirectory = template.workingDirectory ?? project.rootPath
         config.command = finalCommand
-        config.environmentVariables = template.environmentVariables
-        if let taskFilePath = sourceTaskFilePath {
-            config.environmentVariables["GHOSTTIES_TASK_FILE"] = taskFilePath
-        }
-        if let taskId = sourceTaskId {
-            config.environmentVariables["GHOSTTIES_TASK_ID"] = taskId
-        }
-        // Overlay any per-call env vars (e.g. GHOSTTIES_TEMPLATE for review sessions).
-        for (key, value) in extraEnvironment {
-            config.environmentVariables[key] = value
-        }
+        config.environmentVariables = Self.spawnEnvironment(
+            template: template,
+            taskFilePath: sourceTaskFilePath,
+            taskId: sourceTaskId,
+            extra: extraEnvironment,
+            sessionId: session.id
+        )
 
         let newView = Ghostty.SurfaceView(ghosttyApp, baseConfig: config)
         let newTree = SplitTree(view: newView)
@@ -997,6 +993,32 @@ final class SessionCoordinator: ObservableObject {
     nonisolated static func removeLauncherScript(for sessionId: UUID) {
         let path = (launcherScriptDir as NSString).appendingPathComponent("\(sessionId.uuidString).sh")
         try? FileManager.default.removeItem(atPath: path)
+    }
+
+    /// Assemble the environment for a spawned session: the template's own
+    /// vars, the task-context overlays, the `GHOSTTIES_SESSION_ID` stamp
+    /// (every template, including plain shell), and finally any per-call
+    /// overrides so a caller can still win.
+    nonisolated static func spawnEnvironment(
+        template: AgentTemplate,
+        taskFilePath: String?,
+        taskId: String?,
+        extra: [String: String],
+        sessionId: UUID
+    ) -> [String: String] {
+        var result = template.environmentVariables
+        if let taskFilePath {
+            result["GHOSTTIES_TASK_FILE"] = taskFilePath
+        }
+        if let taskId {
+            result["GHOSTTIES_TASK_ID"] = taskId
+        }
+        result["GHOSTTIES_SESSION_ID"] = sessionId.uuidString
+        // Overlay any per-call env vars (e.g. GHOSTTIES_TEMPLATE for review sessions).
+        for (key, value) in extra {
+            result[key] = value
+        }
+        return result
     }
 
     /// Sweep `~/.ghostties/cache/launchers` on app launch for `*.sh` scripts

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -1299,6 +1299,15 @@ final class SessionCoordinator: ObservableObject {
     /// (by the real timer, or synchronously by tests) without waiting on a
     /// `Timer` fire.
     private func performActivityTick() {
+        // Clear any stale `processingStartTimes` entry for a session whose
+        // latest Claude hook event is `idle` (a `Stop`). This is the
+        // 30-minute false-orange fix: `processingStartTimes` is set on
+        // first output and, before this, cleared in exactly one place
+        // (`promptDidBecomeReady`, on OSC 133) which Claude's TUI never
+        // emits — so every Claude session promoted to `.longRunning` 30
+        // minutes after its first output and stayed there forever.
+        reconcileClaudeState()
+
         // Only fire objectWillChange if there are running sessions that could transition.
         let hasRunning = self.statuses.values.contains { $0.isAlive }
         if hasRunning {
@@ -1342,10 +1351,24 @@ final class SessionCoordinator: ObservableObject {
         }
     }
 
+    /// Clear `processingStartTimes` for any alive session whose latest
+    /// Claude hook state is `idle` — the same mutation `promptDidBecomeReady`
+    /// performs on OSC 133. Mutation lives here (called once per 1Hz tick),
+    /// never inside `indicatorState(for:)`, which must stay a pure read
+    /// since it is called directly from SwiftUI `body`.
+    private func reconcileClaudeState() {
+        for id in statuses.keys where statuses[id]?.isAlive == true {
+            if ClaudeStateStore.shared.state(for: id)?.state == .idle {
+                processingStartTimes.removeValue(forKey: id)
+            }
+        }
+    }
+
     /// Compute the view-layer indicator state for a session.
     ///
     /// Combines lifecycle status, output recency, and shell prompt signals into
     /// one of seven visual states. For running sessions:
+    /// - A Claude hook state (if present, not ended, not stale) wins outright
     /// - Recent output → processing (or long-running if 30+ min continuous)
     /// - No recent output + at shell prompt → idle
     /// - No recent output + NOT at prompt + likely prompting → needsAttention
@@ -1365,6 +1388,26 @@ final class SessionCoordinator: ObservableObject {
 
         switch status {
         case .running:
+            // Pure in-memory dictionary lookup — no filesystem access on
+            // this render-path call. `ClaudeStateStore.state(for:)` already
+            // filters out `.ended` and stale entries, so `.ended` never
+            // reaches this switch; the case exists only for exhaustiveness.
+            if let claudeState = ClaudeStateStore.shared.state(for: sessionId) {
+                switch claudeState.state {
+                case .busy:
+                    if let start = processingStartTimes[sessionId],
+                       ContinuousClock.now - start > Self.longRunningThreshold {
+                        return .longRunning
+                    }
+                    return .processing
+                case .idle:
+                    return .idle
+                case .needsInput, .needsPermission:
+                    return .needsAttention
+                case .ended:
+                    break
+                }
+            }
             // Check if the session has produced output recently.
             if let lastOutput = lastOutputTimestamps[sessionId],
                ContinuousClock.now - lastOutput < Self.activityThreshold {
@@ -1490,6 +1533,7 @@ final class SessionCoordinator: ObservableObject {
         case .completed, .exited, .killed:
             cachedIndicatorStates?.removeValue(forKey: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
+            ClaudeStateStore.shared.removeState(for: id)
         case .error:
             cachedIndicatorStates?[id] = .error
             WorkspaceStore.shared.updateIndicatorState(id: id, state: .error)

--- a/macos/Sources/Features/Ghostties/TaskFileWatcher.swift
+++ b/macos/Sources/Features/Ghostties/TaskFileWatcher.swift
@@ -126,13 +126,35 @@ final class TaskFileWatcher {
         pendingReload = nil
         retryItem?.cancel()
         retryItem = nil
+        // Invariant: exactly one path ever closes `fd`, and `fd` is cleared
+        // the moment ownership of the close passes elsewhere. `src.cancel()`
+        // hands the close to the cancel handler (which captured the
+        // descriptor by value), so we must clear `fd` here too -- otherwise
+        // a later `stopInternal()` call (source == nil, stale fd) closes the
+        // same descriptor a second time after the OS has already reissued
+        // it to something unrelated. Do not remove this without re-reading
+        // the cancel handler's capture semantics above.
         if let src = source {
             src.cancel()
             source = nil
+            fd = -1
         } else if fd >= 0 {
             close(fd)
             fd = -1
         }
         isRunning = false
     }
+
+#if DEBUG
+    /// Test-only: drains the watcher's serial queue (twice, to also flush
+    /// anything a just-completed block enqueued, e.g. a source's cancel
+    /// handler) and returns the resulting `fd`. Exists so tests can prove
+    /// the single-owner-close invariant in `stopInternal()` without
+    /// guessing at fd-reuse timing.
+    func debugDrainAndReadFD() -> Int32 {
+        queue.sync {}
+        queue.sync {}
+        return queue.sync { fd }
+    }
+#endif
 }

--- a/macos/Sources/Features/Ghostties/TaskFileWatcher.swift
+++ b/macos/Sources/Features/Ghostties/TaskFileWatcher.swift
@@ -83,11 +83,13 @@ final class TaskFileWatcher {
             self.scheduleDebouncedFire()
         }
 
-        src.setCancelHandler { [weak self] in
-            guard let self = self else { return }
-            if self.fd >= 0 {
-                close(self.fd)
-                self.fd = -1
+        src.setCancelHandler { [descriptor] in
+            // Capture the fd by value, not `[weak self]`: `deinit` ->
+            // `stopInternal()` -> `src.cancel()` runs while `self` is already
+            // deallocating, so a weak lookup here would find nil and leak
+            // the descriptor.
+            if descriptor >= 0 {
+                close(descriptor)
             }
         }
 

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -176,6 +176,7 @@ final class WorkspaceStore: ObservableObject {
 
         // Seed bundled presets to ~/.ghostties/presets/ on first launch.
         PresetLoader.seedIfNeeded()
+        HookInstaller.seedIfNeeded()
 
         // Load file-based presets from ~/.ghostties/presets/ and sanitize them.
         let presetsResult = PresetLoader.loadPresetsResult()

--- a/macos/Tests/Ghostties/ClaudeStateStoreTests.swift
+++ b/macos/Tests/Ghostties/ClaudeStateStoreTests.swift
@@ -1,0 +1,144 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+@testable import Ghostty
+
+/// Coverage for `ClaudeStateStore.derive(from:)` (pure mapping) and
+/// `ClaudeStateStore`'s staleness/robustness rules. Fixtures are JSON
+/// strings built from the exact key sets measured in
+/// `docs/plans/session-row-status/gate-evidence.md`, decoded through the
+/// real `ClaudeHookWrapper`/`ClaudeHookPayload` types — never a
+/// hand-written guess at the decoded shape.
+@MainActor
+final class ClaudeStateStoreTests: XCTestCase {
+
+    // MARK: - Fixture helpers
+
+    private func wrapper(_ json: String) -> ClaudeHookWrapper {
+        guard let decoded = try? JSONDecoder().decode(ClaudeHookWrapper.self, from: Data(json.utf8)) else {
+            XCTFail("fixture JSON failed to decode as ClaudeHookWrapper: \(json)")
+            fatalError("unreachable after XCTFail")
+        }
+        return decoded
+    }
+
+    private func fixture(ghosttiesSessionId: String = "9B2A6E10-1234-4A11-8B00-000000000001",
+                          updatedAt: Int = 1_700_000_000,
+                          hook: String) -> ClaudeHookWrapper {
+        wrapper(#"""
+        {"ghosttiesSessionId":"\#(ghosttiesSessionId)","updatedAt":\#(updatedAt),"hook":\#(hook)}
+        """#)
+    }
+
+    // MARK: - derive(from:) mapping
+
+    func testDerivesBusyFromPreToolUse() {
+        let w = fixture(hook: #"""
+        {"cwd":"/Users/sean/proj","hook_event_name":"PreToolUse","effort":"medium","permission_mode":"default","prompt_id":"p1","session_id":"claude-1","tool_input":{},"tool_name":"Bash","tool_use_id":"tu-1","transcript_path":"/tmp/t.jsonl"}
+        """#)
+        let state = ClaudeStateStore.derive(from: w)
+        XCTAssertEqual(state?.state, .busy)
+        XCTAssertEqual(state?.claudeSessionId, "claude-1")
+        XCTAssertEqual(state?.cwd, "/Users/sean/proj")
+    }
+
+    func testDerivesIdleFromStop() {
+        let w = fixture(hook: #"""
+        {"background_tasks":[],"cwd":"/tmp","effort":"medium","hook_event_name":"Stop","last_assistant_message":"done","permission_mode":"default","prompt_id":"p1","session_crons":[],"session_id":"claude-2","stop_hook_active":false,"transcript_path":"/tmp/t.jsonl"}
+        """#)
+        let state = ClaudeStateStore.derive(from: w)
+        XCTAssertEqual(state?.state, .idle)
+    }
+
+    func testDerivesNeedsPermissionFromPermissionRequest() {
+        let w = fixture(hook: #"""
+        {"cwd":"/tmp","effort":"medium","hook_event_name":"PermissionRequest","permission_mode":"default","permission_suggestions":[],"prompt_id":"p1","session_id":"claude-3","tool_input":{},"tool_name":"Write","transcript_path":"/tmp/t.jsonl"}
+        """#)
+        let state = ClaudeStateStore.derive(from: w)
+        XCTAssertEqual(state?.state, .needsPermission)
+        XCTAssertEqual(state?.structuredPrompt?.toolName, "Write")
+        XCTAssertNil(
+            state?.structuredPrompt?.toolUseId,
+            "PermissionRequest carries no tool_use_id, and the preceding PreToolUse's id is already overwritten (last-event-wins)"
+        )
+    }
+
+    func testDerivesNeedsPermissionFromNotificationPermissionPrompt() {
+        let w = fixture(hook: #"""
+        {"cwd":"/tmp","hook_event_name":"Notification","message":"needs permission","notification_type":"permission_prompt","prompt_id":"p1","session_id":"claude-4","transcript_path":"/tmp/t.jsonl"}
+        """#)
+        let state = ClaudeStateStore.derive(from: w)
+        XCTAssertEqual(state?.state, .needsPermission)
+    }
+
+    func testDerivesNeedsInputFromNotificationIdlePrompt() {
+        let w = fixture(hook: #"""
+        {"cwd":"/tmp","hook_event_name":"Notification","message":"idle","notification_type":"idle_prompt","prompt_id":"p1","session_id":"claude-5","transcript_path":"/tmp/t.jsonl"}
+        """#)
+        let state = ClaudeStateStore.derive(from: w)
+        XCTAssertEqual(state?.state, .needsInput)
+    }
+
+    func testDerivesEndedFromSessionEnd() {
+        let w = fixture(hook: #"""
+        {"cwd":"/tmp","hook_event_name":"SessionEnd","prompt_id":"p1","reason":"other","session_id":"claude-6","transcript_path":"/tmp/t.jsonl"}
+        """#)
+        let state = ClaudeStateStore.derive(from: w)
+        XCTAssertEqual(state?.state, .ended)
+    }
+
+    func testUnknownNotificationTypeIsIgnored() {
+        let w = fixture(hook: #"""
+        {"cwd":"/tmp","hook_event_name":"Notification","message":"?","notification_type":"something_unmapped","prompt_id":"p1","session_id":"claude-7","transcript_path":"/tmp/t.jsonl"}
+        """#)
+        XCTAssertNil(ClaudeStateStore.derive(from: w))
+    }
+
+    // MARK: - Store-level staleness / robustness (real directory, temp dir only)
+
+    private func makeTempStore() -> (store: ClaudeStateStore, dir: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeStateStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let store = ClaudeStateStore(directoryURL: dir)
+        return (store, dir)
+    }
+
+    private func writeFixtureFile(id: UUID, dir: URL, updatedAt: Int, hookEventName: String = "Stop") {
+        let json = #"""
+        {"ghosttiesSessionId":"\#(id.uuidString)","updatedAt":\#(updatedAt),"hook":{"cwd":"/tmp","hook_event_name":"\#(hookEventName)","session_id":"claude-x"}}
+        """#
+        try? json.write(to: dir.appendingPathComponent("\(id.uuidString).json"), atomically: true, encoding: .utf8)
+    }
+
+    func testStateOlderThanThirtyMinutesIsIgnored() {
+        let (store, dir) = makeTempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let id = UUID()
+        let old = Int(Date().addingTimeInterval(-40 * 60).timeIntervalSince1970)
+        writeFixtureFile(id: id, dir: dir, updatedAt: old)
+        store.refreshForTesting()
+
+        XCTAssertNil(store.state(for: id), "a state file older than 30 minutes must be ignored, falling through to today's heuristics")
+    }
+
+    func testMalformedFileDoesNotBreakRefresh() {
+        let (store, dir) = makeTempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let goodId = UUID()
+        writeFixtureFile(id: goodId, dir: dir, updatedAt: Int(Date().timeIntervalSince1970))
+
+        let badId = UUID()
+        try? "{ not valid json at all".write(
+            to: dir.appendingPathComponent("\(badId.uuidString).json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        store.refreshForTesting()
+
+        XCTAssertNotNil(store.state(for: goodId), "a malformed sibling file must not prevent a valid file from being decoded")
+        XCTAssertNil(store.state(for: badId))
+    }
+}

--- a/macos/Tests/Ghostties/ClaudeStateStoreTests.swift
+++ b/macos/Tests/Ghostties/ClaudeStateStoreTests.swift
@@ -144,4 +144,26 @@ final class ClaudeStateStoreTests: XCTestCase {
         XCTAssertNotNil(store.state(for: goodId), "a malformed sibling file must not prevent a valid file from being decoded")
         XCTAssertNil(store.state(for: badId))
     }
+
+    /// Coverage for `refresh()`'s failure branch (G5): a mode-drifted
+    /// directory that fails `contentsOfDirectory` must self-heal via
+    /// `ensureDirectory()` rather than leaving `states` permanently wedged.
+    /// `chmod 000` on our own temp dir deterministically denies even the
+    /// owner read access, so this doesn't depend on filesystem timing.
+    func testRefreshSelfHealsAModeDriftedDirectory() throws {
+        let (store, dir) = makeTempStore()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: dir.path)
+
+        store.refreshForTesting()
+
+        let mode = (try? FileManager.default.attributesOfItem(atPath: dir.path))?[.posixPermissions] as? NSNumber
+        XCTAssertEqual(mode?.uint16Value, 0o700,
+            "a directory that fails to list must be repaired back to 0700 by the failure-path ensureDirectory() call")
+        XCTAssertNil(store.state(for: UUID()), "states must reset to empty on the failure path, not retain stale data")
+    }
 }

--- a/macos/Tests/Ghostties/ClaudeStateStoreTests.swift
+++ b/macos/Tests/Ghostties/ClaudeStateStoreTests.swift
@@ -14,17 +14,20 @@ final class ClaudeStateStoreTests: XCTestCase {
 
     // MARK: - Fixture helpers
 
-    private func wrapper(_ json: String) -> ClaudeHookWrapper {
+    /// Returns nil (after an `XCTFail`) rather than trapping, so one bad
+    /// fixture fails the single test that used it instead of crashing the
+    /// whole `xcodebuild test` run with no result bundle.
+    private func wrapper(_ json: String) -> ClaudeHookWrapper? {
         guard let decoded = try? JSONDecoder().decode(ClaudeHookWrapper.self, from: Data(json.utf8)) else {
             XCTFail("fixture JSON failed to decode as ClaudeHookWrapper: \(json)")
-            fatalError("unreachable after XCTFail")
+            return nil
         }
         return decoded
     }
 
     private func fixture(ghosttiesSessionId: String = "9B2A6E10-1234-4A11-8B00-000000000001",
                           updatedAt: Int = 1_700_000_000,
-                          hook: String) -> ClaudeHookWrapper {
+                          hook: String) -> ClaudeHookWrapper? {
         wrapper(#"""
         {"ghosttiesSessionId":"\#(ghosttiesSessionId)","updatedAt":\#(updatedAt),"hook":\#(hook)}
         """#)
@@ -33,9 +36,9 @@ final class ClaudeStateStoreTests: XCTestCase {
     // MARK: - derive(from:) mapping
 
     func testDerivesBusyFromPreToolUse() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"cwd":"/Users/sean/proj","hook_event_name":"PreToolUse","effort":"medium","permission_mode":"default","prompt_id":"p1","session_id":"claude-1","tool_input":{},"tool_name":"Bash","tool_use_id":"tu-1","transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         let state = ClaudeStateStore.derive(from: w)
         XCTAssertEqual(state?.state, .busy)
         XCTAssertEqual(state?.claudeSessionId, "claude-1")
@@ -43,17 +46,17 @@ final class ClaudeStateStoreTests: XCTestCase {
     }
 
     func testDerivesIdleFromStop() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"background_tasks":[],"cwd":"/tmp","effort":"medium","hook_event_name":"Stop","last_assistant_message":"done","permission_mode":"default","prompt_id":"p1","session_crons":[],"session_id":"claude-2","stop_hook_active":false,"transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         let state = ClaudeStateStore.derive(from: w)
         XCTAssertEqual(state?.state, .idle)
     }
 
     func testDerivesNeedsPermissionFromPermissionRequest() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"cwd":"/tmp","effort":"medium","hook_event_name":"PermissionRequest","permission_mode":"default","permission_suggestions":[],"prompt_id":"p1","session_id":"claude-3","tool_input":{},"tool_name":"Write","transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         let state = ClaudeStateStore.derive(from: w)
         XCTAssertEqual(state?.state, .needsPermission)
         XCTAssertEqual(state?.structuredPrompt?.toolName, "Write")
@@ -64,33 +67,33 @@ final class ClaudeStateStoreTests: XCTestCase {
     }
 
     func testDerivesNeedsPermissionFromNotificationPermissionPrompt() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"cwd":"/tmp","hook_event_name":"Notification","message":"needs permission","notification_type":"permission_prompt","prompt_id":"p1","session_id":"claude-4","transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         let state = ClaudeStateStore.derive(from: w)
         XCTAssertEqual(state?.state, .needsPermission)
     }
 
     func testDerivesNeedsInputFromNotificationIdlePrompt() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"cwd":"/tmp","hook_event_name":"Notification","message":"idle","notification_type":"idle_prompt","prompt_id":"p1","session_id":"claude-5","transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         let state = ClaudeStateStore.derive(from: w)
         XCTAssertEqual(state?.state, .needsInput)
     }
 
     func testDerivesEndedFromSessionEnd() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"cwd":"/tmp","hook_event_name":"SessionEnd","prompt_id":"p1","reason":"other","session_id":"claude-6","transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         let state = ClaudeStateStore.derive(from: w)
         XCTAssertEqual(state?.state, .ended)
     }
 
     func testUnknownNotificationTypeIsIgnored() {
-        let w = fixture(hook: #"""
+        guard let w = fixture(hook: #"""
         {"cwd":"/tmp","hook_event_name":"Notification","message":"?","notification_type":"something_unmapped","prompt_id":"p1","session_id":"claude-7","transcript_path":"/tmp/t.jsonl"}
-        """#)
+        """#) else { return }
         XCTAssertNil(ClaudeStateStore.derive(from: w))
     }
 

--- a/macos/Tests/Ghostties/HookInstallerTests.swift
+++ b/macos/Tests/Ghostties/HookInstallerTests.swift
@@ -58,11 +58,14 @@ struct HookInstallerTests {
 
         let destPath = (destDir as NSString).appendingPathComponent(HookInstaller.scriptName)
         try "tampered".write(toFile: destPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: destPath)
 
         #expect(HookInstaller.seed(from: sourceURL, into: destDir, version: 2))
 
         let contents = try String(contentsOfFile: destPath, encoding: .utf8)
         #expect(contents == "#!/bin/sh\necho original\n")
+        let permissions = try FileManager.default.attributesOfItem(atPath: destPath)[.posixPermissions] as? Int
+        #expect(permissions == 0o700)
     }
 
     @Test

--- a/macos/Tests/Ghostties/HookInstallerTests.swift
+++ b/macos/Tests/Ghostties/HookInstallerTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Ghostty
+
+/// Coverage for `HookInstaller.seed(from:into:version:)` (session-row-status
+/// spec, Phase 1). Exercises the real seeding logic against a temp directory
+/// and a temp source script, without needing `Bundle.main`.
+struct HookInstallerTests {
+
+    /// Write a fixture "source" hook script to a fresh temp file and return
+    /// its URL. Caller owns cleanup.
+    private func makeSourceScript(contents: String = "#!/bin/sh\nexit 0\n") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("HookInstallerTests-src-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(HookInstaller.scriptName)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func makeDestDirectory() -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("HookInstallerTests-dest-\(UUID().uuidString)")
+        return dir.path
+    }
+
+    @Test
+    func testSeedWritesExecutableHookScript() throws {
+        let sourceURL = try makeSourceScript()
+        defer { try? FileManager.default.removeItem(at: sourceURL.deletingLastPathComponent()) }
+        let destDir = makeDestDirectory()
+        defer { try? FileManager.default.removeItem(atPath: destDir) }
+
+        let seeded = HookInstaller.seed(from: sourceURL, into: destDir, version: 1)
+        #expect(seeded)
+
+        let destPath = (destDir as NSString).appendingPathComponent(HookInstaller.scriptName)
+        #expect(FileManager.default.fileExists(atPath: destPath))
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: destPath)
+        let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        #expect(permissions == 0o700)
+
+        let versionPath = (destDir as NSString).appendingPathComponent(".seed-version")
+        let versionString = try String(contentsOfFile: versionPath, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(versionString == "1")
+    }
+
+    @Test
+    func testSeedOverwritesOnVersionBump() throws {
+        let sourceURL = try makeSourceScript(contents: "#!/bin/sh\necho original\n")
+        defer { try? FileManager.default.removeItem(at: sourceURL.deletingLastPathComponent()) }
+        let destDir = makeDestDirectory()
+        defer { try? FileManager.default.removeItem(atPath: destDir) }
+
+        #expect(HookInstaller.seed(from: sourceURL, into: destDir, version: 1))
+
+        let destPath = (destDir as NSString).appendingPathComponent(HookInstaller.scriptName)
+        try "tampered".write(toFile: destPath, atomically: true, encoding: .utf8)
+
+        #expect(HookInstaller.seed(from: sourceURL, into: destDir, version: 2))
+
+        let contents = try String(contentsOfFile: destPath, encoding: .utf8)
+        #expect(contents == "#!/bin/sh\necho original\n")
+    }
+
+    @Test
+    func testSeedIsNoOpAtSameVersion() throws {
+        let sourceURL = try makeSourceScript(contents: "#!/bin/sh\necho original\n")
+        defer { try? FileManager.default.removeItem(at: sourceURL.deletingLastPathComponent()) }
+        let destDir = makeDestDirectory()
+        defer { try? FileManager.default.removeItem(atPath: destDir) }
+
+        #expect(HookInstaller.seed(from: sourceURL, into: destDir, version: 1))
+
+        let destPath = (destDir as NSString).appendingPathComponent(HookInstaller.scriptName)
+        try "tampered".write(toFile: destPath, atomically: true, encoding: .utf8)
+
+        #expect(!HookInstaller.seed(from: sourceURL, into: destDir, version: 1))
+
+        let contents = try String(contentsOfFile: destPath, encoding: .utf8)
+        #expect(contents == "tampered")
+    }
+}

--- a/macos/Tests/Ghostties/HookInstallerTests.swift
+++ b/macos/Tests/Ghostties/HookInstallerTests.swift
@@ -82,4 +82,26 @@ struct HookInstallerTests {
         let contents = try String(contentsOfFile: destPath, encoding: .utf8)
         #expect(contents == "tampered")
     }
+
+    @Test
+    func testSeedRestoresMissingScriptAtSameVersion() throws {
+        let sourceURL = try makeSourceScript(contents: "#!/bin/sh\necho original\n")
+        defer { try? FileManager.default.removeItem(at: sourceURL.deletingLastPathComponent()) }
+        let destDir = makeDestDirectory()
+        defer { try? FileManager.default.removeItem(atPath: destDir) }
+
+        #expect(HookInstaller.seed(from: sourceURL, into: destDir, version: 1))
+
+        let destPath = (destDir as NSString).appendingPathComponent(HookInstaller.scriptName)
+        try FileManager.default.removeItem(atPath: destPath)
+        #expect(!FileManager.default.fileExists(atPath: destPath))
+
+        // Marker still reads version 1 — reseeding at the same version must
+        // still restore the missing script, not treat it as already seeded.
+        #expect(HookInstaller.seed(from: sourceURL, into: destDir, version: 1))
+
+        #expect(FileManager.default.fileExists(atPath: destPath))
+        let contents = try String(contentsOfFile: destPath, encoding: .utf8)
+        #expect(contents == "#!/bin/sh\necho original\n")
+    }
 }

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -366,6 +366,13 @@ final class RecentsListViewTests: XCTestCase {
         let sessions = [stopped]
 
         let coordinator = SessionCoordinator()
+        // closeSession -> setStatus(.killed) reaches claudeStateStore.removeState(for:);
+        // point it at a temp directory so this never touches Sean's real
+        // ~/.ghostties/state/ (matches SessionCoordinatorIndicatorCacheTests).
+        let claudeStateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecentsListViewTests-\(UUID().uuidString)", isDirectory: true)
+        coordinator.claudeStateStoreForTesting = ClaudeStateStore(directoryURL: claudeStateDir)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
         coordinator.seedEmptySessionTreeForTesting(id: stopped.id)
         XCTAssertTrue(coordinator.hasLiveSurface(id: stopped.id), "sanity: session has a live surface right after starting")
 

--- a/macos/Tests/Ghostties/SessionCoordinatorClaudeStateTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorClaudeStateTests.swift
@@ -4,16 +4,31 @@ import XCTest
 @testable import Ghostty
 
 /// Coverage for the Phase 2 read: `SessionCoordinator.indicatorState(for:)`
-/// consulting `ClaudeStateStore.shared`, and `performActivityTick()`'s
+/// consulting its `claudeStateStore`, and `performActivityTick()`'s
 /// `reconcileClaudeState()` clearing `processingStartTimes` on a hook
 /// `idle`. Follows the injection pattern in
 /// `SessionCoordinatorIndicatorCacheTests.swift`.
 ///
-/// Seeds go into `ClaudeStateStore.shared` via the in-memory
-/// `seedStateForTesting`/`clearStateForTesting` seams — never through the
-/// filesystem, so these tests never touch the real `~/.ghostties/state/`.
+/// Each test's `SessionCoordinator` is pointed at its own temp-directory
+/// `ClaudeStateStore` via `claudeStateStoreForTesting`, seeded in-memory via
+/// `seedStateForTesting` — never `.shared`, which reads/writes the real
+/// `~/.ghostties/state/` that live sessions are writing to right now.
+///
+/// `seedStateForTesting` mutates the store's in-memory dictionary directly;
+/// it is not durable across a `refresh()`. `refresh()` does a full rebuild
+/// (`states = newStates`), so if a test body ever becomes `async` and lets
+/// the main runloop turn between a seed and its assertion, a watcher-driven
+/// refresh of the (empty) temp directory would wipe the seed. Every test
+/// here is synchronous today, so nothing preempts — keep it that way, or
+/// re-seed after any awaited gap.
 @MainActor
 final class SessionCoordinatorClaudeStateTests: XCTestCase {
+
+    private func makeStore() -> (store: ClaudeStateStore, dir: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionCoordinatorClaudeStateTests-\(UUID().uuidString)", isDirectory: true)
+        return (ClaudeStateStore(directoryURL: dir), dir)
+    }
 
     private func claudeState(
         id: UUID,
@@ -31,19 +46,21 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
         )
     }
 
-    private func teardown(_ id: UUID) {
+    private func teardown(_ id: UUID, dir: URL) {
         WorkspaceStore.shared.removeSessionStatus(id: id)
         WorkspaceStore.shared.removeIndicatorState(id: id)
-        ClaudeStateStore.shared.clearStateForTesting(id: id)
+        try? FileManager.default.removeItem(at: dir)
     }
 
     func testHookBusyMapsToProcessing() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
-        addTeardownBlock { self.teardown(id) }
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
 
         coordinator.seedRunningSessionForTesting(id: id)
-        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .busy))
+        store.seedStateForTesting(claudeState(id: id, kind: .busy))
         coordinator.runActivityTickForTesting()
 
         XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .processing)
@@ -51,13 +68,15 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
 
     func testHookIdleMapsToIdle() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
-        addTeardownBlock { self.teardown(id) }
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
 
         // Recent output would resolve to .processing under today's
         // heuristics alone — the hook idle state must win.
         coordinator.seedRunningSessionForTesting(id: id)
-        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .idle))
+        store.seedStateForTesting(claudeState(id: id, kind: .idle))
         coordinator.runActivityTickForTesting()
 
         XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .idle)
@@ -65,11 +84,13 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
 
     func testHookNeedsInputMapsToNeedsAttention() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
-        addTeardownBlock { self.teardown(id) }
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
 
         coordinator.seedRunningSessionForTesting(id: id)
-        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .needsInput))
+        store.seedStateForTesting(claudeState(id: id, kind: .needsInput))
         coordinator.runActivityTickForTesting()
 
         XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .needsAttention)
@@ -77,11 +98,13 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
 
     func testHookNeedsPermissionMapsToNeedsAttention() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
-        addTeardownBlock { self.teardown(id) }
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
 
         coordinator.seedRunningSessionForTesting(id: id)
-        ClaudeStateStore.shared.seedStateForTesting(
+        store.seedStateForTesting(
             claudeState(id: id, kind: .needsPermission, toolName: "Write", toolUseId: nil)
         )
         coordinator.runActivityTickForTesting()
@@ -95,8 +118,10 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
     /// stay `.longRunning` forever, even after a fresh `busy` event.
     func testHookIdleClearsProcessingStartTime() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
-        addTeardownBlock { self.teardown(id) }
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
 
         // Seed a session that has been "processing" continuously for far
         // longer than the 1800s long-running threshold, as though it had
@@ -108,11 +133,11 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
         )
 
         // A Stop event lands: the hook says idle.
-        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .idle))
+        store.seedStateForTesting(claudeState(id: id, kind: .idle))
         coordinator.runActivityTickForTesting()
 
         // A fresh turn starts: the hook says busy again.
-        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .busy))
+        store.seedStateForTesting(claudeState(id: id, kind: .busy))
         coordinator.runActivityTickForTesting()
 
         XCTAssertEqual(
@@ -127,12 +152,41 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
     /// heuristic.
     func testSessionWithNoStateFileKeepsExistingHeuristics() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
-        addTeardownBlock { self.teardown(id) }
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
 
         coordinator.seedRunningSessionForTesting(id: id)
         coordinator.runActivityTickForTesting()
 
         XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .processing)
+    }
+
+    /// F5: `reconcileClaudeState()`'s partner promotion inside
+    /// `indicatorState(for:)` — a hook `busy` whose `processingStartTimes`
+    /// entry already exceeds the long-running threshold must resolve
+    /// `.longRunning`, not `.processing`. No existing test reached this:
+    /// `testHookIdleClearsProcessingStartTime` clears the value on the idle
+    /// tick before the busy read, and every other test above never sets
+    /// `processingStartTimes` at all.
+    func testHookBusyPastThresholdMapsToLongRunning() {
+        let id = UUID()
+        let (store, dir) = makeStore()
+        let coordinator = SessionCoordinator()
+        coordinator.claudeStateStoreForTesting = store
+        addTeardownBlock { self.teardown(id, dir: dir) }
+
+        // Seed a session already past the 1800s long-running threshold, with
+        // no intervening idle tick to clear processingStartTimes.
+        coordinator.seedIndicatorStateForTesting(
+            id: id,
+            lastOutputSecondsAgo: 0,
+            processingStartSecondsAgo: 2000
+        )
+        store.seedStateForTesting(claudeState(id: id, kind: .busy))
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .longRunning)
     }
 }

--- a/macos/Tests/Ghostties/SessionCoordinatorClaudeStateTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorClaudeStateTests.swift
@@ -6,13 +6,16 @@ import XCTest
 /// Coverage for the Phase 2 read: `SessionCoordinator.indicatorState(for:)`
 /// consulting its `claudeStateStore`, and `performActivityTick()`'s
 /// `reconcileClaudeState()` clearing `processingStartTimes` on a hook
-/// `idle`. Follows the injection pattern in
-/// `SessionCoordinatorIndicatorCacheTests.swift`.
+/// `idle`.
 ///
-/// Each test's `SessionCoordinator` is pointed at its own temp-directory
-/// `ClaudeStateStore` via `claudeStateStoreForTesting`, seeded in-memory via
-/// `seedStateForTesting` — never `.shared`, which reads/writes the real
-/// `~/.ghostties/state/` that live sessions are writing to right now.
+/// Each test in *this file*'s `SessionCoordinator` is pointed at its own
+/// temp-directory `ClaudeStateStore` via `claudeStateStoreForTesting`, seeded
+/// in-memory via `seedStateForTesting` — never `.shared`, which reads/writes
+/// the real `~/.ghostties/state/` that live sessions are writing to right
+/// now. `SessionCoordinatorIndicatorCacheTests.swift` and
+/// `SessionCoordinatorIndicatorStateTests.swift` follow the same injection
+/// pattern for their own `SessionCoordinator`/`WorkspaceStore` instances —
+/// this comment describes this file only; check each file for its own seam.
 ///
 /// `seedStateForTesting` mutates the store's in-memory dictionary directly;
 /// it is not durable across a `refresh()`. `refresh()` does a full rebuild
@@ -59,7 +62,13 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
         coordinator.claudeStateStoreForTesting = store
         addTeardownBlock { self.teardown(id, dir: dir) }
 
-        coordinator.seedRunningSessionForTesting(id: id)
+        // Deliberately no recent output seeded (unlike
+        // `seedRunningSessionForTesting`): with no `lastOutputTimestamps`
+        // entry, `isAtPrompt` false, and no surface title, the pre-Phase-2
+        // fall-through resolves `.waiting`, not `.processing` — so this only
+        // passes if the hook busy read is what actually produced
+        // `.processing`.
+        coordinator.seedIndicatorStateForTesting(id: id)
         store.seedStateForTesting(claudeState(id: id, kind: .busy))
         coordinator.runActivityTickForTesting()
 
@@ -178,10 +187,14 @@ final class SessionCoordinatorClaudeStateTests: XCTestCase {
         addTeardownBlock { self.teardown(id, dir: dir) }
 
         // Seed a session already past the 1800s long-running threshold, with
-        // no intervening idle tick to clear processingStartTimes.
+        // no intervening idle tick to clear processingStartTimes. Deliberately
+        // no recent output (`lastOutputSecondsAgo` omitted): with no
+        // `lastOutputTimestamps` entry the pre-Phase-2 fall-through resolves
+        // `.waiting`, not `.longRunning` — so this only passes if the hook
+        // busy + past-threshold read is what actually produced
+        // `.longRunning`.
         coordinator.seedIndicatorStateForTesting(
             id: id,
-            lastOutputSecondsAgo: 0,
             processingStartSecondsAgo: 2000
         )
         store.seedStateForTesting(claudeState(id: id, kind: .busy))

--- a/macos/Tests/Ghostties/SessionCoordinatorClaudeStateTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorClaudeStateTests.swift
@@ -1,0 +1,138 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+@testable import Ghostty
+
+/// Coverage for the Phase 2 read: `SessionCoordinator.indicatorState(for:)`
+/// consulting `ClaudeStateStore.shared`, and `performActivityTick()`'s
+/// `reconcileClaudeState()` clearing `processingStartTimes` on a hook
+/// `idle`. Follows the injection pattern in
+/// `SessionCoordinatorIndicatorCacheTests.swift`.
+///
+/// Seeds go into `ClaudeStateStore.shared` via the in-memory
+/// `seedStateForTesting`/`clearStateForTesting` seams — never through the
+/// filesystem, so these tests never touch the real `~/.ghostties/state/`.
+@MainActor
+final class SessionCoordinatorClaudeStateTests: XCTestCase {
+
+    private func claudeState(
+        id: UUID,
+        kind: ClaudeState.Kind,
+        toolName: String? = nil,
+        toolUseId: String? = nil
+    ) -> ClaudeState {
+        ClaudeState(
+            ghosttiesSessionId: id,
+            claudeSessionId: "claude-test",
+            cwd: "/tmp",
+            state: kind,
+            structuredPrompt: toolName.map { StructuredPrompt(toolName: $0, toolUseId: toolUseId) },
+            updatedAt: Date()
+        )
+    }
+
+    private func teardown(_ id: UUID) {
+        WorkspaceStore.shared.removeSessionStatus(id: id)
+        WorkspaceStore.shared.removeIndicatorState(id: id)
+        ClaudeStateStore.shared.clearStateForTesting(id: id)
+    }
+
+    func testHookBusyMapsToProcessing() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock { self.teardown(id) }
+
+        coordinator.seedRunningSessionForTesting(id: id)
+        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .busy))
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .processing)
+    }
+
+    func testHookIdleMapsToIdle() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock { self.teardown(id) }
+
+        // Recent output would resolve to .processing under today's
+        // heuristics alone — the hook idle state must win.
+        coordinator.seedRunningSessionForTesting(id: id)
+        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .idle))
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .idle)
+    }
+
+    func testHookNeedsInputMapsToNeedsAttention() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock { self.teardown(id) }
+
+        coordinator.seedRunningSessionForTesting(id: id)
+        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .needsInput))
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .needsAttention)
+    }
+
+    func testHookNeedsPermissionMapsToNeedsAttention() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock { self.teardown(id) }
+
+        coordinator.seedRunningSessionForTesting(id: id)
+        ClaudeStateStore.shared.seedStateForTesting(
+            claudeState(id: id, kind: .needsPermission, toolName: "Write", toolUseId: nil)
+        )
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .needsAttention)
+    }
+
+    /// The false-orange regression test. Without `reconcileClaudeState()`
+    /// clearing `processingStartTimes` on a hook `idle`, a session that was
+    /// promoted to `.longRunning` before its hook ever went `idle` would
+    /// stay `.longRunning` forever, even after a fresh `busy` event.
+    func testHookIdleClearsProcessingStartTime() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock { self.teardown(id) }
+
+        // Seed a session that has been "processing" continuously for far
+        // longer than the 1800s long-running threshold, as though it had
+        // been promoted to .longRunning before hook coverage existed.
+        coordinator.seedIndicatorStateForTesting(
+            id: id,
+            lastOutputSecondsAgo: 0,
+            processingStartSecondsAgo: 2000
+        )
+
+        // A Stop event lands: the hook says idle.
+        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .idle))
+        coordinator.runActivityTickForTesting()
+
+        // A fresh turn starts: the hook says busy again.
+        ClaudeStateStore.shared.seedStateForTesting(claudeState(id: id, kind: .busy))
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(
+            WorkspaceStore.shared.globalIndicatorStates[id],
+            .processing,
+            "processingStartTimes must be cleared on a hook idle, so a subsequent busy read is .processing, not .longRunning"
+        )
+    }
+
+    /// A session with no Claude state file must behave exactly as it did
+    /// before this phase: byte-identical fallback to the output-recency
+    /// heuristic.
+    func testSessionWithNoStateFileKeepsExistingHeuristics() {
+        let id = UUID()
+        let coordinator = SessionCoordinator()
+        addTeardownBlock { self.teardown(id) }
+
+        coordinator.seedRunningSessionForTesting(id: id)
+        coordinator.runActivityTickForTesting()
+
+        XCTAssertEqual(WorkspaceStore.shared.globalIndicatorStates[id], .processing)
+    }
+}

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorCacheTests.swift
@@ -14,16 +14,33 @@ import XCTest
 @MainActor
 final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
 
+    /// Every `SessionCoordinator` here must be pointed at its own
+    /// temp-directory `ClaudeStateStore` via `claudeStateStoreForTesting` —
+    /// never `.shared`, which reads/writes the real `~/.ghostties/state/`
+    /// that live sessions are writing to right now. `closeSession` and
+    /// `setStatusForTesting(.exited/.killed, ...)` both reach
+    /// `claudeStateStore.removeState(for:)`, and `indicatorState(for:)` on a
+    /// `.running` session reaches `claudeStateStore.state(for:)`. Follows
+    /// the pattern in `SessionCoordinatorClaudeStateTests.swift`.
+    private func makeStore() -> (store: ClaudeStateStore, dir: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionCoordinatorIndicatorCacheTests-\(UUID().uuidString)", isDirectory: true)
+        return (ClaudeStateStore(directoryURL: dir), dir)
+    }
+
     /// A `.killed` session's cached indicator state must not survive its own
     /// close: the 1Hz tick only recomputes indicators for sessions where
     /// `status.isAlive`, so once a session goes terminal nothing else will
     /// ever refresh a stale cached value.
     func testClosedSessionIndicatorStateIsInactiveNotStale() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
+        coordinator.claudeStateStoreForTesting = store
         addTeardownBlock {
             WorkspaceStore.shared.removeSessionStatus(id: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
+            try? FileManager.default.removeItem(at: dir)
         }
 
         // Seed a live-looking indicator, mirroring what the 1Hz tick would
@@ -51,10 +68,13 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
     /// `handleSurfaceClose` without a live GhosttyKit surface.
     func testExitedSessionIndicatorStateIsInactive() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
+        coordinator.claudeStateStoreForTesting = store
         addTeardownBlock {
             WorkspaceStore.shared.removeSessionStatus(id: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
+            try? FileManager.default.removeItem(at: dir)
         }
 
         WorkspaceStore.shared.updateIndicatorState(id: id, state: .processing)
@@ -75,10 +95,13 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
     /// user relaunches or Removes them.
     func testErrorSessionIndicatorStateIsErrorAndStaysActive() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
+        coordinator.claudeStateStoreForTesting = store
         addTeardownBlock {
             WorkspaceStore.shared.removeSessionStatus(id: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
+            try? FileManager.default.removeItem(at: dir)
         }
 
         // Seed a live-looking indicator, mirroring what the 1Hz tick would
@@ -114,10 +137,13 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
     /// line in `setStatus(_:for:)` and passes with it.
     func testRelaunchedSessionPublishesIndicatorAfterError() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
+        coordinator.claudeStateStoreForTesting = store
         addTeardownBlock {
             WorkspaceStore.shared.removeSessionStatus(id: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
+            try? FileManager.default.removeItem(at: dir)
         }
 
         // 1. Session starts running and producing output; the tick populates
@@ -159,10 +185,13 @@ final class SessionCoordinatorIndicatorCacheTests: XCTestCase {
     /// line in `setStatus(_:for:)` and passes with it.
     func testRelaunchedSessionPublishesIndicatorAfterClose() {
         let id = UUID()
+        let (store, dir) = makeStore()
         let coordinator = SessionCoordinator()
+        coordinator.claudeStateStoreForTesting = store
         addTeardownBlock {
             WorkspaceStore.shared.removeSessionStatus(id: id)
             WorkspaceStore.shared.removeIndicatorState(id: id)
+            try? FileManager.default.removeItem(at: dir)
         }
 
         // 1. Session starts running and producing output; the tick populates

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorStateTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorStateTests.swift
@@ -25,20 +25,30 @@ final class SessionCoordinatorIndicatorStateTests: XCTestCase {
     /// Builds an isolated `WorkspaceStore` (never touches the real
     /// `workspace.json`) seeded with a single session on the given template,
     /// and a `SessionCoordinator` wired to look up that store instead of
-    /// `WorkspaceStore.shared`.
-    private func makeCoordinator(templateId: UUID) -> (SessionCoordinator, UUID) {
+    /// `WorkspaceStore.shared`. Also points the coordinator's
+    /// `claudeStateStore` at its own temp directory via
+    /// `claudeStateStoreForTesting` — never `.shared`, which
+    /// `indicatorState(for:)` would otherwise reach against the real
+    /// `~/.ghostties/state/` that live sessions are writing to right now.
+    /// Follows the pattern in `SessionCoordinatorClaudeStateTests.swift`.
+    /// The temp directory is torn down in `addTeardownBlock` by the caller.
+    private func makeCoordinator(templateId: UUID) -> (coordinator: SessionCoordinator, sessionId: UUID, claudeStateDir: URL) {
         let project = makeProject()
         let session = AgentSession(name: "Session 1", templateId: templateId, projectId: project.id)
         let store = WorkspaceStore(testingProjects: [project], testingSessions: [session])
         let coordinator = SessionCoordinator()
         coordinator.agentKindLookupStoreForTesting = store
-        return (coordinator, session.id)
+        let claudeStateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionCoordinatorIndicatorStateTests-\(UUID().uuidString)", isDirectory: true)
+        coordinator.claudeStateStoreForTesting = ClaudeStateStore(directoryURL: claudeStateDir)
+        return (coordinator, session.id, claudeStateDir)
     }
 
     // MARK: - The fix
 
     func testAgentSessionSilentNotAtPromptNoPromptTitleIsIdle() {
-        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        let (coordinator, sessionId, claudeStateDir) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
         coordinator.seedIndicatorStateForTesting(id: sessionId, status: .running, isAtPrompt: false)
 
         XCTAssertEqual(
@@ -51,7 +61,8 @@ final class SessionCoordinatorIndicatorStateTests: XCTestCase {
     // MARK: - Unchanged behavior for agent sessions
 
     func testAgentSessionRecentOutputIsProcessing() {
-        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        let (coordinator, sessionId, claudeStateDir) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
         coordinator.seedIndicatorStateForTesting(
             id: sessionId,
             status: .running,
@@ -64,7 +75,8 @@ final class SessionCoordinatorIndicatorStateTests: XCTestCase {
     }
 
     func testAgentSessionSustainedOutputThirtyPlusMinutesIsLongRunning() {
-        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        let (coordinator, sessionId, claudeStateDir) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
         coordinator.seedIndicatorStateForTesting(
             id: sessionId,
             status: .running,
@@ -77,7 +89,8 @@ final class SessionCoordinatorIndicatorStateTests: XCTestCase {
     }
 
     func testAgentSessionPromptShapedTitleIsNeedsAttention() {
-        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        let (coordinator, sessionId, claudeStateDir) = makeCoordinator(templateId: AgentTemplate.claudeCode.id)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
         coordinator.seedIndicatorStateForTesting(
             id: sessionId,
             status: .running,
@@ -99,7 +112,8 @@ final class SessionCoordinatorIndicatorStateTests: XCTestCase {
     /// shell session with no prompt marker yet must keep reading exactly as
     /// it did before this fix — `.waiting` — not flip to `.idle`.
     func testShellSessionSilentNotAtPromptStaysWaitingUnchanged() {
-        let (coordinator, sessionId) = makeCoordinator(templateId: AgentTemplate.shell.id)
+        let (coordinator, sessionId, claudeStateDir) = makeCoordinator(templateId: AgentTemplate.shell.id)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
         coordinator.seedIndicatorStateForTesting(id: sessionId, status: .running, isAtPrompt: false)
 
         XCTAssertEqual(

--- a/macos/Tests/Ghostties/SessionEnvironmentStampTests.swift
+++ b/macos/Tests/Ghostties/SessionEnvironmentStampTests.swift
@@ -1,0 +1,42 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+@testable import Ghostty
+
+/// Phase 0 of the session-row-status plan: every spawned session's
+/// environment is stamped with `GHOSTTIES_SESSION_ID`, unconditionally,
+/// including plain shell templates (`command == nil`) which never go
+/// through the launcher-script path.
+final class SessionEnvironmentStampTests: XCTestCase {
+
+    func testShellTemplateStampsGhosttiesSessionId() {
+        let id = UUID()
+
+        let result = SessionCoordinator.spawnEnvironment(
+            template: .shell,
+            taskFilePath: nil,
+            taskId: nil,
+            extra: [:],
+            sessionId: id
+        )
+
+        XCTAssertEqual(result["GHOSTTIES_SESSION_ID"], id.uuidString)
+    }
+
+    /// The `extra` overlay runs last, so an existing caller (e.g. the
+    /// review-session `GHOSTTIES_TEMPLATE` override) can still win against
+    /// the stamp if it explicitly sets the same key.
+    func testExtraEnvironmentCanOverrideSessionIdStamp() {
+        let id = UUID()
+
+        let result = SessionCoordinator.spawnEnvironment(
+            template: .shell,
+            taskFilePath: nil,
+            taskId: nil,
+            extra: ["GHOSTTIES_SESSION_ID": "override"],
+            sessionId: id
+        )
+
+        XCTAssertEqual(result["GHOSTTIES_SESSION_ID"], "override")
+    }
+}

--- a/macos/Tests/Ghostties/SessionEnvironmentStampTests.swift
+++ b/macos/Tests/Ghostties/SessionEnvironmentStampTests.swift
@@ -39,4 +39,34 @@ final class SessionEnvironmentStampTests: XCTestCase {
 
         XCTAssertEqual(result["GHOSTTIES_SESSION_ID"], "override")
     }
+
+    /// Guards against a regression where deleting the `GHOSTTIES_TASK_FILE`
+    /// assignment in `spawnEnvironment` still passes the whole suite, because
+    /// both existing tests use `.shell` (empty `environmentVariables`) with
+    /// nil task overlays. This exercises template vars, task overlays, and
+    /// the extra overlay together against the exact resulting dictionary.
+    func testSpawnEnvironmentPreservesTemplateVarsTaskOverlaysAndExtra() {
+        let id = UUID()
+        let template = AgentTemplate(
+            name: "Custom",
+            kind: .shell,
+            environmentVariables: ["FOO": "bar", "KEEP": "1"]
+        )
+
+        let result = SessionCoordinator.spawnEnvironment(
+            template: template,
+            taskFilePath: "/tmp/x.md",
+            taskId: "t-1",
+            extra: ["FOO": "override", "ONLY_EXTRA": "y"],
+            sessionId: id
+        )
+
+        XCTAssertEqual(result["FOO"], "override")
+        XCTAssertEqual(result["KEEP"], "1")
+        XCTAssertEqual(result["GHOSTTIES_TASK_FILE"], "/tmp/x.md")
+        XCTAssertEqual(result["GHOSTTIES_TASK_ID"], "t-1")
+        XCTAssertEqual(result["ONLY_EXTRA"], "y")
+        XCTAssertEqual(result["GHOSTTIES_SESSION_ID"], id.uuidString)
+        XCTAssertEqual(result.count, 6)
+    }
 }

--- a/macos/Tests/Ghostties/SessionNameSyncTests.swift
+++ b/macos/Tests/Ghostties/SessionNameSyncTests.swift
@@ -207,6 +207,13 @@ final class SessionNameSyncTests: XCTestCase {
         let session = AgentSession(name: "Session 1", templateId: UUID(), projectId: project.id)
         let store = WorkspaceStore(testingProjects: [project], testingSessions: [session])
         let coordinator = SessionCoordinator()
+        // closeSession -> setStatus(.killed) reaches claudeStateStore.removeState(for:);
+        // point it at a temp directory so this never touches Sean's real
+        // ~/.ghostties/state/ (matches SessionCoordinatorIndicatorCacheTests).
+        let claudeStateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionNameSyncTests-\(UUID().uuidString)", isDirectory: true)
+        coordinator.claudeStateStoreForTesting = ClaudeStateStore(directoryURL: claudeStateDir)
+        addTeardownBlock { try? FileManager.default.removeItem(at: claudeStateDir) }
 
         coordinator.seedEmptySessionTreeForTesting(id: session.id)
         let titleSubject = PassthroughSubject<String, Never>()

--- a/macos/Tests/Ghostties/TaskFileWatcherTests.swift
+++ b/macos/Tests/Ghostties/TaskFileWatcherTests.swift
@@ -133,6 +133,32 @@ final class TaskFileWatcherTests: XCTestCase {
                       "reattached watcher should fire on subsequent writes")
     }
 
+    /// Regression test for the fd single-owner invariant in `stopInternal()`.
+    /// The cancel handler (added in G7, `52c321495`) captures `fd` by value
+    /// and closes it itself; `stopInternal()` must clear the property the
+    /// moment it hands off that close, or a later `stop()`/`deinit` call
+    /// (source == nil, stale fd) closes the same descriptor a second time.
+    func testStopAfterCancelDoesNotDoubleClose() throws {
+        let (watcher, getCount) = makeWatcher()
+        watcher.start()
+        defer { watcher.stop() }
+
+        XCTAssertTrue(waitForCondition(timeout: 2.0) { getCount() >= 1 },
+                      "watcher should fire once on attach; count=\(getCount())")
+
+        watcher.stop()
+        let fdAfterFirstStop = watcher.debugDrainAndReadFD()
+        XCTAssertEqual(fdAfterFirstStop, -1,
+            "fd must be cleared once its close is handed to the cancel handler, " +
+            "or a later stop()/deinit call will close it a second time")
+
+        // Mirrors TaskStore.deinit racing an explicit stop(): a second
+        // teardown call must be a safe no-op now that fd is already -1.
+        watcher.stop()
+        let fdAfterSecondStop = watcher.debugDrainAndReadFD()
+        XCTAssertEqual(fdAfterSecondStop, -1)
+    }
+
     func testBurstOfWritesDebouncesToOneFire() throws {
         // Use a longer debounce so the burst clearly falls inside one window.
         let (watcher, getCount) = makeWatcher(debounce: .milliseconds(300))


### PR DESCRIPTION
## What

The foundation for reading a Claude session's state instead of inferring it from terminal titles. Nothing changes on screen yet.

- **Phase 0** — `SessionCoordinator.spawnEnvironment(...)` stamps `GHOSTTIES_SESSION_ID` into every session's spawn env, plain shell included. The env survives `login → zsh → cco → claude → hook`, which is the whole join (the launcher-UUID argv route was measured dead at 0/10 live sessions).
- **Phase 1** — `macos/Resources/hooks/ghostties-status.sh`, a POSIX `sh` Claude Code hook (no `jq`/python) that wraps the event payload and writes `~/.ghostties/state/<uuid>.json` (or `.todos.json`) by temp+rename. `HookInstaller.seedIfNeeded()` seeds it to `~/.ghostties/hooks/` on launch, overwriting on `seedVersion` bump (app-owned code, unlike presets). Bundled via four pbxproj entries mirroring `presets`.
- Sean registers the script in `~/.claude/settings.json` with `"async": true` on seven events (snippet in the script header). `async` on `PermissionRequest` makes the hook structurally unable to alter a permission decision.

## Evidence

`docs/plans/session-row-status/gate-evidence.md` — live results for the plan's three gate experiments:
- **E3 pass:** 7 real sidebar rows across 3 Dev-build launches reported their ids to the hook; shell `echo $GHOSTTIES_SESSION_ID` printed the "Shell 40" row's id. Installer bump 1→2 replaced the seeded script with the bundle copy (md5-identical).
- **E2 measured:** `PermissionRequest` fires immediately but carries no `tool_use_id`; the preceding `PreToolUse` does. Phase 4 pairs them.
- **E1 fails as specified:** the main thread has no `TodoWrite`/`Task*` tool in CC 2.1.248. Phase 3's source is an open decision (default: `Stop.last_assistant_message`).

## Tests

Step 0 baseline re-measured on the branch point: **964** (prior claims of 625/885 were stale). After: **971**, 0 new failures; the one failure is the pre-existing timing flake `GitWorktreeCreationTests.raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes`. Totals from `xcresulttool`. New tests name production symbols and were mutant-verified (`SessionEnvironmentStampTests` ×3, `HookInstallerTests` ×4).

## Review

Three adversarial rounds; each fix commit re-reviewed as new code. Round 1: event gate on the todos branch, closed-stdin hang, reseed-if-missing, env-overlay equivalence test. Round 2: `replaceItemAt` had silently dropped the 0700 chmod; first-seed now uses `moveItem` (macOS 13 floor). Round 3: `seedVersion` bump + tmp chmod.

## Merge note

`BACKLOG.md` gains a `2026-08-26 — Session-row status` section here; the docs branch `docs/session-row-status-spec` adds the same heading — expect a trivial conflict whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wuN57EPRSi29AT4zCHtpv