### PR TITLE
fix(dist): resolve latest release at install time, refresh stale versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
     attributes:
       label: Ghostties version
       description: About Ghostties in the menu bar, or `gt --version`.
-      placeholder: v0.1.0-beta.21
+      placeholder: v0.1.0-beta.24
     validations:
       required: true
 

--- a/dist/ghostties/homebrew/README.md
+++ b/dist/ghostties/homebrew/README.md
@@ -30,7 +30,7 @@ sha256 from GitHub and rewrites `version` + `sha256` in this file. Run it by
 hand after cutting a release:
 
 ```
-bash scripts/update-cask-version.sh v0.1.0-beta.22
+bash scripts/update-cask-version.sh v0.1.0-beta.24
 ```
 
 It's idempotent and fails loudly if the release or the DMG asset is missing.
@@ -79,7 +79,7 @@ you need the in-repo copy to reflect the latest release, run the script
 yourself:
 
 ```
-bash scripts/update-cask-version.sh v0.1.0-beta.22
+bash scripts/update-cask-version.sh v0.1.0-beta.24
 ```
 
 ## `brew audit` results

--- a/dist/ghostties/homebrew/ghostties.rb
+++ b/dist/ghostties/homebrew/ghostties.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ghostties" do
-  version "0.1.0-beta.22"
-  sha256 "d98303637d6142af48e165627ca2afb312513610396ca56cda2e781efae780b0"
+  version "0.1.0-beta.24"
+  sha256 "57461f291fd4cef02e5c79c6cca23304deee99c9507af571c93a248d3bfb769b"
 
   # Ghostties has not cut a stable release yet — every tag so far, including
   # this one, is a GitHub prerelease. Tracking beta is a deliberate choice,

--- a/dist/ghostties/npm/ghostties-install/README.md
+++ b/dist/ghostties/npm/ghostties-install/README.md
@@ -1,11 +1,11 @@
 # ghostties-install
 
-A zero-dependency installer shim for [Ghostties](https://ghostties.org). Downloads a
-pinned, checksum-verified build of `Ghostties.app` and places it on your Mac.
+A zero-dependency installer shim for [Ghostties](https://ghostties.org). Downloads the
+newest published build of `Ghostties.app`, verifies it, and places it on your Mac.
 
-**Published to npm.** `npx ghostties-install` downloads the pinned,
-checksum-verified `Ghostties.app` build and installs it — no separate `npm
-install` step needed.
+**Published to npm.** `npx ghostties-install` resolves the newest release,
+downloads it, verifies it, and installs it — no separate `npm install` step
+needed.
 
 **Recommended install path:** `brew install --cask seansmithworks/tap/ghostties`
 (see [`../../homebrew/README.md`](../../homebrew/README.md)). This npm shim exists
@@ -45,19 +45,25 @@ npx ghostties-install --target ~/Applications
 
 1. Checks that you're on macOS/arm64. Hard-fails with a clear message otherwise —
    Ghostties has no Linux, Windows, or Intel build.
-2. Refuses to overwrite an existing install at the target unless you pass `--force`.
+2. Resolves the newest published release from the GitHub API at run time. Every
+   Ghostties release so far is a GitHub prerelease, so this reads the release list
+   (not the "latest" endpoint, which excludes prereleases) and takes the newest entry.
+3. Refuses to overwrite an existing install at the target unless you pass `--force`.
    Ghostties self-updates via Sparkle, so an existing install may already be newer
-   than the version this installer is pinned to.
-3. Downloads the pinned release zip from GitHub Releases, with progress output
+   than the release this installer just resolved.
+4. Downloads that release's zip from GitHub Releases, with progress output
    (it's ~154 MB).
-4. Verifies the download's SHA-256 against a pinned checksum before touching the
-   archive contents. On mismatch it deletes the download and exits non-zero —
-   it will never extract or install an unverified binary.
-5. Extracts with `ditto -x -k` (not `unzip`), which preserves extended attributes,
+5. Verifies the download's SHA-256 against the digest GitHub published for that
+   asset before touching the archive contents. On mismatch it deletes the download
+   and exits non-zero — it will never extract or install an unverified binary.
+6. Extracts with `ditto -x -k` (not `unzip`), which preserves extended attributes,
    symlinks, and code-signature integrity on `.app` bundles.
-6. Stages the app under a temp name inside the target directory and renames it
+7. Verifies the extracted app bundle's code signature with `codesign` and confirms
+   it's signed by Ghostties' Developer ID team identifier. This check doesn't depend
+   on any version, so it keeps working the same way release after release.
+8. Stages the app under a temp name inside the target directory and renames it
    into place, so a failure mid-install never leaves a half-written app behind.
-7. Cleans up its temp download/extraction directory on both success and failure.
+9. Cleans up its temp download/extraction directory on both success and failure.
 
 It does **not** strip the `com.apple.quarantine` extended attribute. Ghostties is
 signed with a Developer ID certificate and notarized, so Gatekeeper clears it on
@@ -67,20 +73,19 @@ project won't do.
 After install, Ghostties updates itself in place via Sparkle. You do not need to
 re-run this installer for future versions.
 
-## Pinned version
+## Always installs the newest release
 
-This package pins an exact release tag and asset checksum rather than resolving
-"latest" at install time — a pinned checksum is the supply-chain-safe design, and
-because the app self-updates via Sparkle on first launch, a slightly-stale pin
-self-heals immediately after install.
+This package resolves the newest published release from the GitHub API at
+install time rather than pinning a version — a pinned version goes stale the
+moment the next release ships, and this installer has no CI automation to bump
+a pin on every release. Nothing in `bin/ghostties-install.js` needs to be
+edited when a new version ships.
 
-**Bumping the pin is currently a manual step**, not automated in CI. The
-Homebrew cask's version bump is automated by a separate CI workflow in this repo;
-the npm package's is not, because publishing from CI would need an npm
-automation token that isn't configured. If you're bumping
-this by hand: update `RELEASE.tag`, `RELEASE.assetName` (should stay the same name),
-and `RELEASE.sha256` in `bin/ghostties-install.js`, using the sha256 GitHub reports
-for the release asset.
+Integrity is verified two ways instead: the download's SHA-256 is checked
+against the digest GitHub publishes for that exact asset, and the extracted
+app bundle's code signature is checked against Ghostties' Developer ID team
+identifier. The signature check is the stronger guarantee — it holds for every
+future release, not just the one a checksum happened to be pinned to.
 
 ## Zero dependencies
 

--- a/dist/ghostties/npm/ghostties-install/bin/ghostties-install.js
+++ b/dist/ghostties/npm/ghostties-install/bin/ghostties-install.js
@@ -332,38 +332,73 @@ function sha256File(filePath) {
 // ---------------------------------------------------------------------------
 
 function verifyCodeSignature(appPath) {
-  // codesign writes its -dv/--verbose output to stderr regardless of
-  // success or failure, so both streams have to be captured explicitly —
-  // execFileSync only returns stdout on success.
-  const result = spawnSync("codesign", ["-dv", "--verbose=4", appPath], {
-    encoding: "utf8",
-  });
+  // Two separate codesign calls are required here, not one — they check
+  // different things and neither substitutes for the other:
+  //   `-dv --verbose=4` DISPLAYS signing info (who signed it) but does not
+  //   validate the signature against what's actually on disk; a bundle
+  //   tampered with after signing will still print a readable
+  //   TeamIdentifier and exit 0 under `-dv` alone.
+  //   `--verify --deep --strict` VALIDATES the signature against the
+  //   bundle's current bytes, but doesn't print the identity.
+  // Run --verify first and fail fast: an invalid signature makes the
+  // identity from -dv meaningless, so there's no point reading it.
+  //
+  // codesign writes its output to stderr for both invocations regardless
+  // of success or failure, so both streams have to be captured explicitly
+  // — execFileSync only returns stdout on success.
+  const verifyResult = spawnSync(
+    "codesign",
+    ["--verify", "--deep", "--strict", appPath],
+    { encoding: "utf8" },
+  );
 
-  if (result.error) {
+  if (verifyResult.error) {
     throw new InstallError(
-      `Could not run codesign to verify ${appPath}: ${result.error.message}`,
+      `Could not run codesign to verify ${appPath}: ${verifyResult.error.message}`,
     );
   }
 
-  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  const verifyOutput = `${verifyResult.stdout || ""}${verifyResult.stderr || ""}`;
 
-  if (result.status !== 0) {
+  if (verifyResult.status !== 0) {
     throw new InstallError(
       "Code signature verification FAILED.\n" +
-        `codesign could not verify ${appPath}:\n${output || `exit code ${result.status}`}\n` +
+        `codesign reports the signature on ${appPath} does not match its contents:\n` +
+        `${verifyOutput || `exit code ${verifyResult.status}`}\n` +
+        "The bundle may have been altered after signing. Not installing.",
+    );
+  }
+
+  const displayResult = spawnSync("codesign", ["-dv", "--verbose=4", appPath], {
+    encoding: "utf8",
+  });
+
+  if (displayResult.error) {
+    throw new InstallError(
+      `Could not run codesign to read the signing identity of ${appPath}: ${displayResult.error.message}`,
+    );
+  }
+
+  const displayOutput = `${displayResult.stdout || ""}${displayResult.stderr || ""}`;
+
+  if (displayResult.status !== 0) {
+    throw new InstallError(
+      "Code signature verification FAILED.\n" +
+        `codesign could not read signing info for ${appPath}:\n` +
+        `${displayOutput || `exit code ${displayResult.status}`}\n` +
         "This build will not be installed — it may be corrupted or tampered with.",
     );
   }
 
-  const match = output.match(/TeamIdentifier=([A-Z0-9]+)/);
+  const match = displayOutput.match(/TeamIdentifier=([A-Z0-9]+)/);
   const teamId = match ? match[1] : null;
   if (teamId !== EXPECTED_TEAM_ID) {
     throw new InstallError(
       "Code signature verification FAILED.\n" +
         `  expected team identifier: ${EXPECTED_TEAM_ID}\n` +
         `  actual:                   ${teamId || "(not found)"}\n` +
-        "The app bundle is not signed by the identity Ghostties releases are signed with. " +
-        "Not installing.",
+        "The signature is valid but signed by an identity other than the one Ghostties " +
+        "releases are signed with. Not installing.",
     );
   }
 }

--- a/dist/ghostties/npm/ghostties-install/bin/ghostties-install.js
+++ b/dist/ghostties/npm/ghostties-install/bin/ghostties-install.js
@@ -4,12 +4,14 @@
 /**
  * ghostties-install
  *
- * Downloads a pinned, checksum-verified release of Ghostties.app and places
- * it in /Applications (or --target). Zero runtime dependencies: only Node
- * built-ins and macOS system tools (`ditto`).
+ * Resolves the newest published release of Ghostties.app at run time,
+ * downloads it, verifies the download against GitHub's own asset digest,
+ * and verifies the extracted app bundle's code signature — then places it
+ * in /Applications (or --target). Zero runtime dependencies: only Node
+ * built-ins and macOS system tools (`ditto`, `codesign`).
  *
- * The version/sha256 below are pinned deliberately. See README.md for why,
- * and for how to bump them (it's a manual edit, not automated).
+ * There is no pinned version to bump. See README.md for how release
+ * resolution works and why it's safe to trust "newest" without a pin.
  */
 
 const fs = require("fs");
@@ -17,18 +19,25 @@ const os = require("os");
 const path = require("path");
 const https = require("https");
 const crypto = require("crypto");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 
 // ---------------------------------------------------------------------------
-// Pinned release. Bump manually when a new release ships. See README.md.
+// Release resolution
 // ---------------------------------------------------------------------------
-const RELEASE = {
-  tag: "v0.1.0-beta.22",
-  assetName: "ghostties-macos-arm64.zip",
-  sha256: "0542bd3db77ca60048e3f9aba5096c9779037139a52eee2bd82c6c3e1eea98fc",
-};
-const DOWNLOAD_URL = `https://github.com/SeanSmithWorks/ghostties/releases/download/${RELEASE.tag}/${RELEASE.assetName}`;
+const REPO = "SeanSmithWorks/ghostties";
+const ASSET_NAME = "ghostties-macos-arm64.zip";
 const APP_NAME = "Ghostties.app";
+// The identity every Ghostties release is signed with (Developer ID, Sean's
+// team). Verified after extraction, independent of any version pin.
+const EXPECTED_TEAM_ID = "5P7G79U672";
+
+// GitHub's `/releases/latest` endpoint excludes prereleases, and every
+// Ghostties release published so far is a prerelease — so it would find
+// nothing. Read the release list instead and take the newest entry
+// (the API returns releases newest-first), keeping prereleases in scope.
+// The Homebrew cask's `livecheck` block (dist/ghostties/homebrew/ghostties.rb)
+// works around the same GitHub behavior the same way.
+const RELEASES_API_URL = `https://api.github.com/repos/${REPO}/releases?per_page=10`;
 
 // ---------------------------------------------------------------------------
 // CLI plumbing
@@ -47,7 +56,10 @@ Options:
   --force           Overwrite an existing install at the target.
   -h, --help        Show this help.
 
-Pinned release: ${RELEASE.tag}
+Always installs the newest published release (GitHub API resolves it at run
+time — nothing is pinned). The download is verified against GitHub's own
+asset digest, and the extracted app bundle's code signature is verified
+against Sean's Developer ID team identifier before install.
 `);
 }
 
@@ -99,6 +111,134 @@ function checkPlatform(platform, arch) {
 }
 
 class InstallError extends Error {}
+
+// ---------------------------------------------------------------------------
+// GitHub API
+// ---------------------------------------------------------------------------
+
+function httpsGetJson(url, { redirectsLeft = 5 } = {}) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(
+      url,
+      {
+        headers: {
+          "User-Agent": "ghostties-install",
+          Accept: "application/vnd.github+json",
+        },
+      },
+      (res) => {
+        const { statusCode, headers } = res;
+
+        if (statusCode >= 300 && statusCode < 400 && headers.location) {
+          res.resume();
+          if (redirectsLeft <= 0) {
+            reject(
+              new InstallError(
+                "Too many redirects while querying the GitHub API.",
+              ),
+            );
+            return;
+          }
+          httpsGetJson(headers.location, {
+            redirectsLeft: redirectsLeft - 1,
+          }).then(resolve, reject);
+          return;
+        }
+
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () => {
+          if (statusCode === 403 || statusCode === 429) {
+            reject(
+              new InstallError(
+                `GitHub API rate limit hit (HTTP ${statusCode}) while resolving the latest ` +
+                  "Ghostties release.\nTry again in a few minutes, or download a release " +
+                  `directly from https://github.com/${REPO}/releases.`,
+              ),
+            );
+            return;
+          }
+          if (statusCode !== 200) {
+            reject(
+              new InstallError(
+                `GitHub API request failed: HTTP ${statusCode} for ${url}.\n` +
+                  "GitHub may be down, or the repository may be unreachable.",
+              ),
+            );
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (err) {
+            reject(
+              new InstallError(
+                `GitHub API returned a response that could not be parsed as JSON: ${err.message}`,
+              ),
+            );
+          }
+        });
+        res.on("error", (err) => reject(err));
+      },
+    );
+
+    request.on("error", (err) => {
+      reject(
+        new InstallError(
+          `Network error while contacting the GitHub API at ${url}: ${err.message}`,
+        ),
+      );
+    });
+  });
+}
+
+async function resolveLatestRelease() {
+  let releases;
+  try {
+    releases = await httpsGetJson(RELEASES_API_URL);
+  } catch (err) {
+    if (err instanceof InstallError) throw err;
+    throw new InstallError(
+      `Could not resolve the latest Ghostties release: ${err.message}`,
+    );
+  }
+
+  if (!Array.isArray(releases) || releases.length === 0) {
+    throw new InstallError(
+      `No releases found for ${REPO}. This is unexpected — the project always has at ` +
+        "least one published release. GitHub's API may be having issues.",
+    );
+  }
+
+  // The API returns releases newest-first; drafts are never returned to
+  // unauthenticated requests, but skip them defensively anyway.
+  const release = releases.find((r) => !r.draft);
+  if (!release) {
+    throw new InstallError(
+      `No published (non-draft) releases found for ${REPO}.`,
+    );
+  }
+
+  const asset = (release.assets || []).find((a) => a.name === ASSET_NAME);
+  if (!asset) {
+    throw new InstallError(
+      `Release ${release.tag_name} has no "${ASSET_NAME}" asset.\n` +
+        `See https://github.com/${REPO}/releases/tag/${release.tag_name} for what it does have.`,
+    );
+  }
+
+  if (!asset.digest || !asset.digest.startsWith("sha256:")) {
+    throw new InstallError(
+      `Release ${release.tag_name}'s "${ASSET_NAME}" asset has no sha256 digest from GitHub.\n` +
+        "Refusing to install an asset that can't be integrity-checked.",
+    );
+  }
+
+  return {
+    tag: release.tag_name,
+    downloadUrl: asset.browser_download_url,
+    sha256: asset.digest.slice("sha256:".length),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Download with progress
@@ -188,6 +328,47 @@ function sha256File(filePath) {
 }
 
 // ---------------------------------------------------------------------------
+// Code signature
+// ---------------------------------------------------------------------------
+
+function verifyCodeSignature(appPath) {
+  // codesign writes its -dv/--verbose output to stderr regardless of
+  // success or failure, so both streams have to be captured explicitly —
+  // execFileSync only returns stdout on success.
+  const result = spawnSync("codesign", ["-dv", "--verbose=4", appPath], {
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw new InstallError(
+      `Could not run codesign to verify ${appPath}: ${result.error.message}`,
+    );
+  }
+
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+
+  if (result.status !== 0) {
+    throw new InstallError(
+      "Code signature verification FAILED.\n" +
+        `codesign could not verify ${appPath}:\n${output || `exit code ${result.status}`}\n` +
+        "This build will not be installed — it may be corrupted or tampered with.",
+    );
+  }
+
+  const match = output.match(/TeamIdentifier=([A-Z0-9]+)/);
+  const teamId = match ? match[1] : null;
+  if (teamId !== EXPECTED_TEAM_ID) {
+    throw new InstallError(
+      "Code signature verification FAILED.\n" +
+        `  expected team identifier: ${EXPECTED_TEAM_ID}\n` +
+        `  actual:                   ${teamId || "(not found)"}\n` +
+        "The app bundle is not signed by the identity Ghostties releases are signed with. " +
+        "Not installing.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -203,6 +384,9 @@ async function main() {
 
     checkPlatform(process.platform, process.arch);
 
+    console.log("Resolving the latest Ghostties release…");
+    const release = await resolveLatestRelease();
+
     const target = path.resolve(args.target);
     const destAppPath = path.join(target, APP_NAME);
 
@@ -211,7 +395,7 @@ async function main() {
         throw new InstallError(
           `${destAppPath} already exists.\n` +
             "Ghostties self-updates via Sparkle, so the installed copy may already be newer " +
-            `than the ${RELEASE.tag} build this installer knows about. Refusing to overwrite it.\n` +
+            `than the ${release.tag} build this installer just resolved. Refusing to overwrite it.\n` +
             "Pass --force if you want this installer to replace it anyway.",
         );
       }
@@ -220,25 +404,25 @@ async function main() {
     fs.mkdirSync(target, { recursive: true });
 
     workDir = fs.mkdtempSync(path.join(os.tmpdir(), "ghostties-install-"));
-    const zipPath = path.join(workDir, RELEASE.assetName);
+    const zipPath = path.join(workDir, ASSET_NAME);
     const extractDir = path.join(workDir, "extracted");
 
-    console.log(`Ghostties installer — ${RELEASE.tag}`);
+    console.log(`Ghostties installer — ${release.tag}`);
     console.log(`Target: ${destAppPath}`);
     console.log("");
-    console.log(`Downloading ${RELEASE.assetName} (~154 MB)…`);
+    console.log(`Downloading ${ASSET_NAME} (~154 MB)…`);
     downloadStarted = true;
-    await downloadWithProgress(DOWNLOAD_URL, zipPath);
+    await downloadWithProgress(release.downloadUrl, zipPath);
 
     console.log("Verifying checksum…");
     const actualSha256 = await sha256File(zipPath);
-    if (actualSha256 !== RELEASE.sha256) {
+    if (actualSha256 !== release.sha256) {
       throw new InstallError(
         "Checksum verification FAILED.\n" +
-          `  expected: ${RELEASE.sha256}\n` +
+          `  expected: ${release.sha256}\n` +
           `  actual:   ${actualSha256}\n` +
-          "The downloaded file does not match the pinned release and will be deleted. " +
-          "This could mean a corrupted download or a tampered asset — not installing.",
+          "The downloaded file does not match the digest GitHub published for this release " +
+          "and will be deleted. This could mean a corrupted download or a tampered asset — not installing.",
       );
     }
     console.log("Checksum OK.");
@@ -257,6 +441,10 @@ async function main() {
         `Could not find ${APP_NAME} inside the downloaded archive after extraction.`,
       );
     }
+
+    console.log("Verifying code signature…");
+    verifyCodeSignature(extractedAppPath);
+    console.log("Code signature OK.");
 
     console.log(`Installing to ${destAppPath}…`);
     // Stage into a temp name in the target directory, then rename into place
@@ -277,7 +465,7 @@ async function main() {
 
     console.log("");
     console.log(`Installed ${APP_NAME} to ${target}.`);
-    console.log(`Version: ${RELEASE.tag}`);
+    console.log(`Version: ${release.tag}`);
     console.log(
       "Ghostties updates itself from here on via Sparkle — no need to re-run this installer.",
     );

--- a/dist/ghostties/npm/ghostties-install/package.json
+++ b/dist/ghostties/npm/ghostties-install/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghostties-install",
-  "version": "0.1.1",
-  "description": "Installer shim for Ghostties (macOS, Apple silicon). Downloads and verifies a pinned release build of Ghostties.app.",
+  "version": "0.2.0",
+  "description": "Installer shim for Ghostties (macOS, Apple silicon). Downloads and verifies the newest release build of Ghostties.app.",
   "license": "MIT",
   "os": [
     "darwin"

--- a/scripts/update-cask-version.sh
+++ b/scripts/update-cask-version.sh
@@ -2,7 +2,7 @@
 # update-cask-version.sh — Bump dist/ghostties/homebrew/ghostties.rb to a new release.
 #
 # Usage: bash scripts/update-cask-version.sh <tag>
-#   e.g. bash scripts/update-cask-version.sh v0.1.0-beta.22
+#   e.g. bash scripts/update-cask-version.sh v0.1.0-beta.24
 #
 # Resolves the sha256 of that release's Ghostties.dmg from GitHub (never
 # hand-typed) and rewrites `version` + `sha256` in the cask. Idempotent —
@@ -22,7 +22,7 @@ ASSET="Ghostties.dmg"
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <tag>" >&2
-    echo "  e.g. $0 v0.1.0-beta.22" >&2
+    echo "  e.g. $0 v0.1.0-beta.24" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- `dist/ghostties/npm/ghostties-install/bin/ghostties-install.js` no longer hardcodes a release tag/sha256. It now resolves the newest published release from the GitHub releases list at run time (not `/releases/latest`, which excludes prereleases — every Ghostties release so far is a prerelease, same workaround the Homebrew cask's `livecheck` block already uses), verifies the download against the sha256 digest GitHub publishes per-asset, then extracts and verifies the app bundle's code signature against Sean's Developer ID team identifier (`5P7G79U672`) before installing. A hardcoded pin only protects the one release it names; the signature check holds for every future release without any edit.
- Bumped the npm package to `0.2.0` (behavior change) and rewrote its README's pinned-version section to describe the new resolve-verify-signature flow.
- Brought the in-repo Homebrew cask (`dist/ghostties/homebrew/ghostties.rb`) current to `v0.1.0-beta.24`, sha256 resolved via `scripts/update-cask-version.sh` against GitHub's own published digest (verified independently against the GitHub API before committing).
- Refreshed stale `v0.1.0-beta.2x` version examples in the bug report template and the two scripts/docs that reference the cask-update usage.

One thing left after this merges: **`npm publish` to make `0.2.0` live** — that's Sean's call, from a real terminal; not run here.

## Test plan
- [x] `node --check` passes on the rewritten installer
- [x] `grep -n "beta\." bin/ghostties-install.js` returns nothing — no hardcoded version anywhere
- [x] Ran the installer end-to-end against a scratch `--target` dir: resolved beta.24, downloaded, verified digest, verified codesign, installed `Ghostties.app`; confirmed installed bundle's `TeamIdentifier=5P7G79U672` via `codesign -dv`; deleted the temp install
- [x] Simulated a digest mismatch and a signature mismatch (against `/usr/bin/env`, not the real app) — both produce the intended `InstallError` messages and leave nothing behind
- [x] `grep -E "version|sha256" dist/ghostties/homebrew/ghostties.rb` shows beta.24 + the sha256 that matches GitHub's published digest for `Ghostties.dmg`
- [x] `grep -rnE "0\.1\.0-beta\.(1[0-9]|2[0-3])\b" .github/ dist/ scripts/` returns nothing in scope (the one remaining hit, `scripts/update-web-version.py`, is explicitly out of scope for this change)
- [x] `git diff main --stat` lists only the 7 files this PR is scoped to

🤖 Generated with [Claude Code](https://claude.com/claude-code)