### PR TITLE
fix(tests): import GhosttiesCore in SessionEnvironmentStampTests

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2015,3 +2015,24 @@ Branch `feat/composer-branch-segment` @ `948ad5fa8`, pushed, suite 871/0/1, tree
 **Accepted risks, stated rather than solved:** no macOS 13 coverage (a VM is disproportionate);
 keyboard behavior gated on Sean's manual pass — subagents may screen-capture but must NEVER drive
 synthetic keystrokes ([[feedback_subagent-gui-automation-hit-live-session]]).
+
+## 2026-08-31 — Composer variant G session (carried)
+
+Branch `feat/composer-variant-g`, 10 commits pushed to origin, UNMERGED.
+
+**Decisions open on Sean (carried 1×):**
+- [ ] Composer type scale — mockup values (header 10pt `.bold` + 0.6 tracking; footer 10.5pt `design: .monospaced`; strip `Color.secondary.opacity(0.08)`) vs `DESIGN.md`'s 15/13/11 scale + one font family. Note: no monospaced font carries `↵`/`⇥`, so the footer mixes families either way — weakens the mono case.
+- [ ] `macos/Tests/Ghostties/ThrottleTrailingEdgeHypothesisTests.swift` — delete or fix? Untracked, dated Aug 14, self-described "DIAGNOSTIC ONLY". Missing `import GhosttiesCore`; breaks local `xcodebuild test` for every session in this repo until resolved.
+- [ ] Tab-to-complete in the DEFAULT field — Tab filling the field from the highlighted row. Model-B only today. Its own change, not this branch.
+
+**Parked (off-objective):**
+- [ ] Template setup — bundled preset `macos/Presets/orchestrator.md` never seeds; `templates = presets + defaults + custom` has no dedupe (two "Orchestrator" rows if it does seed); Release `workspace.json` holds 3 junk "New Template" entries; presets sort ABOVE built-ins.
+- [ ] `inlineProjectPicker` orphaned — nothing sets `isProjectPickerOpen = true` since `projectControl` was deleted. Left working deliberately; retiring it is its own change (entangled with `ComposerQueryField.isPickerOpen` gating the field's ↑/↓/Return).
+- [ ] `ghostties.composerModelBField.MUTANT` debris in Sean's real Dev `UserDefaults` — left by an agent's mutation test.
+- [ ] `MEMORY.md` is 23.9KB against a 20KB cap; needs a routing pass to `INDEX.md`.
+
+**beta.24:**
+- [ ] Merge PR #149 (unblocks the suite — `main`'s test target did not compile).
+- [ ] CHANGELOG entry for #141
+- [ ] Tag beta.24; unpin both distribution surfaces from beta.22
+- [ ] Re-run full suite on a QUIET machine — last 3 runs each showed 6 failures in `SessionComposerWorktreeLaunchTests`/`GitWorktreeCreationTests`, clean in isolation every time (parallel-agent load).

--- a/macos/Tests/Ghostties/SessionEnvironmentStampTests.swift
+++ b/macos/Tests/Ghostties/SessionEnvironmentStampTests.swift
@@ -1,6 +1,7 @@
 // IDE-ONLY: not currently exercised in CI macos job (build-only).
 // Run via Xcode Cmd+U or xcodebuild test locally.
 import XCTest
+import GhosttiesCore
 @testable import Ghostty
 
 /// Phase 0 of the session-row-status plan: every spawned session's


### PR DESCRIPTION
## What
`SessionEnvironmentStampTests.swift` uses `AgentTemplate` but only imported `XCTest`. `AgentTemplate` lives in `GhosttiesCore` since #143's module move — the file was missing `import GhosttiesCore`, so the whole `GhosttyTests` target failed to compile. No test run on `main` could pass.

This is the same latent-break class as `a2a28870b` (fallout from #143's module move, documented as `reference_module-move-leaves-latent-breaks` in project memory).

## Fix
One line: add `import GhosttiesCore`, matching the import order used by neighbouring test files in the directory.

## Verification
This unblocks the beta.24 suite run. Ran the full unfiltered `GhosttyTests`/`GhosttyKitTests` suite locally:

- Total: 1016, Passed: 1014, Failed: 1, Skipped: 1
- The single failure is `GitWorktreeCreationTests/raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes()` — a known flake, not a regression.

Note: local verification required temporarily setting aside an untracked file (`ThrottleTrailingEdgeHypothesisTests.swift`, not part of this branch or of `main`) that carries the same missing-`GhosttiesCore`-import bug and also fails to compile. That file is unrelated to this PR and untouched here — flagging separately so it isn't lost.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>