### PR TITLE
refactor(composer): move the command parser into GhosttiesCore so its invariants run in CI

### DIFF
--- a/cli/Sources/GhosttiesCore/AgentTemplate.swift
+++ b/cli/Sources/GhosttiesCore/AgentTemplate.swift
@@ -6,36 +6,36 @@ import OSLog
 /// Every session is an "agent" — Shell is just an agent with no AI config.
 /// Replaces SessionTemplate with support for Claude Code agent configuration
 /// (system prompt, model, permissions) that rebuilds from template on every relaunch.
-struct AgentTemplate: Identifiable, Codable, Hashable {
-    let id: UUID
-    var name: String
-    var kind: Kind
-    var isDefault: Bool
-    var isGlobal: Bool
-    var projectId: UUID?
+public struct AgentTemplate: Identifiable, Codable, Hashable {
+    public let id: UUID
+    public var name: String
+    public var kind: Kind
+    public var isDefault: Bool
+    public var isGlobal: Bool
+    public var projectId: UUID?
 
     /// Short description shown in the template picker subtitle.
-    var templateDescription: String?
+    public var templateDescription: String?
 
     /// SF Symbol name for the picker icon (e.g. "star", "building.2").
-    var icon: String?
+    public var icon: String?
 
     /// Display label for the preset's access level (e.g. "read-only", "full").
-    var accessLabel: String?
+    public var accessLabel: String?
 
     // Terminal config
-    var command: String?
-    var environmentVariables: [String: String]
-    var workingDirectory: String?
+    public var command: String?
+    public var environmentVariables: [String: String]
+    public var workingDirectory: String?
 
     // Agent config (nil for .shell)
-    var agent: AgentConfig?
+    public var agent: AgentConfig?
 
     /// Path to a Claude MCP config file (`--mcp-config`), injected at launch.
     ///
     /// Set by folder-format presets that bundle an `mcp-servers.json`. nil for
     /// built-in and flat-file presets.
-    var mcpConfigPath: String?
+    public var mcpConfigPath: String?
 
     // MARK: - Kind
 
@@ -44,7 +44,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     /// Uses String raw values for safe Codable persistence.
     /// Custom `init(from:)` decodes as raw String and falls back to `.shell`
     /// on unknown values — never throws, never wipes state.
-    enum Kind: String, Codable, Hashable {
+    public enum Kind: String, Codable, Hashable {
         case shell
         case claudeCode
         case custom
@@ -52,7 +52,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
 
         // Safe decoder: decode as raw String, construct with init(rawValue:),
         // fall back to .shell on unknown values. Never throws, never wipes state.
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             let rawValue = try container.decode(String.self)
             self = Kind(rawValue: rawValue) ?? .shell
@@ -64,20 +64,38 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     /// Configuration for Claude Code agent sessions.
     ///
     /// All fields are optional — a minimal agent template needs only a command.
-    struct AgentConfig: Codable, Hashable {
-        var systemPromptFile: String?
+    public struct AgentConfig: Codable, Hashable {
+        public var systemPromptFile: String?
         /// Inline system prompt content (used by presets instead of a file reference).
-        var systemPrompt: String?
-        var model: String?
-        var permissionMode: String?
-        var effort: String?
-        var allowedTools: [String]?
-        var additionalFlags: [String]?
+        public var systemPrompt: String?
+        public var model: String?
+        public var permissionMode: String?
+        public var effort: String?
+        public var allowedTools: [String]?
+        public var additionalFlags: [String]?
+
+        public init(
+            systemPromptFile: String? = nil,
+            systemPrompt: String? = nil,
+            model: String? = nil,
+            permissionMode: String? = nil,
+            effort: String? = nil,
+            allowedTools: [String]? = nil,
+            additionalFlags: [String]? = nil
+        ) {
+            self.systemPromptFile = systemPromptFile
+            self.systemPrompt = systemPrompt
+            self.model = model
+            self.permissionMode = permissionMode
+            self.effort = effort
+            self.allowedTools = allowedTools
+            self.additionalFlags = additionalFlags
+        }
     }
 
     // MARK: - Initializer
 
-    init(
+    public init(
         id: UUID = UUID(),
         name: String,
         kind: Kind,
@@ -112,7 +130,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     // MARK: - Built-in Templates (deterministic UUIDs)
 
     /// Default shell session — uses the user's login shell.
-    static let shell = AgentTemplate(
+    public static let shell = AgentTemplate(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
         name: "Shell",
         kind: .shell,
@@ -121,7 +139,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     )
 
     /// Claude Code agent session.
-    static let claudeCode = AgentTemplate(
+    public static let claudeCode = AgentTemplate(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
         name: "Claude Code",
         kind: .claudeCode,
@@ -131,7 +149,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     )
 
     /// Orchestrator agent — Claude Code with system prompt and opus model.
-    static let orchestrator = AgentTemplate(
+    public static let orchestrator = AgentTemplate(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
         name: "Orchestrator",
         kind: .claudeCode,
@@ -145,7 +163,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     )
 
     /// Embedded Chromium browser session.
-    static let browser = AgentTemplate(
+    public static let browser = AgentTemplate(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!,
         name: "Browser",
         kind: .browser,
@@ -161,7 +179,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     /// in the PR that introduced this template. `agent` (Claude-CLI-specific
     /// flags: system prompt, model, permissions, `--mcp-config`) is intentionally
     /// nil; those flags don't map to the `codex` CLI.
-    static let codex = AgentTemplate(
+    public static let codex = AgentTemplate(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!,
         name: "Codex",
         kind: .custom,
@@ -172,7 +190,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     )
 
     /// All built-in templates, in display order.
-    static let defaults: [AgentTemplate] = [shell, claudeCode, codex, orchestrator, browser]
+    public static let defaults: [AgentTemplate] = [shell, claudeCode, codex, orchestrator, browser]
 
     // MARK: - CLI Construction
 
@@ -197,7 +215,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     ///
     /// Creates `~/.ghostties/cache/prompts/<template-id>.prompt.md` with 0o700 directory
     /// permissions. Returns nil if the write fails.
-    static func writePromptCacheFile(templateId: UUID, content: String) -> String? {
+    public static func writePromptCacheFile(templateId: UUID, content: String) -> String? {
         let fm = FileManager.default
         let dirPath = promptCacheDir
 
@@ -229,7 +247,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     /// agent config flags. All values are shell-escaped with single quotes.
     /// Prompt files are referenced via `--append-system-prompt-file`; inline
     /// prompts are written to cache files first. File size capped at 1 MB.
-    func buildCommand() -> String {
+    public func buildCommand() -> String {
         var parts: [String] = []
 
         if let command {
@@ -304,7 +322,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     ///
     /// Renders as a terracotta (#C97350) background bar with white bold text
     /// and a ghost icon, matching the Ghostties brand.
-    var launchBanner: String? {
+    public var launchBanner: String? {
         guard let agent else { return nil }
         var parts: [String] = [name]
         if let model = agent.model { parts.append(model) }
@@ -322,7 +340,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     /// Environment variable keys that should be stripped from loaded templates.
     ///
     /// Shared constant — used by WorkspacePersistence and any other validation sites.
-    static let dangerousEnvKeys: Set<String> = [
+    public static let dangerousEnvKeys: Set<String> = [
         "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
         "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FALLBACK_FRAMEWORK_PATH",
         "LD_PRELOAD", "LD_LIBRARY_PATH",
@@ -336,7 +354,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     ///
     /// Preserves all other fields. Safer than manual field-by-field copy
     /// because new fields are automatically included.
-    func withoutAgent() -> AgentTemplate {
+    public func withoutAgent() -> AgentTemplate {
         var copy = self
         copy.agent = nil
         return copy
@@ -359,7 +377,7 @@ struct AgentTemplate: Identifiable, Codable, Hashable {
     /// 2. Old SessionTemplate format: flat command/envVars, no kind/agent
     ///
     /// Migration: command == nil -> .shell, command == "claude" -> .claudeCode, else -> .custom
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.id = try container.decode(UUID.self, forKey: .id)

--- a/cli/Sources/GhosttiesCore/GhostCharacter.swift
+++ b/cli/Sources/GhosttiesCore/GhostCharacter.swift
@@ -1,12 +1,13 @@
-import SwiftUI
+import Foundation
 
 /// One of 24 pixel-art ghost characters assignable to a project.
 ///
 /// Each case owns a 12×12 boolean grid that defines its silhouette.
-/// `drawPath(in:)` renders the grid as filled rectangles within a SwiftUI
-/// `Path`, producing crisp vector art at any size. At a 20pt render size
-/// each "pixel" is ~1.67pt — sharp at @2x Retina.
-enum GhostCharacter: String, CaseIterable, Codable {
+/// `drawPath(in:)` (see `GhostCharacter+Drawing.swift`) renders the grid as
+/// filled rectangles within a SwiftUI `Path`, producing crisp vector art at
+/// any size. At a 20pt render size each "pixel" is ~1.67pt — sharp at @2x
+/// Retina.
+public enum GhostCharacter: String, CaseIterable, Codable {
     case blinky
     case pinky
     case inky
@@ -34,7 +35,7 @@ enum GhostCharacter: String, CaseIterable, Codable {
 
     /// 12×12 boolean grid defining the ghost's silhouette.
     /// `true` = filled pixel, `false` = transparent.
-    var pixelGrid: [[Bool]] { Self.grids[self]! }
+    public var pixelGrid: [[Bool]] { Self.grids[self]! }
 
     /// Pre-computed grids for all characters (parsed once from compact string data).
     private static let grids: [GhostCharacter: [[Bool]]] = {
@@ -385,51 +386,6 @@ enum GhostCharacter: String, CaseIterable, Codable {
         }
     }
 
-    /// Render the pixel grid as a SwiftUI `Path` within the given rectangle.
-    ///
-    /// Builds the path from a cached unit-square (1×1) path via
-    /// `CGAffineTransform` scaling — benchmarked at the real 14×14 render size
-    /// with the real `.blinky` grid (108 filled cells): building the path from
-    /// scratch every call costs 7.862 µs vs `Circle()`'s 0.030 µs (264×).
-    /// Reusing a cached unit path and scaling it is ~9.5× cheaper and has no
-    /// behavior change — same filled cells, same crisp-at-any-size rendering.
-    func drawPath(in rect: CGRect) -> Path {
-        guard rect.width > 0, rect.height > 0 else { return Path() }
-        let unit = Self.unitPaths[self] ?? Path()
-        let transform = CGAffineTransform(translationX: rect.minX, y: rect.minY)
-            .scaledBy(x: rect.width, y: rect.height)
-        return unit.applying(transform)
-    }
-
-    /// One 1×1 (unit square) `Path` per character, built once from `grids` —
-    /// the basis `drawPath(in:)` scales via `CGAffineTransform` on every call
-    /// instead of rebuilding ~108 `addRect` calls from scratch each time.
-    private static let unitPaths: [GhostCharacter: Path] = {
-        var paths: [GhostCharacter: Path] = [:]
-        for character in GhostCharacter.allCases {
-            let grid = character.pixelGrid
-            let rows = grid.count
-            let cols = grid.first?.count ?? 0
-            guard rows > 0, cols > 0 else {
-                paths[character] = Path()
-                continue
-            }
-            let cellW = 1.0 / CGFloat(cols)
-            let cellH = 1.0 / CGFloat(rows)
-            var path = Path()
-            for row in 0..<rows {
-                for col in 0..<cols {
-                    guard grid[row][col] else { continue }
-                    let x = CGFloat(col) * cellW
-                    let y = CGFloat(row) * cellH
-                    path.addRect(CGRect(x: x, y: y, width: cellW, height: cellH))
-                }
-            }
-            paths[character] = path
-        }
-        return paths
-    }()
-
     /// Pick a random ghost not present in `used`. Once all 24 are already in
     /// use, degrades to a deterministic least-used round-robin (ties broken by
     /// `allCases` order) instead of a uniform random pick — a uniform pick
@@ -439,7 +395,7 @@ enum GhostCharacter: String, CaseIterable, Codable {
     /// `used` is a multiset (duplicates preserved), not a `Set` — the
     /// duplicate counts are exactly what the round-robin fallback needs to
     /// find the least-used ghost once every ghost is taken at least once.
-    static func randomUnused(excluding used: [GhostCharacter]) -> GhostCharacter {
+    public static func randomUnused(excluding used: [GhostCharacter]) -> GhostCharacter {
         let usedSet = Set(used)
         let available = allCases.filter { !usedSet.contains($0) }
         if let pick = available.randomElement() {

--- a/cli/Sources/GhosttiesCore/GitWorktreeEnumerator.swift
+++ b/cli/Sources/GhosttiesCore/GitWorktreeEnumerator.swift
@@ -8,14 +8,20 @@ import Foundation
 /// `nonisolated` because both entry points are meant to run off the main
 /// actor (called from a `Task.detached` in `SessionComposerStore`), mirroring
 /// `SessionDraftStore.currentGitBranch(atCwd:)`.
-nonisolated enum GitWorktreeEnumerator {
+public nonisolated enum GitWorktreeEnumerator {
 
     /// One `git worktree list --porcelain` stanza, filtered to the ones the
     /// branch chip can offer: real, non-bare, non-detached worktrees.
-    struct Worktree: Equatable {
-        let path: String
-        let branch: String?
-        let isLocked: Bool
+    public struct Worktree: Equatable {
+        public let path: String
+        public let branch: String?
+        public let isLocked: Bool
+
+        public init(path: String, branch: String?, isLocked: Bool) {
+            self.path = path
+            self.branch = branch
+            self.isLocked = isLocked
+        }
     }
 
     /// Parses `git worktree list --porcelain` output into `Worktree` values.
@@ -41,7 +47,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// `bare`, `detached`, and `prunable` stanzas are dropped entirely.
     /// `locked` stanzas are kept with `isLocked = true` (a locked worktree is
     /// still a valid pick, just one Sean has pinned against pruning).
-    static func parsePorcelain(_ output: String) -> [Worktree] {
+    public static func parsePorcelain(_ output: String) -> [Worktree] {
         var results: [Worktree] = []
 
         var currentPath: String?
@@ -108,7 +114,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// Git resolves worktree enumeration from ANY worktree of a repo to the
     /// full set, so `repoPath` does not need to be the repo's primary
     /// checkout — a linked worktree works identically.
-    static func list(repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> [Worktree] {
+    public static func list(repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> [Worktree] {
         dispatchPrecondition(condition: .notOnQueue(.main))
 
         let task = Process()
@@ -168,7 +174,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// BOTH: exit 0 (repo exists at all — exit 128 means "fatal: not a git
     /// repository") AND stdout trims to exactly `"true"` (a real, non-bare
     /// worktree).
-    static func isInsideWorkTree(repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> Bool {
+    public static func isInsideWorkTree(repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> Bool {
         dispatchPrecondition(condition: .notOnQueue(.main))
 
         let task = Process()
@@ -202,7 +208,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// unchanged if it doesn't exist (matches `realpath(3)`'s own
     /// "resolution requires the path to exist" behavior; a nonexistent path
     /// can't be a git repo anyway).
-    static func canonicalPath(_ path: String) -> String {
+    public static func canonicalPath(_ path: String) -> String {
         // Nit fix (Slice B review round 3): should-fix 11 (round 1) moved
         // this call off the main actor specifically to keep the blocking
         // `realpath(3)` syscall away from it — this assertion is what makes
@@ -239,7 +245,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// checkout. Reading the porcelain output directly needs no version
     /// check and has no such fallthrough — the first `worktree` line IS the
     /// main worktree path, unconditionally.
-    static func mainWorktreePath(repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> String? {
+    public static func mainWorktreePath(repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> String? {
         dispatchPrecondition(condition: .notOnQueue(.main))
 
         let task = Process()
@@ -288,7 +294,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// already has this precomputed by the time it calls here. `nil`
     /// (default) preserves the original self-contained behavior for any
     /// other caller.
-    static func branchesWithoutWorktree(
+    public static func branchesWithoutWorktree(
         repoPath: String,
         claimedBranches: Set<String>? = nil,
         onProcessStarted: ((Process) -> Void)? = nil
@@ -342,12 +348,16 @@ nonisolated enum GitWorktreeEnumerator {
     /// `Result<String, GitWorktreeCreationError>` — `String` itself doesn't
     /// conform to `Error`. `.message` is git's stderr first line, verbatim;
     /// nothing paraphrases it between here and `SessionComposerStore.writeError`.
-    struct GitWorktreeCreationError: Error, CustomStringConvertible {
-        let message: String
-        var description: String { message }
+    public struct GitWorktreeCreationError: Error, CustomStringConvertible {
+        public let message: String
+        public var description: String { message }
+
+        public init(message: String) {
+            self.message = message
+        }
     }
 
-    static func branchExists(_ name: String, repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> Bool {
+    public static func branchExists(_ name: String, repoPath: String, onProcessStarted: ((Process) -> Void)? = nil) -> Bool {
         dispatchPrecondition(condition: .notOnQueue(.main))
 
         let task = Process()
@@ -400,7 +410,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// (branch already checked out elsewhere, destination exists and is
     /// non-empty, invalid ref name, unwritable destination) reaches the
     /// user without a paraphrase in between.
-    static func add(
+    public static func add(
         branch: String,
         directory: String,
         repoPath: String,
@@ -463,7 +473,7 @@ nonisolated enum GitWorktreeEnumerator {
     /// starting with `fatal:` and falls back to the literal first line only
     /// if git's output ever omits one (a case not observed, but not worth
     /// returning nothing over).
-    static func firstMeaningfulLine(ofStderr stderrText: String) -> String {
+    public static func firstMeaningfulLine(ofStderr stderrText: String) -> String {
         let lines = stderrText.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
         if let fatalLine = lines.first(where: { $0.hasPrefix("fatal:") }) {
             return fatalLine

--- a/cli/Sources/GhosttiesCore/Project.swift
+++ b/cli/Sources/GhosttiesCore/Project.swift
@@ -1,26 +1,26 @@
 import Foundation
 
 /// A workspace project representing a directory the user has pinned.
-struct Project: Identifiable, Codable, Hashable {
-    let id: UUID
-    var name: String
-    var rootPath: String
-    var isPinned: Bool
+public struct Project: Identifiable, Codable, Hashable {
+    public let id: UUID
+    public var name: String
+    public var rootPath: String
+    public var isPinned: Bool
 
     /// The pixel-art ghost character displayed in the icon rail.
     /// Nil means the project predates the ghost system (shows initial fallback).
-    var ghostCharacter: GhostCharacter?
+    public var ghostCharacter: GhostCharacter?
 
     /// The default template to use when creating sessions with a single click.
     /// Nil means always show the template picker.
-    var defaultTemplateId: UUID?
+    public var defaultTemplateId: UUID?
 
     /// The last moment any session in this project produced output, was focused,
     /// or was created. Drives the "Recent" smart-section membership rule.
     /// Nil means this project predates the timestamp system or has never been touched.
-    var lastActiveAt: Date?
+    public var lastActiveAt: Date?
 
-    init(
+    public init(
         id: UUID = UUID(),
         name: String,
         rootPath: String,
@@ -40,7 +40,7 @@ struct Project: Identifiable, Codable, Hashable {
 
     // Custom decoder so existing workspace.json files (without ghost/template/timestamp
     // fields) load without error. New fields default to nil when missing.
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(UUID.self, forKey: .id)
         self.name = try container.decode(String.self, forKey: .name)

--- a/cli/Sources/GhosttiesCore/SessionComposerCommandParser.swift
+++ b/cli/Sources/GhosttiesCore/SessionComposerCommandParser.swift
@@ -5,9 +5,13 @@ import Foundation
 /// `SessionComposerCommandParser.resolveCommitWorktreePathForCommit` and
 /// `SessionComposerStore.resolveLaunchTemplate`, so both commit-time
 /// validation seams return the same shape instead of each inventing one.
-struct SessionComposerCommitError: Error, CustomStringConvertible, Equatable {
-    let message: String
-    var description: String { message }
+public struct SessionComposerCommitError: Error, CustomStringConvertible, Equatable {
+    public let message: String
+    public var description: String { message }
+
+    public init(message: String) {
+        self.message = message
+    }
 }
 
 /// Pure, testable command-grammar parsing for the session composer's
@@ -21,7 +25,7 @@ struct SessionComposerCommitError: Error, CustomStringConvertible, Equatable {
 /// blanket-executing the remainder as a shell command (that would break
 /// `ghostties orchestrator`, which must still reach the Orchestrator
 /// template via the ordinary template-matching path).
-enum SessionComposerCommandParser {
+public enum SessionComposerCommandParser {
 
     /// The fixed identity of the composer's synthesized "Run" row.
     /// `ComposerOption.id` is injectable specifically to avoid UUID churn on
@@ -29,28 +33,28 @@ enum SessionComposerCommandParser {
     /// row's underlying command changes on every keystroke by design, so a
     /// stable sentinel id (rather than deriving one from the command text)
     /// is what keeps hover/scroll state settled while the label updates.
-    static let runRowId = UUID(uuidString: "89FA0000-0000-0000-0000-000000000001")!
+    public static let runRowId = UUID(uuidString: "89FA0000-0000-0000-0000-000000000001")!
 
     /// The fixed identity of the composer's synthesized "Create worktree
     /// for <branch>" row — Sean's decision 1: a typed branch that matches a
     /// known branch with no worktree gets an offered row to create it,
     /// mirroring `runRowId`'s stable-sentinel reasoning above (the label
     /// changes on every keystroke; the id must not).
-    static let createWorktreeRowId = UUID(uuidString: "89FA0000-0000-0000-0000-000000000002")!
+    public static let createWorktreeRowId = UUID(uuidString: "89FA0000-0000-0000-0000-000000000002")!
 
     /// Result of tokenizing a composer query against the known project
     /// list. `projectId == nil` means "no command was recognized" — every
     /// caller must fall through to the existing whole-string filter,
     /// byte-identical, in that case.
-    struct ParseResult: Equatable {
-        let projectId: UUID?
-        let remainderTokens: [String]
+    public struct ParseResult: Equatable {
+        public let projectId: UUID?
+        public let remainderTokens: [String]
         /// Slice B (composer breadcrumb spec): the branch segment's raw
         /// token, present only when an explicit `>` introduced it (see
         /// the disambiguation rule on `parse(query:)`). `nil` for every
         /// slice-1 shape — explicit default keeps every existing
         /// construction site (including `.none` below) byte-identical.
-        let branchToken: String?
+        public let branchToken: String?
         /// Round-3 review, Blocker 1: the template a chevron/space-terminated
         /// operator token resolved to (`Segment.Resolution.template`),
         /// carried through so callers can rank/launch it directly instead of
@@ -65,9 +69,9 @@ enum SessionComposerCommandParser {
         /// named. `nil` for every slice-1/Slice-B shape and whenever no
         /// operator segment resolved to a real template — explicit default
         /// keeps every existing construction site byte-identical.
-        let resolvedTemplateId: UUID?
+        public let resolvedTemplateId: UUID?
 
-        init(projectId: UUID?, remainderTokens: [String], branchToken: String? = nil, resolvedTemplateId: UUID? = nil) {
+        public init(projectId: UUID?, remainderTokens: [String], branchToken: String? = nil, resolvedTemplateId: UUID? = nil) {
             self.projectId = projectId
             self.remainderTokens = remainderTokens
             self.branchToken = branchToken
@@ -79,11 +83,11 @@ enum SessionComposerCommandParser {
         /// template filter. Quote marks used only to keep a multi-word
         /// argument as one token are not reconstructed — display never
         /// needs to round-trip back into a query string.
-        var remainderText: String {
+        public var remainderText: String {
             remainderTokens.joined(separator: " ")
         }
 
-        static let none = ParseResult(projectId: nil, remainderTokens: [])
+        public static let none = ParseResult(projectId: nil, remainderTokens: [])
     }
 
     /// Straight `"` plus the curly quotes macOS's "Use smart quotes and
@@ -110,7 +114,7 @@ enum SessionComposerCommandParser {
     /// tokens; so is a `>` acting as a separator. `separatorsIncludeChevron`
     /// defaults to `false` so every existing caller stays byte-identical —
     /// `>` is only ever a separator where a caller opts in.
-    static func tokenize(_ input: String, separatorsIncludeChevron: Bool = false) -> [String] {
+    public static func tokenize(_ input: String, separatorsIncludeChevron: Bool = false) -> [String] {
         var tokens: [String] = []
         var current = ""
         var hasCurrent = false
@@ -172,21 +176,21 @@ enum SessionComposerCommandParser {
     /// The four segment positions the grammar can fill, in walk order.
     /// `operation` because `operator` is a Swift keyword — the grammar's
     /// word for it is still "operator" everywhere it's user-facing.
-    enum SegmentKind: Int, Comparable, CaseIterable {
+    public enum SegmentKind: Int, Comparable, CaseIterable {
         case project = 0, branch = 1, operation = 2, thread = 3
-        static func < (l: Self, r: Self) -> Bool { l.rawValue < r.rawValue }
+        public static func < (l: Self, r: Self) -> Bool { l.rawValue < r.rawValue }
     }
 
     /// A single resolved (settled) segment of a `PathParse`.
-    struct Segment: Equatable {
-        let kind: SegmentKind
+    public struct Segment: Equatable {
+        public let kind: SegmentKind
         /// UTF-16 offsets into `PathParse.source` — never a `Range<String.Index>`:
         /// an index from a different string is undefined behavior, whereas a
         /// stale `NSRange` is merely out of bounds and guardable.
-        let range: NSRange
-        let resolved: Resolution
+        public let range: NSRange
+        public let resolved: Resolution
 
-        enum Resolution: Equatable {
+        public enum Resolution: Equatable {
             case project(UUID)
             case branch(String)      // token only; worktree lookup stays in the view
             case template(UUID)      // operator matched a known template
@@ -208,7 +212,7 @@ enum SessionComposerCommandParser {
         /// produced against (`PathParse.source`, verbatim) — this matters
         /// more once D11 hands these same ranges to `NSTextStorage`, where
         /// the same silent-wrong-text failure mode applies.
-        func text(in source: String) -> String {
+        public func text(in source: String) -> String {
             guard let r = Range(range, in: source) else { return "" }
             return String(source[r])
         }
@@ -221,22 +225,22 @@ enum SessionComposerCommandParser {
     /// ends — still absorbing keystrokes, not yet closed by a `>` — is
     /// exposed separately via `remainderRange`/`activeKind` rather than
     /// added to `segments`, since it isn't a settled fact yet.
-    struct PathParse: Equatable {
+    public struct PathParse: Equatable {
         /// The exact RAW string every `Segment.range` indexes — never trimmed.
-        let source: String
-        let segments: [Segment]
+        public let source: String
+        public let segments: [Segment]
         /// The still-being-typed tail: not terminated, never resolved. `nil`
         /// once a free-text run has been opened (its content, terminated or
         /// not, belongs to the run instead — see rule 1) or when the query
         /// ends in a terminator or is empty.
-        let trailingTermRange: NSRange?
+        public let trailingTermRange: NSRange?
         /// The type the trailing term (or the next keystroke) would be
         /// tried against — the first unfilled type, or `.operation`/
         /// `.thread` once matching has stopped.
-        let activeKind: SegmentKind?
+        public let activeKind: SegmentKind?
         /// The currently-open, not-yet-closed free-text run, if any.
-        let remainderRange: NSRange?
-        let projectId: UUID?
+        public let remainderRange: NSRange?
+        public let projectId: UUID?
         /// Whether the currently-open run (`remainderRange`, if non-nil) is
         /// genuinely a THREAD run — set directly from `openRunKind` at the
         /// point the walk ends, never derived from `activeKind`. `activeKind`
@@ -251,9 +255,21 @@ enum SessionComposerCommandParser {
         /// the run opened by the trailing `"te"` is genuinely `.thread`).
         /// Fix 2 (round-2 review): this field is what callers needing "is
         /// the open run a thread run" must read instead.
-        let openRunIsThreadRun: Bool
+        public let openRunIsThreadRun: Bool
 
-        static let none = PathParse(source: "", segments: [], trailingTermRange: nil,
+        public init(source: String, segments: [Segment], trailingTermRange: NSRange?,
+                    activeKind: SegmentKind?, remainderRange: NSRange?, projectId: UUID?,
+                    openRunIsThreadRun: Bool) {
+            self.source = source
+            self.segments = segments
+            self.trailingTermRange = trailingTermRange
+            self.activeKind = activeKind
+            self.remainderRange = remainderRange
+            self.projectId = projectId
+            self.openRunIsThreadRun = openRunIsThreadRun
+        }
+
+        public static let none = PathParse(source: "", segments: [], trailingTermRange: nil,
                                     activeKind: nil, remainderRange: nil, projectId: nil,
                                     openRunIsThreadRun: false)
     }
@@ -348,7 +364,7 @@ enum SessionComposerCommandParser {
     ///   (`"cco"`, no trailing space) can still open a run immediately
     ///   instead of being withheld by rule 1's bare-first-token exception,
     ///   which exists only to protect an as-yet-unresolved PROJECT name.
-    static func parsePath(
+    public static func parsePath(
         rawQuery: String,
         projects: [Project],
         templates: [AgentTemplate],
@@ -677,7 +693,7 @@ enum SessionComposerCommandParser {
     /// the term verbatim; a token-rejoin version would silently normalize
     /// the tail. Returns `parse.source` unchanged if there is no trailing
     /// term to complete.
-    static func completing(parse: PathParse, with value: String) -> String {
+    public static func completing(parse: PathParse, with value: String) -> String {
         guard let range = parse.trailingTermRange, let bounds = Range(range, in: parse.source) else {
             return parse.source
         }
@@ -724,7 +740,7 @@ enum SessionComposerCommandParser {
     /// covers the quoted form; `testFlatFormRedirectTruncatesAtChevron`
     /// pins the unquoted truncation itself so a later "fix" can't silently
     /// walk it back).
-    static func parse(
+    public static func parse(
         query: String,
         projects: [Project],
         knownBranchNames: [String] = [],
@@ -862,7 +878,7 @@ enum SessionComposerCommandParser {
     /// Left in place deliberately: correct behavior if the raw/trimmed
     /// contract at that call site ever changes back, not dead code to
     /// delete.
-    static func effectiveParse(
+    public static func effectiveParse(
         rawQuery: String,
         directParse: ParseResult,
         impliedProject: Project?,
@@ -915,7 +931,7 @@ enum SessionComposerCommandParser {
     /// function stays: `stickyChipProjectId` below still calls it to find
     /// the project-token boundary, engine-side, unrelated to how the field
     /// renders.
-    static func splitOnFirstToken(
+    public static func splitOnFirstToken(
         _ rawQuery: String,
         separatorsIncludeChevron: Bool = false
     ) -> (prefix: String, remainder: String)? {
@@ -977,7 +993,7 @@ enum SessionComposerCommandParser {
     /// one token, no command. Keeping the chip resolved through the
     /// empty-remainder state (this function) means backspacing to nothing
     /// and retyping stays inside the same two-token shape the whole time.
-    static func stickyChipProjectId(rawQuery: String, projects: [Project], isLocked: Bool) -> UUID? {
+    public static func stickyChipProjectId(rawQuery: String, projects: [Project], isLocked: Bool) -> UUID? {
         guard !isLocked else { return nil }
         // Chevron-aware so `ghostties>` (Slice B's typable `>`) triggers
         // the sticky chip exactly like `ghostties ` already does — `>` is a
@@ -1029,7 +1045,7 @@ enum SessionComposerCommandParser {
     /// token after it becomes `agent.additionalFlags`, the only
     /// per-token-escaped carrier — splitting this way is what keeps
     /// `cco -n test` from collapsing into one unrunnable argv word.
-    static func makeAdHocTemplate(remainderTokens: [String]) -> AgentTemplate? {
+    public static func makeAdHocTemplate(remainderTokens: [String]) -> AgentTemplate? {
         guard let first = remainderTokens.first else { return nil }
         let rest = Array(remainderTokens.dropFirst())
 
@@ -1065,7 +1081,7 @@ enum SessionComposerCommandParser {
     /// project A, commits into project B" blocker — `SessionComposerPalette`
     /// itself has no testable seam for this (a SwiftUI `View` reading
     /// `@EnvironmentObject` state), so this is the seam.
-    static func resolveCommitProjectId(commandProjectId: UUID?, selectedProjectId: UUID?) -> UUID? {
+    public static func resolveCommitProjectId(commandProjectId: UUID?, selectedProjectId: UUID?) -> UUID? {
         commandProjectId ?? selectedProjectId
     }
 
@@ -1091,7 +1107,7 @@ enum SessionComposerCommandParser {
     /// `ParseResult.branchToken` against the cached worktree list; this
     /// function only expresses the precedence, the same seam
     /// `resolveCommitProjectId` provides for the project segment.
-    static func resolveCommitWorktreePath(typedWorktreePath: String?, selectedWorktreePath: String?) -> String? {
+    public static func resolveCommitWorktreePath(typedWorktreePath: String?, selectedWorktreePath: String?) -> String? {
         typedWorktreePath ?? selectedWorktreePath
     }
 
@@ -1105,7 +1121,7 @@ enum SessionComposerCommandParser {
     /// typed branch that resolves to nothing must fail loudly instead
     /// (blocker 2). This type is what makes the three real cases
     /// distinguishable at the call site.
-    enum TypedBranchResolution: Equatable {
+    public enum TypedBranchResolution: Equatable {
         /// No branch segment was typed (`commandParse.branchToken == nil`) —
         /// defers entirely to the picker's own pick.
         case notTyped
@@ -1159,7 +1175,7 @@ enum SessionComposerCommandParser {
     /// returns `.pending` rather than trusting `worktrees`/
     /// `currentBranchAtProjectRoot` against a project they were never
     /// fetched for.
-    static func resolveTypedBranch(
+    public static func resolveTypedBranch(
         branchToken: String?,
         worktrees: [GitWorktreeEnumerator.Worktree],
         currentBranchAtProjectRoot: String?,
@@ -1184,7 +1200,7 @@ enum SessionComposerCommandParser {
     /// returns `.failure` with a message meant for `writeError` directly;
     /// every other case resolves the same way `resolveCommitWorktreePath`
     /// already did.
-    static func resolveCommitWorktreePathForCommit(
+    public static func resolveCommitWorktreePathForCommit(
         typedBranch: TypedBranchResolution,
         selectedWorktreePath: String?
     ) -> Result<String?, SessionComposerCommitError> {
@@ -1216,18 +1232,26 @@ enum SessionComposerCommandParser {
     /// usual view-test-harness gap). Now consumed by
     /// `SessionComposerPalette.ghostPlaceholder` (Step 3) and
     /// `trailingControlVisibility` (Step 5) instead of a rendered line.
-    struct ResolutionLineSegments: Equatable {
-        let projectLabel: String
-        let isProjectClickable: Bool
+    public struct ResolutionLineSegments: Equatable {
+        public let projectLabel: String
+        public let isProjectClickable: Bool
         /// `nil` when the branch segment shouldn't render at all — a
         /// non-git project (mirrors the deleted branch chip's own
         /// "no chip, not a disabled one" rule).
-        let branchLabel: String?
+        public let branchLabel: String?
         /// Whether `branchLabel` should render in the error color — a
         /// typed branch that doesn't resolve to anything. Always `false`
         /// when `branchLabel == nil`.
-        let branchIsError: Bool
-        let templateLabel: String
+        public let branchIsError: Bool
+        public let templateLabel: String
+
+        public init(projectLabel: String, isProjectClickable: Bool, branchLabel: String?, branchIsError: Bool, templateLabel: String) {
+            self.projectLabel = projectLabel
+            self.isProjectClickable = isProjectClickable
+            self.branchLabel = branchLabel
+            self.branchIsError = branchIsError
+            self.templateLabel = templateLabel
+        }
     }
 
     /// Computes `ResolutionLineSegments` from the composer's current
@@ -1244,7 +1268,7 @@ enum SessionComposerCommandParser {
     /// - `templateTitle`: the currently-selected result row's title
     ///   (`selectedOption?.title`), or `nil` if nothing is selected (an
     ///   empty results list).
-    static func resolutionLineSegments(
+    public static func resolutionLineSegments(
         projectName: String?,
         isProjectLocked: Bool,
         isBranchSegmentEligible: Bool,
@@ -1309,7 +1333,7 @@ enum SessionComposerCommandParser {
     /// 3. `!projectsExist` — the zero-project first-run lifeline (G-F7).
     /// 4. Otherwise — the field never states a destination Return will not
     ///    go to.
-    static func ghostPlaceholder(
+    public static func ghostPlaceholder(
         segments: ResolutionLineSegments,
         hasSelection: Bool,
         projectsExist: Bool
@@ -1342,7 +1366,7 @@ enum SessionComposerCommandParser {
     /// found message (`TypedBranchResolution.unresolved`, plan §4 row 5);
     /// `nil` renders nothing, so the happy-path card matches the board
     /// exactly with no strip at all.
-    static func statusStripMessage(
+    public static func statusStripMessage(
         writeError: String?,
         typedBranchResolution: TypedBranchResolution
     ) -> String? {
@@ -1358,7 +1382,7 @@ enum SessionComposerCommandParser {
     /// composer must never render a dead-end "No matches" against an empty
     /// project list; the caller pairs this copy with a clickable row when
     /// `isProjectsEmpty` is true, plain text otherwise.
-    static func emptyResultsCopy(isProjectsEmpty: Bool) -> String {
+    public static func emptyResultsCopy(isProjectsEmpty: Bool) -> String {
         isProjectsEmpty ? "Add project…" : "No matches"
     }
 
@@ -1369,22 +1393,22 @@ enum SessionComposerCommandParser {
     /// table, rows "mouse route into project/branch picker"). A single
     /// pure function so the view and this test suite read the exact same
     /// decision — never two independently-written copies that can diverge.
-    struct TrailingControlVisibility: Equatable {
+    public struct TrailingControlVisibility: Equatable {
         /// `isBranchSegmentEligible` — a non-git project shows no branch
         /// control at all, not a disabled one (mirrors the deleted branch
         /// segment's own rule).
-        let showBranchControl: Bool
+        public let showBranchControl: Bool
         /// `nil` means "no news": default branch. The word "Default" is
         /// never restated outside the rest-state ghost path. Always `nil`
         /// when `showBranchControl` is `false`.
-        let branchControlLabel: String?
+        public let branchControlLabel: String?
         /// Hidden (not disabled) when the project is `.locked` — the
         /// locked rule survives verbatim (DESIGN.md: a locked composer
         /// must never expose a live picker affordance).
-        let showProjectControl: Bool
+        public let showProjectControl: Bool
     }
 
-    static func trailingControlVisibility(
+    public static func trailingControlVisibility(
         isProjectLocked: Bool,
         isBranchSegmentEligible: Bool,
         isCreatingWorktree: Bool,

--- a/cli/Tests/GhosttiesCoreTests/SessionComposerCommandParserIdiomTests.swift
+++ b/cli/Tests/GhosttiesCoreTests/SessionComposerCommandParserIdiomTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import GhosttiesCore
+
+/// Real-usage idiom invariant (`repo cco -n "thread name"` / `repo ccp`).
+///
+/// Moved out of `macos/Tests/Ghostties/SessionComposerCommandParserTests.swift`
+/// (commit `151898bbd`) so it runs under `swift test` in CI —
+/// `SessionComposerCommandParser` now lives in `GhosttiesCore`
+/// (`cli/Sources/GhosttiesCore/SessionComposerCommandParser.swift`), which
+/// `.github/workflows/test-ghostties.yml` actually executes (`swift test
+/// --parallel`); the app-hosted macOS test target is build-only in CI.
+///
+/// Sean's actual daily usage is `repo cco -n "thread name"` and `repo
+/// ccp`, ~95% of everything typed into the composer. `-n` is `cco`'s own
+/// flag — the composer must NEVER claim it for itself (e.g. to name a
+/// session). These tests pin that the remainder — including `-n` and a
+/// quoted multi-word argument — reaches both `ParseResult.remainderTokens`
+/// AND the synthesized `AgentTemplate` (what actually launches) byte-for-
+/// byte, attributed entirely to the ad-hoc command (`cco`), never
+/// consumed or reinterpreted by the parser. Synthetic project name
+/// (`atlas`) — this is a public repo.
+final class SessionComposerCommandParserIdiomTests: XCTestCase {
+
+    private func makeProject(name: String, rootPath: String = "/Users/sean/Code/ghostties") -> Project {
+        Project(name: name, rootPath: rootPath)
+    }
+
+    func testRealIdiomCcoDashNQuotedThreadNameReachesRemainderIntact() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: #"atlas cco -n "thread name""#,
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.projectId, project.id)
+        XCTAssertEqual(result.remainderTokens, ["cco", "-n", "thread name"])
+    }
+
+    /// The remainder above must also reach the LAUNCHED command intact —
+    /// `-n` and the quoted thread name attributed to `cco` via
+    /// `additionalFlags`, not folded into `command` or dropped. Calls the
+    /// real production `buildCommand()` so a future per-token escaping
+    /// change that mangled `-n` specifically would also be caught here.
+    func testRealIdiomCcoDashNQuotedThreadNameReachesLaunchCommandIntact() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: #"atlas cco -n "thread name""#,
+            projects: [project],
+            isLocked: false
+        )
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: result.remainderTokens)
+        XCTAssertEqual(template?.command, "cco")
+        XCTAssertEqual(template?.agent?.additionalFlags, ["-n", "thread name"])
+        XCTAssertEqual(template?.buildCommand(), "'cco' '-n' 'thread name'")
+    }
+
+    /// `repo ccp` — the other half of the 95% idiom. A single-token
+    /// remainder must still resolve the project and pass `ccp` through
+    /// untouched; nothing about a bare remainder should special-case or
+    /// drop it.
+    func testRealIdiomCcpSingleTokenRemainderResolves() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: "atlas ccp",
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.projectId, project.id)
+        XCTAssertEqual(result.remainderTokens, ["ccp"])
+    }
+
+    /// Explicit guard: `-n` must never be treated as a composer-owned flag
+    /// anywhere in the parse — not consumed into `branchToken`, not
+    /// resolved as a template/operator segment, and not stripped from
+    /// `remainderTokens`. `ParseResult` has no field of its own for a
+    /// captured session name; if one is ever added and wired to intercept
+    /// `-n`, this must be the test that goes red first.
+    func testDashNIsNeverClaimedAsAComposerOwnedFlag() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: #"atlas run -n "some name""#,
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.remainderTokens, ["run", "-n", "some name"])
+        XCTAssertNil(result.branchToken, "-n must not be captured as a branch/name segment")
+        XCTAssertNil(result.resolvedTemplateId, "-n must not resolve as an operator/template segment")
+    }
+}

--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -5,6 +5,7 @@ import OSLog
 import MetricKit
 import Sparkle
 import GhosttyKit
+import GhosttiesCore
 
 class AppDelegate: NSObject,
                     ObservableObject,
@@ -1153,7 +1154,7 @@ class AppDelegate: NSObject,
     /// Silent no-op when no row is focused or the file URL cannot be resolved.
     @objc private func openFocusedTaskNotes(_ sender: Any?) {
         // Menu actions arrive on the main thread; hop to MainActor for RowFocusStore.
-        Task { @MainActor in
+        _Concurrency.Task { @MainActor in
             guard let task = RowFocusStore.shared.focusedTask,
                   let taskStore = RowFocusStore.shared.focusedTaskStore,
                   let url = taskStore.fileURL(for: task) else { return }
@@ -1172,7 +1173,7 @@ class AppDelegate: NSObject,
             return
         }
         // Menu actions arrive on the main thread; hop to MainActor for RowFocusStore.
-        Task { @MainActor in
+        _Concurrency.Task { @MainActor in
         guard let task = RowFocusStore.shared.focusedTask else { return }
         // SessionCoordinator and WorkspaceStore are window-scoped; look them up
         // from the key window's TerminalController via the notification-based
@@ -1487,7 +1488,7 @@ class AppDelegate: NSObject,
     }
 
     private func updateAppIcon(from config: Ghostty.Config) {
-        Task.detached {
+        _Concurrency.Task.detached {
             await self.appIconUpdater.update(icon: AppIcon(config: config))
         }
     }
@@ -1899,7 +1900,7 @@ extension AppDelegate {
     @IBAction func setAsDefaultTerminal(_ sender: NSMenuItem) {
         NSWorkspace.shared.setDefaultApplication(at: Bundle.main.bundleURL, toOpen: .unixExecutable) { error in
             guard let error else { return }
-            Task { @MainActor in
+            _Concurrency.Task { @MainActor in
                 let alert = NSAlert()
                 alert.messageText = "Failed to Set Default Terminal"
                 alert.informativeText = """

--- a/macos/Sources/Features/Ghostties/ComposerGhostTextField.swift
+++ b/macos/Sources/Features/Ghostties/ComposerGhostTextField.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import GhosttiesCore
 
 // MARK: - UNVERIFIED — read before touching this file
 

--- a/macos/Sources/Features/Ghostties/EmptyState/PhysicsWorld.swift
+++ b/macos/Sources/Features/Ghostties/EmptyState/PhysicsWorld.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// Phase C carrier role for a ghost body.
 ///

--- a/macos/Sources/Features/Ghostties/EmptyState/SurfaceEmptyStatePhysics.swift
+++ b/macos/Sources/Features/Ghostties/EmptyState/SurfaceEmptyStatePhysics.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// Ambient ghost-drift layer for an empty terminal surface.
 ///

--- a/macos/Sources/Features/Ghostties/EmptyState/WordmarkGlyphs.swift
+++ b/macos/Sources/Features/Ghostties/EmptyState/WordmarkGlyphs.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import GhosttiesCore
 
 // No SwiftUI imports — pure CoreGraphics math.
 

--- a/macos/Sources/Features/Ghostties/GhostCharacter+Drawing.swift
+++ b/macos/Sources/Features/Ghostties/GhostCharacter+Drawing.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import GhosttiesCore
+
+/// SwiftUI rendering support for `GhostCharacter`.
+///
+/// Split out of `Models/GhostCharacter.swift` so that enum, which is
+/// otherwise pure data, can move into `GhosttiesCore` without dragging
+/// SwiftUI through `Project`'s dependency graph.
+extension GhostCharacter {
+    /// Render the pixel grid as a SwiftUI `Path` within the given rectangle.
+    ///
+    /// Builds the path from a cached unit-square (1×1) path via
+    /// `CGAffineTransform` scaling — benchmarked at the real 14×14 render size
+    /// with the real `.blinky` grid (108 filled cells): building the path from
+    /// scratch every call costs 7.862 µs vs `Circle()`'s 0.030 µs (264×).
+    /// Reusing a cached unit path and scaling it is ~9.5× cheaper and has no
+    /// behavior change — same filled cells, same crisp-at-any-size rendering.
+    func drawPath(in rect: CGRect) -> Path {
+        guard rect.width > 0, rect.height > 0 else { return Path() }
+        let unit = Self.unitPaths[self] ?? Path()
+        let transform = CGAffineTransform(translationX: rect.minX, y: rect.minY)
+            .scaledBy(x: rect.width, y: rect.height)
+        return unit.applying(transform)
+    }
+
+    /// One 1×1 (unit square) `Path` per character, built once from `pixelGrid` —
+    /// the basis `drawPath(in:)` scales via `CGAffineTransform` on every call
+    /// instead of rebuilding ~108 `addRect` calls from scratch each time.
+    fileprivate static let unitPaths: [GhostCharacter: Path] = {
+        var paths: [GhostCharacter: Path] = [:]
+        for character in GhostCharacter.allCases {
+            let grid = character.pixelGrid
+            let rows = grid.count
+            let cols = grid.first?.count ?? 0
+            guard rows > 0, cols > 0 else {
+                paths[character] = Path()
+                continue
+            }
+            let cellW = 1.0 / CGFloat(cols)
+            let cellH = 1.0 / CGFloat(rows)
+            var path = Path()
+            for row in 0..<rows {
+                for col in 0..<cols {
+                    guard grid[row][col] else { continue }
+                    let x = CGFloat(col) * cellW
+                    let y = CGFloat(row) * cellH
+                    path.addRect(CGRect(x: x, y: y, width: cellW, height: cellH))
+                }
+            }
+            paths[character] = path
+        }
+        return paths
+    }()
+}

--- a/macos/Sources/Features/Ghostties/GhostCharacterView.swift
+++ b/macos/Sources/Features/Ghostties/GhostCharacterView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// Whether the ghost is rendered filled or as an outline stroke.
 enum GhostStyle {

--- a/macos/Sources/Features/Ghostties/MenuBar/MenuBarDropdownView.swift
+++ b/macos/Sources/Features/Ghostties/MenuBar/MenuBarDropdownView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// SwiftUI view shown inside the menu bar popover.
 ///

--- a/macos/Sources/Features/Ghostties/Models/AgentSession.swift
+++ b/macos/Sources/Features/Ghostties/Models/AgentSession.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttiesCore
 
 /// Persistent metadata for a terminal session.
 ///

--- a/macos/Sources/Features/Ghostties/Models/ComposerCoreBridge.swift
+++ b/macos/Sources/Features/Ghostties/Models/ComposerCoreBridge.swift
@@ -1,0 +1,17 @@
+import Foundation
+import GhosttiesCore
+
+/// Bridges the session-composer command grammar and its supporting models
+/// into the app target from `GhosttiesCore`, where they moved so
+/// `swift test` in `cli/` can run their tests in CI (app-hosted tests
+/// cannot run there — see `.github/workflows/test-ghostties.yml`).
+///
+/// Mirrors `TaskModel.swift`'s `typealias TaskPriority = GhosttiesCore.TaskPriority`
+/// pattern: every existing call site across the app and its tests keeps
+/// using the bare type name unchanged.
+typealias GhostCharacter = GhosttiesCore.GhostCharacter
+typealias Project = GhosttiesCore.Project
+typealias AgentTemplate = GhosttiesCore.AgentTemplate
+typealias SessionComposerCommitError = GhosttiesCore.SessionComposerCommitError
+typealias SessionComposerCommandParser = GhosttiesCore.SessionComposerCommandParser
+typealias GitWorktreeEnumerator = GhosttiesCore.GitWorktreeEnumerator

--- a/macos/Sources/Features/Ghostties/NewTaskComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/NewTaskComposerStore.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import SwiftUI
+import GhosttiesCore
 
 /// State machine and commit logic for the inline new-task composer (U8 / SEA-164).
 ///

--- a/macos/Sources/Features/Ghostties/NewTaskComposerView.swift
+++ b/macos/Sources/Features/Ghostties/NewTaskComposerView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import GhosttiesCore
 
 /// Inline composer card for creating a new task (U8 / SEA-164).
 ///

--- a/macos/Sources/Features/Ghostties/OrphanTriageCardView.swift
+++ b/macos/Sources/Features/Ghostties/OrphanTriageCardView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import GhosttiesCore
 
 /// Inline triage card for orphan Inbox rows (U6 / SEA-162).
 ///

--- a/macos/Sources/Features/Ghostties/PresetLoader.swift
+++ b/macos/Sources/Features/Ghostties/PresetLoader.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CryptoKit
 import OSLog
+import GhosttiesCore
 
 /// Loads agent presets from `~/.ghostties/presets/` as `.md` files with YAML frontmatter.
 ///

--- a/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
+++ b/macos/Sources/Features/Ghostties/ProjectDisclosureRow.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// A project row in the disclosure list that expands to show sessions inline.
 ///
@@ -478,7 +479,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         if NSEvent.modifierFlags.contains(.option),
            let defaultId = project.defaultTemplateId,
            let template = store.templates.first(where: { $0.id == defaultId }) {
-            Task {
+            _Concurrency.Task {
                 await coordinator.createQuickSession(for: project, template: template)
             }
         } else {
@@ -496,7 +497,7 @@ private struct ProjectDisclosureRowContent: View, Equatable {
         // No pre-check needed — SessionCoordinator.createSession() calls
         // buildCommand() itself and handles missing prompt files gracefully.
         coordinator.clearRuntime(id: session.id)
-        Task {
+        _Concurrency.Task {
             await coordinator.createSession(session: session, template: template, project: project)
         }
     }

--- a/macos/Sources/Features/Ghostties/ProjectSettingsView.swift
+++ b/macos/Sources/Features/Ghostties/ProjectSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// Popover for editing a project's display name, ghost character, and default template.
 struct ProjectSettingsView: View {

--- a/macos/Sources/Features/Ghostties/RecentsListView.swift
+++ b/macos/Sources/Features/Ghostties/RecentsListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// The Sessions tab content: a flat, time-sorted list of all sessions across projects.
 ///
@@ -293,7 +294,7 @@ struct RecentsListView: View {
         // No pre-check needed — SessionCoordinator.createSession() calls
         // buildCommand() itself and handles missing prompt files gracefully.
         coordinator.clearRuntime(id: session.id)
-        Task {
+        _Concurrency.Task {
             await coordinator.createSession(session: session, template: template, project: project)
         }
     }

--- a/macos/Sources/Features/Ghostties/RowClickHandlers.swift
+++ b/macos/Sources/Features/Ghostties/RowClickHandlers.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import GhosttiesCore
 
 /// Handler stubs for the five R1 click lanes.
 ///

--- a/macos/Sources/Features/Ghostties/RowClickRouter.swift
+++ b/macos/Sources/Features/Ghostties/RowClickRouter.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import GhosttiesCore
 
 /// The logical lane a task row belongs to, derived at click-time from the
 /// task's `status` + whether it has valid project context in `WorkspaceStore`.

--- a/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerPalette.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import GhosttiesCore
 
 /// The session composer, presented in the existing sidebar popover (Phase 2
 /// of session-creation-unified — fixes D3/D11). A forked COPY of
@@ -109,7 +110,7 @@ struct SessionComposerPalette: View {
     /// and replaced on every `commandProject` change so a fast typist who
     /// flips through several project names before settling only ever fires
     /// the LAST one, never one refresh per keystroke.
-    @State private var commandProjectRefreshTask: Task<Void, Never>?
+    @State private var commandProjectRefreshTask: _Concurrency.Task<Void, Never>?
     @State private var isAddingTemplate = false
     @State private var newTemplateName = ""
     @State private var newTemplateToEdit: AgentTemplate?
@@ -1180,9 +1181,9 @@ struct SessionComposerPalette: View {
                 // still flip it more than once before settling.
                 commandProjectRefreshTask?.cancel()
                 if let project = commandProject {
-                    commandProjectRefreshTask = Task {
-                        try? await Task.sleep(for: .milliseconds(300))
-                        guard !Task.isCancelled else { return }
+                    commandProjectRefreshTask = _Concurrency.Task {
+                        try? await _Concurrency.Task.sleep(for: .milliseconds(300))
+                        guard !_Concurrency.Task.isCancelled else { return }
                         await composerStore.refreshWorktrees(for: project.rootPath, projectId: project.id)
                     }
                 } else {
@@ -1202,9 +1203,9 @@ struct SessionComposerPalette: View {
                     // fast-typing burst to coalesce here — this is the one
                     // moment the resolved project just disappeared.
                     if let project = currentProject {
-                        Task { await composerStore.refreshWorktrees(for: project.rootPath, projectId: project.id) }
+                        _Concurrency.Task { await composerStore.refreshWorktrees(for: project.rootPath, projectId: project.id) }
                     } else {
-                        Task { await composerStore.refreshWorktrees(for: nil, projectId: nil) }
+                        _Concurrency.Task { await composerStore.refreshWorktrees(for: nil, projectId: nil) }
                     }
                 }
             }
@@ -1561,7 +1562,7 @@ struct SessionComposerPalette: View {
         // actually drives it, not the click itself.
         .onChange(of: isBranchPickerOpen) { isOpen in
             guard isOpen, let project = currentProject else { return }
-            Task { await composerStore.refreshWorktrees(for: project.rootPath, projectId: project.id) }
+            _Concurrency.Task { await composerStore.refreshWorktrees(for: project.rootPath, projectId: project.id) }
         }
     }
 

--- a/macos/Sources/Features/Ghostties/SessionComposerRanking.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerRanking.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttiesCore
 
 /// Pure, testable relevance ranking + project ordering for the session
 /// composer (Phase 2 of session-creation-unified). Neither type touches

--- a/macos/Sources/Features/Ghostties/SessionComposerStore.swift
+++ b/macos/Sources/Features/Ghostties/SessionComposerStore.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import SwiftUI
+import GhosttiesCore
 
 /// Describes how a `SessionComposerPalette` was invoked (Phase 2 of
 /// session-creation-unified). Nothing else parameterizes the composer.
@@ -239,7 +240,7 @@ final class SessionComposerStore: ObservableObject {
     /// landing after a newer one — this store is a process-wide singleton,
     /// so a slow enumeration for project A must not overwrite project B's
     /// already-returned result if the user switched projects (or reopened
-    /// the composer) before A's `Task.detached` finished.
+    /// the composer) before A's `_Concurrency.Task.detached` finished.
     private var worktreeRefreshToken: Int = 0
 
     /// Re-enumerates worktrees for `repoPath` off the main actor, discarding
@@ -250,7 +251,7 @@ final class SessionComposerStore: ObservableObject {
     /// `await`ed `listTask.value`, which does not return early against a
     /// blocking `Process.waitUntilExit()` (cancellation is cooperative —
     /// nothing inside `GitWorktreeEnumerator.list`/`branchesWithoutWorktree`
-    /// checks `Task.isCancelled`). A hung `git` left `isRefreshingWorktrees`
+    /// checks `_Concurrency.Task.isCancelled`). A hung `git` left `isRefreshingWorktrees`
     /// stuck true forever, showing "Refreshing…" permanently, with every
     /// reopen spawning another hung process on top. `race(_:timeoutSeconds:)`
     /// is the same unstructured, never-await-the-loser shape
@@ -302,7 +303,7 @@ final class SessionComposerStore: ObservableObject {
         // entry point still called directly from this `@MainActor` method,
         // running a blocking `realpath(3)` syscall on the main thread on
         // every refresh.
-        let listTask = Task.detached(priority: .userInitiated) { () -> (isRepo: Bool, canonicalRepoPath: String, rawList: [GitWorktreeEnumerator.Worktree], branches: [String]) in
+        let listTask = _Concurrency.Task.detached(priority: .userInitiated) { () -> (isRepo: Bool, canonicalRepoPath: String, rawList: [GitWorktreeEnumerator.Worktree], branches: [String]) in
             let canonicalRepoPath = GitWorktreeEnumerator.canonicalPath(repoPath)
             // Should-fix 7 fix: derived from `git rev-parse
             // --is-inside-work-tree`'s exit status, never from
@@ -327,11 +328,11 @@ final class SessionComposerStore: ObservableObject {
             // terminate, since the caller had already returned. `listTask`
             // is now explicitly `.cancel()`ed on timeout (below) so this
             // check actually trips.
-            guard !Task.isCancelled else { return (false, canonicalRepoPath, [], []) }
+            guard !_Concurrency.Task.isCancelled else { return (false, canonicalRepoPath, [], []) }
             let rawList = GitWorktreeEnumerator.list(repoPath: repoPath) { process in
                 processHandle.set(process)
             }
-            guard !Task.isCancelled else { return (isRepo, canonicalRepoPath, rawList, []) }
+            guard !_Concurrency.Task.isCancelled else { return (isRepo, canonicalRepoPath, rawList, []) }
             // Nit fix (Slice B review round 2): pass the already-fetched
             // claimed-branch set in rather than letting
             // `branchesWithoutWorktree` call `list(repoPath:)` a SECOND
@@ -352,7 +353,7 @@ final class SessionComposerStore: ObservableObject {
             processHandle.terminate()
             // SF-3 fix (Slice B review round 3): cancels the still-running
             // detached task itself, not just the process it's currently
-            // blocked on — see the `Task.isCancelled` guards threaded
+            // blocked on — see the `_Concurrency.Task.isCancelled` guards threaded
             // through `listTask` above. Without this, killing ONE hung
             // process just let the task move on to the NEXT of the three
             // git invocations, which nothing was left to terminate.
@@ -386,8 +387,8 @@ final class SessionComposerStore: ObservableObject {
             // project, with no new UI surface and no synthetic input
             // required, until the machine's load clears and a refresh
             // finally lands.
-            Task {
-                try? await Task.sleep(for: .seconds(2))
+            _Concurrency.Task {
+                try? await _Concurrency.Task.sleep(for: .seconds(2))
                 guard token == worktreeRefreshToken else { return }
                 await self.refreshWorktrees(for: repoPath, projectId: projectId)
             }
@@ -634,7 +635,7 @@ final class SessionComposerStore: ObservableObject {
 
         if let projectId = selectedProjectId,
            let project = workspaceStore.projects.first(where: { $0.id == projectId }) {
-            Task { await self.refreshWorktrees(for: project.rootPath, projectId: project.id) }
+            _Concurrency.Task { await self.refreshWorktrees(for: project.rootPath, projectId: project.id) }
         }
     }
 
@@ -802,7 +803,7 @@ final class SessionComposerStore: ObservableObject {
         // no composer left to surface it into. This is exactly the
         // existing Option-click instant-create path's behaviour today —
         // the composer is at parity, not newly regressed.
-        Task.detached { [coordinator, launchTemplate] in
+        _Concurrency.Task.detached { [coordinator, launchTemplate] in
             _ = await coordinator.createQuickSession(for: project, template: launchTemplate)
         }
 
@@ -993,7 +994,7 @@ final class SessionComposerStore: ObservableObject {
         guard let projectId,
               let project = cachedWorkspaceStore?.projects.first(where: { $0.id == projectId })
         else { return }
-        Task { await self.refreshWorktrees(for: project.rootPath, projectId: project.id) }
+        _Concurrency.Task { await self.refreshWorktrees(for: project.rootPath, projectId: project.id) }
     }
 
     // MARK: - Branch chip (Slice B, B3)
@@ -1094,7 +1095,7 @@ final class SessionComposerStore: ObservableObject {
         // Unstructured (not a child of any task group) so a hang in the
         // `git` call it eventually makes never blocks the race below from
         // returning at the timeout deadline.
-        let gitTask = Task.detached(priority: .userInitiated) { () -> Result<String, GitWorktreeEnumerator.GitWorktreeCreationError> in
+        let gitTask = _Concurrency.Task.detached(priority: .userInitiated) { () -> Result<String, GitWorktreeEnumerator.GitWorktreeCreationError> in
             // Blocker 17 fix: resolves the repo's MAIN worktree explicitly
             // via `git rev-parse --git-common-dir`, never by assuming
             // `list(repoPath:)`'s first element is main — that list drops
@@ -1121,7 +1122,7 @@ final class SessionComposerStore: ObservableObject {
             return result
         }
 
-        Task {
+        _Concurrency.Task {
             let outcome = await Self.race(gitTask, timeoutSeconds: 10)
 
             // Discard if superseded — see `worktreeCreationToken`'s doc
@@ -1228,7 +1229,7 @@ final class SessionComposerStore: ObservableObject {
     /// that shape calls `.cancel()` on a timeout and then still `await`s
     /// the cancelled task's `.value`, which only works because
     /// `resolveCommand` eventually returns on its own — a blocking
-    /// `Process.waitUntilExit()` never checks `Task.isCancelled`, so the
+    /// `Process.waitUntilExit()` never checks `_Concurrency.Task.isCancelled`, so the
     /// same shape here would block on a hung `git worktree add` indefinitely
     /// regardless of the "timeout". Both branches below are independent,
     /// unstructured `Task`s (not children of a `TaskGroup`, which would
@@ -1240,12 +1241,12 @@ final class SessionComposerStore: ObservableObject {
     /// short `timeoutSeconds` against a task that never completes, since a
     /// real `createWorktree` timeout would otherwise take an actual 10
     /// seconds of wall-clock time to prove.
-    static func race(_ task: Task<Result<String, GitWorktreeEnumerator.GitWorktreeCreationError>, Never>, timeoutSeconds: Double) async -> WorktreeCreationOutcome {
+    static func race(_ task: _Concurrency.Task<Result<String, GitWorktreeEnumerator.GitWorktreeCreationError>, Never>, timeoutSeconds: Double) async -> WorktreeCreationOutcome {
         await withCheckedContinuation { continuation in
             let lock = NSLock()
             var didResume = false
-            var waiterTask: Task<Void, Never>?
-            var timeoutTask: Task<Void, Never>?
+            var waiterTask: _Concurrency.Task<Void, Never>?
+            var timeoutTask: _Concurrency.Task<Void, Never>?
             func resumeOnce(_ outcome: WorktreeCreationOutcome) {
                 lock.lock()
                 defer { lock.unlock() }
@@ -1266,12 +1267,12 @@ final class SessionComposerStore: ObservableObject {
             // genuine data race on the references themselves, independent
             // of the (much narrower, effectively unobservable in practice
             // given the real work — a detached `git worktree add`, or a
-            // multi-second `Task.sleep` — each side does before it can call
+            // multi-second `_Concurrency.Task.sleep` — each side does before it can call
             // `resumeOnce`) ordering window where a task could finish and
             // call `resumeOnce` before its OWN reference is even stored.
             // Locking every write closes the data race the reviewer flagged;
             // the latter, narrower window is unchanged from before this fix.
-            let waiter = Task<Void, Never> {
+            let waiter = _Concurrency.Task<Void, Never> {
                 let result = await task.value
                 resumeOnce(.completed(result))
             }
@@ -1279,8 +1280,8 @@ final class SessionComposerStore: ObservableObject {
             waiterTask = waiter
             lock.unlock()
 
-            let timeout = Task<Void, Never> {
-                try? await Task.sleep(for: .seconds(timeoutSeconds))
+            let timeout = _Concurrency.Task<Void, Never> {
+                try? await _Concurrency.Task.sleep(for: .seconds(timeoutSeconds))
                 resumeOnce(.timedOut)
             }
             lock.lock()
@@ -1307,12 +1308,12 @@ final class SessionComposerStore: ObservableObject {
     /// caller's `T` (this file's own tuple result type) is already
     /// `Sendable`, so this is a compile-time-only tightening, not a
     /// behavior change.
-    static func raceAny<T: Sendable>(_ task: Task<T, Never>, timeoutSeconds: Double) async -> T? {
+    static func raceAny<T: Sendable>(_ task: _Concurrency.Task<T, Never>, timeoutSeconds: Double) async -> T? {
         await withCheckedContinuation { continuation in
             let lock = NSLock()
             var didResume = false
-            var waiterTask: Task<Void, Never>?
-            var timeoutTask: Task<Void, Never>?
+            var waiterTask: _Concurrency.Task<Void, Never>?
+            var timeoutTask: _Concurrency.Task<Void, Never>?
             func resumeOnce(_ outcome: T?) {
                 lock.lock()
                 defer { lock.unlock() }
@@ -1328,7 +1329,7 @@ final class SessionComposerStore: ObservableObject {
             // Nit fix (Slice B review round 3): same synchronization fix as
             // `race(_:timeoutSeconds:)` above — see that function's matching
             // comment.
-            let waiter = Task<Void, Never> {
+            let waiter = _Concurrency.Task<Void, Never> {
                 let result = await task.value
                 resumeOnce(result)
             }
@@ -1336,8 +1337,8 @@ final class SessionComposerStore: ObservableObject {
             waiterTask = waiter
             lock.unlock()
 
-            let timeout = Task<Void, Never> {
-                try? await Task.sleep(for: .seconds(timeoutSeconds))
+            let timeout = _Concurrency.Task<Void, Never> {
+                try? await _Concurrency.Task.sleep(for: .seconds(timeoutSeconds))
                 resumeOnce(nil)
             }
             lock.lock()

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -2,6 +2,7 @@ import AppKit
 import Combine
 import SwiftUI
 import GhosttyKit
+import GhosttiesCore
 
 /// Bridges the SwiftUI sidebar to Ghostty's terminal surface system.
 ///
@@ -192,7 +193,7 @@ final class SessionCoordinator: ObservableObject {
         let resolvedCommand: String? = await {
             guard template.command != nil else { return nil }
 
-            let buildAndResolveTask = Task.detached(priority: .userInitiated) { () -> String? in
+            let buildAndResolveTask = _Concurrency.Task.detached(priority: .userInitiated) { () -> String? in
                 // Build the full command string (includes agent flags, prompt file references).
                 let built = template.buildCommand()
                 guard !built.isEmpty else { return nil }
@@ -207,8 +208,8 @@ final class SessionCoordinator: ObservableObject {
                 }
                 return built
             }
-            let timeoutTask = Task {
-                try await Task.sleep(for: .seconds(3))
+            let timeoutTask = _Concurrency.Task {
+                try await _Concurrency.Task.sleep(for: .seconds(3))
                 buildAndResolveTask.cancel()
             }
             let result = await buildAndResolveTask.value

--- a/macos/Sources/Features/Ghostties/SessionDetailView.swift
+++ b/macos/Sources/Features/Ghostties/SessionDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// A single session row: name + ghost character status indicator.
 ///

--- a/macos/Sources/Features/Ghostties/SessionTemplateResolver.swift
+++ b/macos/Sources/Features/Ghostties/SessionTemplateResolver.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttiesCore
 
 /// The single source of truth for "which templates are available to a
 /// project, in what order" for the session-creation surfaces (the New

--- a/macos/Sources/Features/Ghostties/TaskRowView.swift
+++ b/macos/Sources/Features/Ghostties/TaskRowView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import GhosttiesCore
 
 // MARK: - ReturnKeyActivationModifier
 

--- a/macos/Sources/Features/Ghostties/TemplatePickerView.swift
+++ b/macos/Sources/Features/Ghostties/TemplatePickerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import GhosttiesCore
 
 /// A popover presenting available session templates for a project.
 ///
@@ -367,7 +368,7 @@ struct TemplatePickerView: View {
     }
 
     private func createSession(from template: AgentTemplate) {
-        Task {
+        _Concurrency.Task {
             await coordinator.createQuickSession(for: project, template: template)
         }
         dismiss()

--- a/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
+++ b/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OSLog
+import GhosttiesCore
 
 /// Reads and writes workspace state (projects) to a JSON file
 /// at ~/Library/Application Support/Ghostties/workspace.json (release) or

--- a/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceSidebarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import GhosttiesCore
 
 /// The two top-level views the sidebar can display.
 ///

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import SwiftUI
+import GhosttiesCore
 
 /// Central state manager for workspace projects, sessions, and templates.
 ///
@@ -1257,7 +1258,7 @@ final class WorkspaceStore: ObservableObject {
 
     /// Debounced persistence — coalesces rapid mutations into a single disk write
     /// on a background thread to avoid blocking the main actor.
-    private var persistTask: Task<Void, Never>?
+    private var persistTask: _Concurrency.Task<Void, Never>?
 
     #if DEBUG
     /// Test-only invocation counter — increments on every `persist()` call
@@ -1274,9 +1275,9 @@ final class WorkspaceStore: ObservableObject {
         #endif
         guard !persistenceDisabled else { return }
         persistTask?.cancel()
-        persistTask = Task { [projects, sessions, templates, sidebarMode, lastSelectedProjectId, hasShownPinMigrationNotice, hasDismissedPinMigrationNotice] in
-            try? await Task.sleep(for: .milliseconds(100))
-            guard !Task.isCancelled else { return }
+        persistTask = _Concurrency.Task { [projects, sessions, templates, sidebarMode, lastSelectedProjectId, hasShownPinMigrationNotice, hasDismissedPinMigrationNotice] in
+            try? await _Concurrency.Task.sleep(for: .milliseconds(100))
+            guard !_Concurrency.Task.isCancelled else { return }
             let customTemplates = templates.filter { !$0.isDefault }
             // Overlay is transient — persist as closed so next launch starts closed.
             let persistedMode: SidebarMode = sidebarMode == .overlay ? .closed : sidebarMode
@@ -1289,7 +1290,7 @@ final class WorkspaceStore: ObservableObject {
                 hasShownPinMigrationNotice: hasShownPinMigrationNotice,
                 hasDismissedPinMigrationNotice: hasDismissedPinMigrationNotice
             )
-            await Task.detached(priority: .utility) {
+            await _Concurrency.Task.detached(priority: .utility) {
                 WorkspacePersistence.save(state)
             }.value
         }

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import SwiftUI
+import GhosttiesCore
 
 /// Observable width holder for the sidebar's SwiftUI `.frame(width:)` pin.
 /// Owned by `WorkspaceViewContainer` and updated by the drag handler on every
@@ -912,7 +913,7 @@ class WorkspaceViewContainer: NSView {
                 // docs/plans/session-creation-unified.html).
                 // Create a new browser session — this will call showBrowserContent,
                 // which embeds into the side panel and animates it open.
-                Task { @MainActor in
+                _Concurrency.Task { @MainActor in
                     await coordinator.createQuickSession(for: project, template: .browser)
                 }
             }
@@ -1772,7 +1773,7 @@ class WorkspaceViewContainer: NSView {
             userInfo: ["projectId": project.id]
         )
 
-        Task {
+        _Concurrency.Task {
             await coordinator.createQuickSession(for: project, template: template)
         }
     }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -3,6 +3,7 @@ import Cocoa
 import SwiftUI
 import Combine
 import GhosttyKit
+import GhosttiesCore
 
 /// A classic, tabbed terminal experience.
 class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Controller {

--- a/macos/Tests/Ghostties/ComposerCardFitTests.swift
+++ b/macos/Tests/Ghostties/ComposerCardFitTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// COMMITTED invariant test for the composer card-fit regression fixed by

--- a/macos/Tests/Ghostties/ComposerGhostTextFieldTests.swift
+++ b/macos/Tests/Ghostties/ComposerGhostTextFieldTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Step 7 (Composer UI 11 plan §5/§7) — model B spike tests.

--- a/macos/Tests/Ghostties/EmptyStatePhysicsTests.swift
+++ b/macos/Tests/Ghostties/EmptyStatePhysicsTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import CoreGraphics
 import SwiftUI
+import GhosttiesCore
 @testable import Ghostty
 
 final class EmptyStatePhysicsTests: XCTestCase {

--- a/macos/Tests/Ghostties/ExpandGraveyardTaskTests.swift
+++ b/macos/Tests/Ghostties/ExpandGraveyardTaskTests.swift
@@ -3,6 +3,7 @@
 // See .github/workflows/test-ghostties.yml — macos-app job is build-only due to
 // XCTest host app hang in headless GH Actions runners.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for U7 Graveyard inline expansion state logic (SEA-163).

--- a/macos/Tests/Ghostties/FocusRunningTaskTests.swift
+++ b/macos/Tests/Ghostties/FocusRunningTaskTests.swift
@@ -3,6 +3,7 @@
 // See .github/workflows/test-ghostties.yml — macos-app job is build-only due to
 // XCTest host app hang in headless GH Actions runners.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for `RowClickHandlers.focusRunningTask` and `focusNeedsYouTask` (U5, SEA-161).

--- a/macos/Tests/Ghostties/GitWorktreeCreationTests.swift
+++ b/macos/Tests/Ghostties/GitWorktreeCreationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Coverage for `GitWorktreeEnumerator.branchExists`/`add(branch:directory:repoPath:)`
@@ -275,8 +276,8 @@ struct GitWorktreeCreationTests {
     /// `task.value` directly (no independent race) would hang this test
     /// instead of failing it fast.
     @Test func raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes() async {
-        let neverFinishes: Task<Result<String, GitWorktreeEnumerator.GitWorktreeCreationError>, Never> = Task {
-            try? await Task.sleep(for: .seconds(3600))
+        let neverFinishes: _Concurrency.Task<Result<String, GitWorktreeEnumerator.GitWorktreeCreationError>, Never> = _Concurrency.Task {
+            try? await _Concurrency.Task.sleep(for: .seconds(3600))
             return .success("unreachable")
         }
         defer { neverFinishes.cancel() }
@@ -411,7 +412,7 @@ struct GitWorktreeCreationTests {
     }
 
     @Test func raceReturnsCompletedWhenTheUnderlyingTaskFinishesBeforeTheDeadline() async {
-        let fastTask: Task<Result<String, GitWorktreeEnumerator.GitWorktreeCreationError>, Never> = Task {
+        let fastTask: _Concurrency.Task<Result<String, GitWorktreeEnumerator.GitWorktreeCreationError>, Never> = _Concurrency.Task {
             .success("/fast/path")
         }
 

--- a/macos/Tests/Ghostties/GitWorktreeEnumeratorTests.swift
+++ b/macos/Tests/Ghostties/GitWorktreeEnumeratorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Coverage for `GitWorktreeEnumerator.parsePorcelain` (composer breadcrumb

--- a/macos/Tests/Ghostties/KeyboardShortcutsTests.swift
+++ b/macos/Tests/Ghostties/KeyboardShortcutsTests.swift
@@ -6,6 +6,7 @@
 // NOTE (R14): j/k full-row cycling is explicitly deferred to v0.1+.
 // Only Return (activate) and ⌘O (open .md) are wired in v0.
 import XCTest
+import struct GhosttiesCore.Project
 @testable import Ghostty
 
 /// Tests for the U11 keyboard shortcut infrastructure:

--- a/macos/Tests/Ghostties/MultiWindowScopingTests.swift
+++ b/macos/Tests/Ghostties/MultiWindowScopingTests.swift
@@ -8,6 +8,7 @@
 //   P1-001   — spawn fires only in the window that owns the clicked coordinator
 //
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for D9 / P1-001 multi-window scoping in the row-click flow.

--- a/macos/Tests/Ghostties/NewTaskComposerTests.swift
+++ b/macos/Tests/Ghostties/NewTaskComposerTests.swift
@@ -3,6 +3,7 @@
 // See .github/workflows/test-ghostties.yml — macos-app job is build-only due to
 // XCTest host app hang in headless GH Actions runners.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for `NewTaskComposerStore` and the U8 inline new-task composer

--- a/macos/Tests/Ghostties/RecentsListViewTests.swift
+++ b/macos/Tests/Ghostties/RecentsListViewTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for the recents-list ordering + section-membership logic in RecentsListView.

--- a/macos/Tests/Ghostties/RowClickRouterTests.swift
+++ b/macos/Tests/Ghostties/RowClickRouterTests.swift
@@ -3,6 +3,7 @@
 // See .github/workflows/test-ghostties.yml — macos-app job is build-only due to
 // XCTest host app hang in headless GH Actions runners.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for `RowClickRouter.computeLane(for:workspaceStore:)`.

--- a/macos/Tests/Ghostties/SessionComposerBranchLaunchTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerBranchLaunchTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Coverage for finding 18 (Slice B review round 1): "the feature itself has

--- a/macos/Tests/Ghostties/SessionComposerBreadcrumbChipTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerBreadcrumbChipTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Coverage for the breadcrumb chip's cascade + undo logic (composer

--- a/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for the composer's text-forward command grammar (slice 1). Pure
@@ -1793,77 +1794,9 @@ final class SessionComposerCommandParserTests: XCTestCase {
         XCTAssertEqual(operatorSegment?.resolved, .template(template.id))
     }
 
-    // MARK: - Real-usage idiom invariant (`repo cco -n "thread name"` / `repo ccp`)
-    //
-    // Sean's actual daily usage is `repo cco -n "thread name"` and `repo
-    // ccp`, ~95% of everything typed into the composer. `-n` is `cco`'s own
-    // flag — the composer must NEVER claim it for itself (e.g. to name a
-    // session). These tests pin that the remainder — including `-n` and a
-    // quoted multi-word argument — reaches both `ParseResult.remainderTokens`
-    // AND the synthesized `AgentTemplate` (what actually launches) byte-for-
-    // byte, attributed entirely to the ad-hoc command (`cco`), never
-    // consumed or reinterpreted by the parser. Synthetic project name
-    // (`atlas`) — this is a public repo.
-
-    func testRealIdiomCcoDashNQuotedThreadNameReachesRemainderIntact() {
-        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
-        let result = SessionComposerCommandParser.parse(
-            query: #"atlas cco -n "thread name""#,
-            projects: [project],
-            isLocked: false
-        )
-        XCTAssertEqual(result.projectId, project.id)
-        XCTAssertEqual(result.remainderTokens, ["cco", "-n", "thread name"])
-    }
-
-    /// The remainder above must also reach the LAUNCHED command intact —
-    /// `-n` and the quoted thread name attributed to `cco` via
-    /// `additionalFlags`, not folded into `command` or dropped. Calls the
-    /// real production `buildCommand()` so a future per-token escaping
-    /// change that mangled `-n` specifically would also be caught here.
-    func testRealIdiomCcoDashNQuotedThreadNameReachesLaunchCommandIntact() {
-        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
-        let result = SessionComposerCommandParser.parse(
-            query: #"atlas cco -n "thread name""#,
-            projects: [project],
-            isLocked: false
-        )
-        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: result.remainderTokens)
-        XCTAssertEqual(template?.command, "cco")
-        XCTAssertEqual(template?.agent?.additionalFlags, ["-n", "thread name"])
-        XCTAssertEqual(template?.buildCommand(), "'cco' '-n' 'thread name'")
-    }
-
-    /// `repo ccp` — the other half of the 95% idiom. A single-token
-    /// remainder must still resolve the project and pass `ccp` through
-    /// untouched; nothing about a bare remainder should special-case or
-    /// drop it.
-    func testRealIdiomCcpSingleTokenRemainderResolves() {
-        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
-        let result = SessionComposerCommandParser.parse(
-            query: "atlas ccp",
-            projects: [project],
-            isLocked: false
-        )
-        XCTAssertEqual(result.projectId, project.id)
-        XCTAssertEqual(result.remainderTokens, ["ccp"])
-    }
-
-    /// Explicit guard: `-n` must never be treated as a composer-owned flag
-    /// anywhere in the parse — not consumed into `branchToken`, not
-    /// resolved as a template/operator segment, and not stripped from
-    /// `remainderTokens`. `ParseResult` has no field of its own for a
-    /// captured session name; if one is ever added and wired to intercept
-    /// `-n`, this must be the test that goes red first.
-    func testDashNIsNeverClaimedAsAComposerOwnedFlag() {
-        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
-        let result = SessionComposerCommandParser.parse(
-            query: #"atlas run -n "some name""#,
-            projects: [project],
-            isLocked: false
-        )
-        XCTAssertEqual(result.remainderTokens, ["run", "-n", "some name"])
-        XCTAssertNil(result.branchToken, "-n must not be captured as a branch/name segment")
-        XCTAssertNil(result.resolvedTemplateId, "-n must not resolve as an operator/template segment")
-    }
+    // The real-usage idiom invariant (`repo cco -n "thread name"` / `repo
+    // ccp`, four tests from commit `151898bbd`) moved to
+    // `cli/Tests/GhosttiesCoreTests/SessionComposerCommandParserIdiomTests.swift`
+    // alongside `SessionComposerCommandParser`'s move into `GhosttiesCore` —
+    // `swift test` in `cli/` runs there in CI; this app-hosted target does not.
 }

--- a/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerCommandParserTests.swift
@@ -1792,4 +1792,78 @@ final class SessionComposerCommandParserTests: XCTestCase {
         let operatorSegment = result.segments.first { $0.kind == .operation }
         XCTAssertEqual(operatorSegment?.resolved, .template(template.id))
     }
+
+    // MARK: - Real-usage idiom invariant (`repo cco -n "thread name"` / `repo ccp`)
+    //
+    // Sean's actual daily usage is `repo cco -n "thread name"` and `repo
+    // ccp`, ~95% of everything typed into the composer. `-n` is `cco`'s own
+    // flag — the composer must NEVER claim it for itself (e.g. to name a
+    // session). These tests pin that the remainder — including `-n` and a
+    // quoted multi-word argument — reaches both `ParseResult.remainderTokens`
+    // AND the synthesized `AgentTemplate` (what actually launches) byte-for-
+    // byte, attributed entirely to the ad-hoc command (`cco`), never
+    // consumed or reinterpreted by the parser. Synthetic project name
+    // (`atlas`) — this is a public repo.
+
+    func testRealIdiomCcoDashNQuotedThreadNameReachesRemainderIntact() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: #"atlas cco -n "thread name""#,
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.projectId, project.id)
+        XCTAssertEqual(result.remainderTokens, ["cco", "-n", "thread name"])
+    }
+
+    /// The remainder above must also reach the LAUNCHED command intact —
+    /// `-n` and the quoted thread name attributed to `cco` via
+    /// `additionalFlags`, not folded into `command` or dropped. Calls the
+    /// real production `buildCommand()` so a future per-token escaping
+    /// change that mangled `-n` specifically would also be caught here.
+    func testRealIdiomCcoDashNQuotedThreadNameReachesLaunchCommandIntact() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: #"atlas cco -n "thread name""#,
+            projects: [project],
+            isLocked: false
+        )
+        let template = SessionComposerCommandParser.makeAdHocTemplate(remainderTokens: result.remainderTokens)
+        XCTAssertEqual(template?.command, "cco")
+        XCTAssertEqual(template?.agent?.additionalFlags, ["-n", "thread name"])
+        XCTAssertEqual(template?.buildCommand(), "'cco' '-n' 'thread name'")
+    }
+
+    /// `repo ccp` — the other half of the 95% idiom. A single-token
+    /// remainder must still resolve the project and pass `ccp` through
+    /// untouched; nothing about a bare remainder should special-case or
+    /// drop it.
+    func testRealIdiomCcpSingleTokenRemainderResolves() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: "atlas ccp",
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.projectId, project.id)
+        XCTAssertEqual(result.remainderTokens, ["ccp"])
+    }
+
+    /// Explicit guard: `-n` must never be treated as a composer-owned flag
+    /// anywhere in the parse — not consumed into `branchToken`, not
+    /// resolved as a template/operator segment, and not stripped from
+    /// `remainderTokens`. `ParseResult` has no field of its own for a
+    /// captured session name; if one is ever added and wired to intercept
+    /// `-n`, this must be the test that goes red first.
+    func testDashNIsNeverClaimedAsAComposerOwnedFlag() {
+        let project = makeProject(name: "atlas", rootPath: "/Users/example/Code/atlas")
+        let result = SessionComposerCommandParser.parse(
+            query: #"atlas run -n "some name""#,
+            projects: [project],
+            isLocked: false
+        )
+        XCTAssertEqual(result.remainderTokens, ["run", "-n", "some name"])
+        XCTAssertNil(result.branchToken, "-n must not be captured as a branch/name segment")
+        XCTAssertNil(result.resolvedTemplateId, "-n must not resolve as an operator/template segment")
+    }
 }

--- a/macos/Tests/Ghostties/SessionComposerGhostPlaceholderTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerGhostPlaceholderTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Step 3 (Composer UI 11 plan §3): `SessionComposerCommandParser.ghostPlaceholder`

--- a/macos/Tests/Ghostties/SessionComposerModelBGhostSourceTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerModelBGhostSourceTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Model B's ghost source (Spotlight-inline-completion + Raycast-Tab-drill

--- a/macos/Tests/Ghostties/SessionComposerPhase3ReviewTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerPhase3ReviewTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import AppKit
 import SwiftUI
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Regression coverage for the Phase 3 review pass of session-creation-unified

--- a/macos/Tests/Ghostties/SessionComposerPinningTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerPinningTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Coverage for the composer's pinned-template data layer (Composer UI 11,

--- a/macos/Tests/Ghostties/SessionComposerRankingTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerRankingTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for the two pure, testable pieces of the session composer's

--- a/macos/Tests/Ghostties/SessionComposerSnapshotTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerSnapshotTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// The Step 2 snapshot harness (Composer UI 11 plan §3, evidence contract

--- a/macos/Tests/Ghostties/SessionComposerStatusStripTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerStatusStripTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Step 4 (Composer UI 11 plan §3): status strip priority and the

--- a/macos/Tests/Ghostties/SessionComposerTrailingControlTests.swift
+++ b/macos/Tests/Ghostties/SessionComposerTrailingControlTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Step 5 (Composer UI 11 plan §3): `trailingControlVisibility`'s matrix —

--- a/macos/Tests/Ghostties/SessionCoordinatorIndicatorStateTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorIndicatorStateTests.swift
@@ -1,6 +1,7 @@
 // IDE-ONLY: not currently exercised in CI macos job (build-only).
 // Run via Xcode Cmd+U or xcodebuild test locally.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for the fallback branch at the end of the `.running` case in

--- a/macos/Tests/Ghostties/SessionCoordinatorOutputActivityTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorOutputActivityTests.swift
@@ -2,6 +2,7 @@
 // Run via Xcode Cmd+U or xcodebuild test locally.
 import Combine
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Pins `SessionCoordinator.subscribeToOutput`'s `isOutput: true` argument —

--- a/macos/Tests/Ghostties/SessionNameSyncTests.swift
+++ b/macos/Tests/Ghostties/SessionNameSyncTests.swift
@@ -2,6 +2,7 @@
 // Run via Xcode Cmd+U or xcodebuild test locally.
 import Combine
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for `WorkspaceStore.syncSessionNameFromTitle` / `renameSession` /

--- a/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
+++ b/macos/Tests/Ghostties/SessionTemplateResolverTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for `SessionTemplateResolver` — the single template scoping +

--- a/macos/Tests/Ghostties/WordmarkPhysicsTests.swift
+++ b/macos/Tests/Ghostties/WordmarkPhysicsTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import CoreGraphics
 import SwiftUI
+import GhosttiesCore
 @testable import Ghostty
 
 final class WordmarkPhysicsTests: XCTestCase {

--- a/macos/Tests/Ghostties/WorkspaceStoreTemplateDedupeTests.swift
+++ b/macos/Tests/Ghostties/WorkspaceStoreTemplateDedupeTests.swift
@@ -3,6 +3,7 @@
 // See .github/workflows/test-ghostties.yml — macos-app job is build-only due to
 // XCTest host app hang in headless GH Actions runners.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for `WorkspaceStore`'s name-uniqueness invariant across all three

--- a/macos/Tests/Workspace/AgentSessionTests.swift
+++ b/macos/Tests/Workspace/AgentSessionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 struct AgentSessionTests {

--- a/macos/Tests/Workspace/AgentTemplateTests.swift
+++ b/macos/Tests/Workspace/AgentTemplateTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 struct AgentTemplateTests {

--- a/macos/Tests/Workspace/PresetLoaderTests.swift
+++ b/macos/Tests/Workspace/PresetLoaderTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 struct PresetLoaderTests {

--- a/macos/Tests/Workspace/WorkspacePersistenceTests.swift
+++ b/macos/Tests/Workspace/WorkspacePersistenceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 struct WorkspacePersistenceTests {
@@ -90,6 +91,66 @@ struct WorkspacePersistenceTests {
         #expect(decoded.projects.isEmpty)
         #expect(decoded.sessions.isEmpty)
         #expect(decoded.templates.isEmpty)
+    }
+
+    /// Module-move proof (composer-parser-to-core): `Project`, `AgentSession`,
+    /// and `GhostCharacter` moved from the app target into `GhosttiesCore`.
+    /// JSON `Codable` doesn't embed module names, so this SHOULD be
+    /// transparent — but that's a claim, not a fact, until a real-shaped
+    /// `workspace.json` fixture with a persisted `ghostCharacter` value
+    /// round-trips through the actual decoder. A silent decode failure here
+    /// wipes Sean's sidebar state.
+    @Test func decodingRealShapedWorkspaceJsonRoundTripsPersistedGhostCharacter() throws {
+        let projectId = UUID()
+        let templateId = UUID()
+        let json = """
+        {
+            "projects": [
+                {
+                    "id": "\(projectId.uuidString)",
+                    "name": "ghostties",
+                    "rootPath": "/Users/sean/Code/ghostties",
+                    "isPinned": true,
+                    "ghostCharacter": "blinky",
+                    "defaultTemplateId": "\(templateId.uuidString)",
+                    "lastActiveAt": 780000000.0
+                }
+            ],
+            "sessions": [],
+            "templates": [
+                {
+                    "id": "\(templateId.uuidString)",
+                    "name": "Claude Code",
+                    "kind": "claudeCode",
+                    "isDefault": true,
+                    "isGlobal": true,
+                    "command": "claude",
+                    "environmentVariables": {}
+                }
+            ],
+            "sidebarMode": 0,
+            "lastSelectedProjectId": "\(projectId.uuidString)"
+        }
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: data)
+
+        #expect(decoded.projects.count == 1)
+        #expect(decoded.projects[0].id == projectId)
+        #expect(decoded.projects[0].ghostCharacter == .blinky)
+        #expect(decoded.projects[0].isPinned == true)
+        #expect(decoded.projects[0].defaultTemplateId == templateId)
+        #expect(decoded.templates.count == 1)
+        #expect(decoded.templates[0].kind == .claudeCode)
+
+        // Full round-trip: re-encode the decoded state and decode it again —
+        // the persisted ghostCharacter must survive a real save/load cycle,
+        // not just a single one-shot decode of a hand-written fixture.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let reEncoded = try encoder.encode(decoded)
+        let reDecoded = try JSONDecoder().decode(WorkspacePersistence.State.self, from: reEncoded)
+        #expect(reDecoded.projects[0].ghostCharacter == .blinky)
     }
 
     @Test func decodingLegacySidebarVisibleTrueMigratesToPinned() throws {

--- a/macos/Tests/Workspace/WorkspaceStoreFreezeTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreFreezeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for Unit 4 of the sidebar smart-sections plan:

--- a/macos/Tests/Workspace/WorkspaceStoreGhostTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreGhostTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for per-session/per-project ghost assignment:

--- a/macos/Tests/Workspace/WorkspaceStoreLastOutputAtTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreLastOutputAtTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Coverage for `lastOutputAt` — the field split out of `lastActiveAt` so

--- a/macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStorePinOnAddTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for Session Composer Phase 5: `WorkspaceStore.addProject(at:pinned:)`

--- a/macos/Tests/Workspace/WorkspaceStorePruneTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStorePruneTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for the launch-time stale-session prune (`pruneStaleSessionsAtLaunch()`).

--- a/macos/Tests/Workspace/WorkspaceStoreSectionsTests.swift
+++ b/macos/Tests/Workspace/WorkspaceStoreSectionsTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import Testing
+import GhosttiesCore
 @testable import Ghostty
 
 /// Tests for Unit 2 of the sidebar smart-sections plan:


### PR DESCRIPTION
Moves the session-composer command parser and its Foundation-only type dependencies into the `GhosttiesCore` Swift package, so the `-n` idiom invariant executes in CI.

## Why

CI runs `swift test --parallel` on `cli/` but only `xcodebuild build-for-testing` on the app (the headless runner hangs on host launch — see `test-ghostties.yml:140-151`). Any invariant living in the app-hosted target only runs when someone remembers Cmd+U. Sean's real input shape — `<repo> cco -n "thread name"`, where `-n` belongs to his `cco` shell function and the composer must never claim it — was pinned by four tests that CI could not execute. Now it can.

## What moved

`macos/Sources/Features/Ghostties/` → `cli/Sources/GhosttiesCore/`:
`SessionComposerCommandParser.swift`, `Project.swift`, `AgentTemplate.swift`, `GhostCharacter.swift`, `GitWorktreeEnumerator.swift`.

`GhostCharacter` was the whole blocker: it imported SwiftUI for a single `drawPath(in:)` on an otherwise pure-data enum, and `Project` holds a `GhostCharacter?`, so that one import dragged SwiftUI through `Project` into the parser. The rendering half now lives in `GhostCharacter+Drawing.swift` in the app target.

Bridging follows the pattern `TaskModel.swift` already established: `ComposerCoreBridge.swift` with six `typealias X = GhosttiesCore.X` lines.

## Diff shape

77 files, +533/−304 — but **57 are exactly one line** (`import GhosttiesCore`, forced by `MemberImportVisibility`, which is on project-wide). Five are renames of the moved files where the edits are `public` widening. The hand-edited production surface is nine files, ~60 lines: `SessionComposerStore.swift` (28/27), `SessionComposerPalette.swift` (8/7), `WorkspaceStore.swift` (6/5), `AppDelegate.swift` (5/4), `SessionCoordinator.swift` (4/3), and four others at 2–3 lines.

Most of that is `_Concurrency.Task` qualification: `GhosttiesCore` already exports a `public struct Task`, so `Task {}` / `Task.detached` became ambiguous in ten files. Same idiom `TaskStore.swift` already uses. One test file hit a second collision (app `TaskStore` vs `GhosttiesCore.TaskStore`), resolved with a scoped `import struct` rather than the blanket module import.

## Evidence

- `cd cli && swift test --parallel` — exit 0, 114 tests, all four idiom tests running and passing.
- **Mutation-verified:** filtering `-n` out of `makeAdHocTemplate`'s flags turned `testRealIdiomCcoDashNQuotedThreadNameReachesLaunchCommandIntact` red (`["thread name"]` vs `["-n", "thread name"]`); the other three correctly stayed green. Reverted, exit 0.
- Persistence round-trip added: `workspace.json` with `"ghostCharacter": "blinky"` survives two encode/decode cycles, so the module move is transparent to `Codable`.
- App suite on the branch: 971 passed / 4 failed / 1 skipped. Three of those four were the ghost-band snapshot failures fixed by #142, which was not in this branch's ancestry; the fourth is the documented `raceReturnsTimedOut` flake. Re-verified against merged `main` before this merges.

Merges clean against `main` (`git merge-tree`, no conflicts).