### PR TITLE
fix(web): update stale homepage version labels and harden version script

### DIFF
--- a/scripts/update-web-version.py
+++ b/scripts/update-web-version.py
@@ -17,18 +17,21 @@ from datetime import datetime
 
 
 failures = []
+contents = {}  # path -> in-memory content, seeded from disk on first use
 
 
 def replace(path: str, pattern: str, repl: str, label: str) -> None:
-    """Replace `pattern` with `repl` in `path`. Logs whether it matched."""
-    src = open(path).read()
-    new, n = re.subn(pattern, repl, src)
+    """Replace `pattern` with `repl` in the in-memory content for `path`.
+    Logs whether it matched. Nothing is written to disk here."""
+    if path not in contents:
+        contents[path] = open(path).read()
+    new, n = re.subn(pattern, repl, contents[path])
     if n == 0:
-        print(f"  ! {label}: pattern did not match in {path}")
+        print(f"  ! {label}: pattern did not match in {path}", flush=True)
         failures.append(label)
     else:
-        open(path, "w").write(new)
-        print(f"  ✓ {label}: {n} replacement(s) in {path}")
+        contents[path] = new
+        print(f"  ✓ {label}: {n} replacement(s) in {path}", flush=True)
 
 
 if len(sys.argv) not in (2, 3):
@@ -48,7 +51,7 @@ if len(sys.argv) == 3:
     mb = round(bytes_ / (1024 * 1024))
     dmg_size_str = f"{mb} MB"
 
-print(f"Bumping site to {version} ({date_long})")
+print(f"Bumping site to {version} ({date_long})", flush=True)
 
 # 1. DMG download URL — both download.html and index.html hardcode one.
 #    (index.html's hero "download now" line links straight to the DMG, not
@@ -102,7 +105,7 @@ replace(
 # 5. index.html — DMG install-cell trailing label ("...Ghostties.dmg</a><br>v0.1.0-beta.X")
 replace(
     "web/index.html",
-    r"(?<=</a><br>)v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
+    r"(?<=Ghostties\.dmg</a><br>)v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
     version,
     "index.html DMG install-cell label",
 )
@@ -117,7 +120,11 @@ replace(
 )
 
 if failures:
+    sys.stdout.flush()
     print(f"\n{len(failures)} pattern(s) failed to match. Aborting.", file=sys.stderr)
     sys.exit(1)
+
+for path, new in contents.items():
+    open(path, "w").write(new)
 
 print("Done.")

--- a/scripts/update-web-version.py
+++ b/scripts/update-web-version.py
@@ -16,12 +16,16 @@ import sys
 from datetime import datetime
 
 
+failures = []
+
+
 def replace(path: str, pattern: str, repl: str, label: str) -> None:
     """Replace `pattern` with `repl` in `path`. Logs whether it matched."""
     src = open(path).read()
     new, n = re.subn(pattern, repl, src)
     if n == 0:
         print(f"  ! {label}: pattern did not match in {path}")
+        failures.append(label)
     else:
         open(path, "w").write(new)
         print(f"  ✓ {label}: {n} replacement(s) in {path}")
@@ -95,25 +99,25 @@ replace(
     "download.html last-updated footer",
 )
 
-# 5. index.html — terminal line-3 version string.
-#    Matches every occurrence of "<+ or %> v<version>": the desktop span
-#    ("+ ghostties % v..."), the mobile-short span ("+ v..." — no "%",
-#    "ghostties" is dropped there too, to fit the mobile character budget),
-#    the CSS comment above the desktop keyframe, the CSS comment above the
-#    mobile-override keyframe, the illustrative example in the mobile
-#    budget-math comment, and the HTML markup comment. The lookbehind
-#    requires a literal "+ " or "% " immediately before "v" so it can't
-#    also match the unrelated "v<version>" inside the DMG URL (handled by
-#    rule 1 above), which is preceded by "/" instead. (The char-count
-#    numbers in those comments aren't touched here: like the rest of this
-#    script, a version bump is assumed not to change the string's length.
-#    If a beta number crosses a digit boundary — e.g. beta.9 → beta.10 —
-#    recheck the *ch counts by hand.)
+# 5. index.html — DMG install-cell trailing label ("...Ghostties.dmg</a><br>v0.1.0-beta.X")
 replace(
     "web/index.html",
-    r"(?<=[+%] )v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
+    r"(?<=</a><br>)v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?",
     version,
-    "index.html terminal line-3 (all occurrences)",
+    "index.html DMG install-cell label",
 )
+
+# 6. index.html — channels-note current-release text
+#    "Current release is <strong>v0.1.0-beta.X</strong> on the beta channel."
+replace(
+    "web/index.html",
+    r"(?<=Current release is <strong>)v[\d]\.\d+\.\d+(?:-[a-z0-9.]+)?(?=</strong>)",
+    version,
+    "index.html channels-note current release",
+)
+
+if failures:
+    print(f"\n{len(failures)} pattern(s) failed to match. Aborting.", file=sys.stderr)
+    sys.exit(1)
 
 print("Done.")

--- a/web/index.html
+++ b/web/index.html
@@ -120,7 +120,7 @@
           </div>
           <div class="install-cell">
             <b>DMG</b>
-            <span><a href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.24/Ghostties.dmg" download>Ghostties.dmg</a><br>v0.1.0-beta.23</span>
+            <span><a href="https://github.com/SeanSmithWorks/ghostties/releases/download/v0.1.0-beta.24/Ghostties.dmg" download>Ghostties.dmg</a><br>v0.1.0-beta.24</span>
           </div>
           <div class="install-cell">
             <b>REQUIREMENTS</b>
@@ -128,7 +128,7 @@
           </div>
         </div>
         <p class="body-text channels-note">
-          Current release is <strong>v0.1.0-beta.23</strong> on the beta channel.
+          Current release is <strong>v0.1.0-beta.24</strong> on the beta channel.
           Auto-update ships via Sparkle — installs check for a new build on
           launch and apply it in the background.
         </p>


### PR DESCRIPTION
## What was stale

Two visible version labels on the homepage (`web/index.html`) said **beta.23** while the DMG download button beside them correctly linked to **beta.24**:

- Line 123 — the DMG install-cell trailing label (`Ghostties.dmg</a><br>v0.1.0-beta.23` → `v0.1.0-beta.24`)
- Line 131 — the channels-note sentence (`Current release is <strong>v0.1.0-beta.23</strong>...` → `v0.1.0-beta.24`)

Before/after:

| | Before | After |
|---|---|---|
| DMG cell label | `v0.1.0-beta.23` | `v0.1.0-beta.24` |
| Channels note | `Current release is v0.1.0-beta.23 on the beta channel.` | `Current release is v0.1.0-beta.24 on the beta channel.` |

## Why the script missed it

`scripts/update-web-version.py` runs in CI on every release (`appcast` job) and rewrites version strings in `web/index.html` and `web/download.html`. It had exactly four `replace()` rules, none targeting these two labels — they were added to the homepage after the script was written and nothing ever covered them. Two new rules now target both, matching the general `v0.1.0-beta.N` form so they keep working across future releases.

## Dead rule found and removed

While extending the script, one existing rule ("index.html terminal line-3") was found to be permanently dead: its pattern matches text from a hero "terminal prompt" (`+ ghostties % v...`) that a prior redesign, `ded288569` ("redesign(web): ship the v3 site refresh to ghostties.org (#139)"), removed from the page entirely. That markup no longer exists anywhere in `index.html`, so the rule has been silently failing — reporting `! ... pattern did not match` and continuing — on every release since #139. It's deleted here rather than fixed, since the feature it targeted is gone by deliberate redesign, not by accident.

## What now prevents recurrence

The script's `replace()` failures used to warn and continue (exit 0), which is exactly how both of the above went unnoticed release after release. Now, any unmatched pattern is collected; the script attempts every remaining replacement so one run reports every problem, then exits non-zero if anything failed. A release will hard-fail in the `appcast` CI job rather than silently shipping a stale page — an intentional trade-off, confirmed with the orchestrator.

## Verification

Ran the script against the live current tag — every rule reports ✓, exit 0:

```
$ python3 scripts/update-web-version.py v0.1.0-beta.24 154154060
Bumping site to v0.1.0-beta.24 (August 31, 2026)
  ✓ download.html DMG URL: 1 replacement(s) in web/download.html
  ✓ index.html DMG URL: 2 replacement(s) in web/index.html
  ✓ download.html button label: 1 replacement(s) in web/download.html
  ✓ download.html meta line (with size): 1 replacement(s) in web/download.html
  ✓ download.html last-updated footer: 1 replacement(s) in web/download.html
  ✓ index.html DMG install-cell label: 1 replacement(s) in web/index.html
  ✓ index.html channels-note current release: 1 replacement(s) in web/index.html
Done.
EXIT: 0
```

Confirmed the strict-failure path against a deliberately broken temp copy — exits non-zero, no artifact left behind:

```
1 pattern(s) failed to match. Aborting.
...
  ! index.html channels-note current release: pattern did not match in web/index.html
EXIT: 1
```

`grep -n "beta\.2[0-9]" web/index.html` returns three hits, all reading beta.24. `git diff --stat` touches exactly two files (`web/index.html` is a 2-line change, not a Prettier reformat).

## Test plan

- [x] `web/index.html` DMG-cell label and channels-note both read `v0.1.0-beta.24`
- [x] `scripts/update-web-version.py` new rules match and update both labels on a real run
- [x] Strict-failure path exits non-zero when a pattern can't match
- [x] `web/download.html` untouched