### PR TITLE
fix(cef): defer browser creation until view is in a window

### DIFF
--- a/macos/Sources/Features/Ghostties/BrowserFailureStateView.swift
+++ b/macos/Sources/Features/Ghostties/BrowserFailureStateView.swift
@@ -1,0 +1,71 @@
+import AppKit
+
+/// Inline empty state rendered inside the browser panel's content area when
+/// the embedded browser could not start — either the creation watchdog
+/// timed out, or CEF itself isn't available (`scripts/download-cef.sh`
+/// hasn't been run). Persistent-panel surface, so this must explain itself
+/// rather than disappear like a toast would.
+@MainActor
+final class BrowserFailureStateView: NSView {
+    var onRetry: (() -> Void)?
+
+    private let messageLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var retryButton: NSButton = {
+        let button = NSButton(title: "Retry", target: self, action: #selector(retryTapped))
+        button.bezelStyle = .rounded
+        button.controlSize = .small
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        wantsLayer = true
+        isHidden = true
+
+        let stack = NSStackView(views: [messageLabel, retryButton])
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -24),
+        ])
+    }
+
+    /// Show the failure state with the given message.
+    func show(message: String) {
+        messageLabel.stringValue = message
+        isHidden = false
+    }
+
+    func hide() {
+        isHidden = true
+    }
+
+    @objc private func retryTapped() {
+        onRetry?()
+    }
+}

--- a/macos/Sources/Features/Ghostties/BrowserPanelView.swift
+++ b/macos/Sources/Features/Ghostties/BrowserPanelView.swift
@@ -15,6 +15,10 @@ final class BrowserPanelView: NSView {
         return view
     }()
 
+    /// Inline empty state shown over `contentArea` when the browser could
+    /// not start (watchdog timeout, or CEF unavailable). Hidden by default.
+    let failureStateView = BrowserFailureStateView()
+
     /// Container for inline DevTools. Hidden by default; shown when the user
     /// toggles DevTools inline. Splits the content area vertically.
     let devToolsArea: NSView = {
@@ -58,10 +62,12 @@ final class BrowserPanelView: NSView {
         addSubview(navigationBar)
         addSubview(tabBar)
         addSubview(contentArea)
+        addSubview(failureStateView)
         addSubview(devToolsArea)
 
         navigationBar.translatesAutoresizingMaskIntoConstraints = false
         tabBar.translatesAutoresizingMaskIntoConstraints = false
+        failureStateView.translatesAutoresizingMaskIntoConstraints = false
 
         // Tab bar starts hidden (alphaValue 0) and shows automatically when >1 tab.
         tabBar.alphaValue = 0
@@ -92,6 +98,12 @@ final class BrowserPanelView: NSView {
             contentArea.topAnchor.constraint(equalTo: tabBar.bottomAnchor),
             contentArea.leadingAnchor.constraint(equalTo: leadingAnchor),
             contentArea.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            // Failure state overlays the content area exactly.
+            failureStateView.topAnchor.constraint(equalTo: contentArea.topAnchor),
+            failureStateView.leadingAnchor.constraint(equalTo: contentArea.leadingAnchor),
+            failureStateView.trailingAnchor.constraint(equalTo: contentArea.trailingAnchor),
+            failureStateView.bottomAnchor.constraint(equalTo: contentArea.bottomAnchor),
 
             // DevTools area (anchored to bottom)
             devToolsArea.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/macos/Sources/Features/Ghostties/BrowserSessionBridge.swift
+++ b/macos/Sources/Features/Ghostties/BrowserSessionBridge.swift
@@ -14,6 +14,13 @@ final class BrowserSessionBridge: NSObject, CEFBrowserViewDelegate {
     /// The tab ID currently associated with this bridge's CEFBrowserView.
     var activeTabId: UUID?
 
+    /// Forwarded to the panel's inline failure state — set by
+    /// `WorkspaceViewContainer` when embedding the browser view.
+    var onCreationFailed: (() -> Void)?
+    /// Forwarded so the panel can dismiss its inline failure state once the
+    /// browser materialises (including after a retry).
+    var onCreationSucceeded: (() -> Void)?
+
     init(sessionId: UUID, tabManager: BrowserTabManager) {
         self.sessionId = sessionId
         self.tabManager = tabManager
@@ -50,5 +57,13 @@ final class BrowserSessionBridge: NSObject, CEFBrowserViewDelegate {
                 accessibilityDescription: "Reload"
             )
         }
+    }
+
+    func browserViewDidFail(toCreate view: CEFBrowserView) {
+        onCreationFailed?()
+    }
+
+    func browserViewDidCreate(_ view: CEFBrowserView) {
+        onCreationSucceeded?()
     }
 }

--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -1069,10 +1069,36 @@ class WorkspaceViewContainer: NSView {
             browserPanelView.contentArea.layoutSubtreeIfNeeded()
             if let cefView = browserView as? CEFBrowserView {
                 cefView.setFrameSize(browserPanelView.contentArea.bounds.size)
+                wireBrowserFailureState(for: cefView, bridge: bridge)
             }
         }
 
         _activeBrowserManager = manager
+    }
+
+    /// Wires a CEFBrowserView's creation-failure/success callbacks to the
+    /// panel's inline empty state, and reflects whatever state the view is
+    /// already in (it may have failed before this embed happened, e.g. the
+    /// CEF-unavailable stub case notifies asynchronously right after init).
+    private func wireBrowserFailureState(for cefView: CEFBrowserView, bridge: BrowserSessionBridge?) {
+        let panel = browserPanelView
+        bridge?.onCreationFailed = { [weak cefView, weak panel] in
+            panel?.failureStateView.show(
+                message: "The browser couldn't start. Retry, or run scripts/download-cef.sh if this keeps happening."
+            )
+            panel?.failureStateView.onRetry = { [weak cefView] in
+                cefView?.retryCreateBrowser()
+            }
+        }
+        bridge?.onCreationSucceeded = { [weak panel] in
+            panel?.failureStateView.hide()
+        }
+
+        if cefView.creationFailed {
+            bridge?.onCreationFailed?()
+        } else {
+            panel.failureStateView.hide()
+        }
     }
 
     // MARK: - Browser Session Content

--- a/macos/Sources/Helpers/CEF/CEFBrowserView.h
+++ b/macos/Sources/Helpers/CEF/CEFBrowserView.h
@@ -10,6 +10,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)browserView:(CEFBrowserView *)view didChangeTitle:(NSString *)title;
 - (void)browserView:(CEFBrowserView *)view didChangeLoadingState:(BOOL)isLoading
          canGoBack:(BOOL)canGoBack canGoForward:(BOOL)canGoForward;
+/// Fired when browser creation could not be completed — either CEF itself
+/// never initialized, or `CefBrowserHost::CreateBrowser` was called but
+/// `OnAfterCreated` never fired within the creation watchdog window.
+- (void)browserViewDidFailToCreate:(CEFBrowserView *)view;
+/// Fired when the browser successfully materialises (`OnAfterCreated`).
+/// Lets UI that showed an inline failure state (including after a retry)
+/// know it can dismiss it.
+- (void)browserViewDidCreate:(CEFBrowserView *)view;
 @end
 
 /// Hosts a single CEF browser instance as an NSView.
@@ -23,6 +31,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *currentURL;
 @property (nonatomic, readonly, nullable) NSString *currentTitle;
 @property (nonatomic, readonly) BOOL isDevToolsOpen;
+/// YES once browser creation has been attempted (successfully or not) for
+/// the current attempt. Attempting again after a failure requires
+/// `-retryCreateBrowser`, which resets this before trying again.
+@property (nonatomic, readonly) BOOL browserCreated;
+/// Number of times `CefBrowserHost::CreateBrowser` has actually been
+/// invoked. Used to prove the window-attach guard never double-creates.
+@property (nonatomic, readonly) NSInteger creationAttemptCount;
+/// YES if the most recent creation attempt failed — either CEF is
+/// unavailable, or the creation watchdog timed out.
+@property (nonatomic, readonly) BOOL creationFailed;
 
 - (instancetype)initWithFrame:(NSRect)frame url:(nullable NSString *)url;
 - (void)loadURL:(NSString *)url;
@@ -35,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Close DevTools (works for both popup and inline).
 - (void)closeDevTools;
 - (void)closeBrowser;
+/// Attempt browser creation again after a failure. No-op if a browser
+/// already exists or is already pending.
+- (void)retryCreateBrowser;
 
 @end
 

--- a/macos/Sources/Helpers/CEF/CEFBrowserView.mm
+++ b/macos/Sources/Helpers/CEF/CEFBrowserView.mm
@@ -48,7 +48,10 @@ static bool GhosttiesIsAllowedSchemeCef(const CefString &url) {
 - (void)_didChangeURL:(NSString *)url;
 - (void)_didChangeTitle:(NSString *)title;
 - (void)_didChangeLoadingState:(BOOL)loading canGoBack:(BOOL)back canGoForward:(BOOL)forward;
+- (void)_notifyCreationFailed;
 #if GHOSTTIES_CEF_AVAILABLE
+- (void)_createBrowserNow;
+- (void)_startCreationWatchdog;
 - (void)_browserDidCreate:(CefRefPtr<CefBrowser>)browser;
 - (void)_browserDidClose;
 #endif
@@ -223,8 +226,18 @@ private:
 @property (nonatomic, readwrite) BOOL canGoForward;
 @property (nonatomic, readwrite, nullable) NSString *currentURL;
 @property (nonatomic, readwrite, nullable) NSString *currentTitle;
-@property (nonatomic) BOOL browserCreated;
+@property (nonatomic, readwrite) BOOL browserCreated;
+@property (nonatomic, readwrite) NSInteger creationAttemptCount;
+@property (nonatomic, readwrite) BOOL creationFailed;
 @property (nonatomic, readwrite) BOOL isDevToolsOpen;
+/// Pending URL captured at init time; consumed the moment creation is
+/// actually attempted (deferred until the view is in a window).
+@property (nonatomic, copy, nullable) NSString *pendingURL;
+/// One-shot timer started right after `CreateBrowser` is called. If
+/// `OnAfterCreated` hasn't fired by the time it elapses, creation is
+/// treated as failed. Ships in Release — this is a behavioral safety net,
+/// not a diagnostic.
+@property (nonatomic, strong, nullable) NSTimer *creationWatchdogTimer;
 
 @end
 
@@ -245,70 +258,43 @@ private:
     self.wantsLayer = YES;
     self.browserCreated = NO;
 
+    self.pendingURL = url ?: @"about:blank";
+
 #if GHOSTTIES_CEF_AVAILABLE
     [CEFBridgeManager initializeIfNeeded];
     if (![CEFBridgeManager isInitialized]) {
-        return self;  // CEF failed to init — return stub view
+        // CEF failed to init — stub view. Notify the failure asynchronously
+        // so the delegate (assigned by the caller right after this
+        // initializer returns) is in place by the time it fires.
+        self.creationFailed = YES;
+        __weak CEFBrowserView *weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf _notifyCreationFailed];
+        });
+        return self;
     }
 
     _client = new GhosttiesCefClient(self);
 
-    // Create browser immediately — Chromium's ProfileManager expects a browser
-    // window shortly after CefInitialize or it shuts down the process.
-    CefWindowInfo windowInfo;
-    CefRect cefRect(0, 0, (int)initialFrame.size.width, (int)initialFrame.size.height);
-    windowInfo.SetAsChild((__bridge CefWindowHandle)self, cefRect);
-
-    CefBrowserSettings settings;
-    NSString *urlStr = url ?: @"about:blank";
-    CefString cefURL([urlStr UTF8String]);
-
-#if DEBUG
-    // Diagnostic 4: the view's window state at the exact moment CreateBrowser
-    // is called. CreateBrowser is invoked from initWithFrame:, where the view
-    // cannot yet be in a window — this confirms or refutes that directly,
-    // without restructuring the call.
-    NSLog(@"[CEFDiag] Pre-CreateBrowser window state: window=%@ superview=%@ frame=%@",
-          self.window, self.superview, NSStringFromRect(self.frame));
-    NSLog(@"[CEFDiag] Calling CefBrowserHost::CreateBrowser (async) for url=%@", urlStr);
-#endif
-    CefBrowserHost::CreateBrowser(windowInfo, _client, cefURL, settings,
-                                  nullptr, nullptr);
-    self.browserCreated = YES;
-
-#if DEBUG
-    // Diagnostic 3: browser-creation watchdog. Log-only — does not alter
-    // when or how CreateBrowser is called. Reports whether OnAfterCreated
-    // has fired yet, plus the view's window hierarchy state at each tick, so
-    // we can tell whether the view was ever attached to a window before the
-    // process exited.
-    __weak CEFBrowserView *diagWeakSelf = self;
-    for (NSNumber *delaySeconds in @[@2.0, @5.0]) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
-                                      (int64_t)(delaySeconds.doubleValue * NSEC_PER_SEC)),
-                       dispatch_get_main_queue(), ^{
-            CEFBrowserView *strongSelf = diagWeakSelf;
-            if (!strongSelf) {
-                NSLog(@"[CEFDiag] CreateBrowser watchdog (%@s): view deallocated",
-                      delaySeconds);
-                return;
-            }
-            NSLog(@"[CEFDiag] CreateBrowser watchdog (%@s): OnAfterCreated fired=%@ "
-                  @"window=%@ superview=%@ frame=%@",
-                  delaySeconds, strongSelf.diagAfterCreatedFired ? @"YES" : @"NO",
-                  strongSelf.window, strongSelf.superview,
-                  NSStringFromRect(strongSelf.frame));
-        });
-    }
-#endif
+    // Creation is deferred to -viewDidMoveToWindow — see that method.
+    // `SetAsChild` requires a view that is already in a window; calling it
+    // here, before the view has ever been added to a superview, guarantees
+    // CreateBrowser fails.
 #else
     NSLog(@"[CEFBrowserView] CEF headers not available — running in stub mode.");
+    self.creationFailed = YES;
+    __weak CEFBrowserView *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf _notifyCreationFailed];
+    });
 #endif
 
     return self;
 }
 
 - (void)dealloc {
+    [_creationWatchdogTimer invalidate];
+    _creationWatchdogTimer = nil;
 #if GHOSTTIES_CEF_AVAILABLE
     if (_browser) {
         _browser->GetHost()->CloseBrowser(true);
@@ -468,6 +454,112 @@ private:
     if (_browser && self.window) {
         _browser->GetHost()->WasResized();
     }
+    // Create the browser the first time this view lands in a real window.
+    // `browserCreated` guards against a second attempt if the view is later
+    // removed from its window and re-added (e.g. re-parented into a
+    // different panel) — it is only cleared by an explicit retry.
+    if (!self.browserCreated && self.window && _client) {
+        [self _createBrowserNow];
+    }
+#endif
+}
+
+#if GHOSTTIES_CEF_AVAILABLE
+/// Actually call `CefBrowserHost::CreateBrowser`. Only ever called from a
+/// path where `self.window != nil` (either -viewDidMoveToWindow, or
+/// -retryCreateBrowser when the view is already attached).
+- (void)_createBrowserNow {
+    if (self.browserCreated) return;
+    self.browserCreated = YES;
+    self.creationAttemptCount += 1;
+
+    CefWindowInfo windowInfo;
+    CefRect cefRect(0, 0, (int)self.frame.size.width, (int)self.frame.size.height);
+    windowInfo.SetAsChild((__bridge CefWindowHandle)self, cefRect);
+
+    CefBrowserSettings settings;
+    NSString *urlStr = self.pendingURL ?: @"about:blank";
+    CefString cefURL([urlStr UTF8String]);
+
+#if DEBUG
+    // Diagnostic 4: the view's window state at the exact moment CreateBrowser
+    // is called. Now guaranteed non-nil by the -viewDidMoveToWindow guard.
+    NSLog(@"[CEFDiag] Pre-CreateBrowser window state: window=%@ superview=%@ frame=%@",
+          self.window, self.superview, NSStringFromRect(self.frame));
+    NSLog(@"[CEFDiag] Calling CefBrowserHost::CreateBrowser (async) for url=%@", urlStr);
+#endif
+    CefBrowserHost::CreateBrowser(windowInfo, _client, cefURL, settings,
+                                  nullptr, nullptr);
+
+#if DEBUG
+    // Diagnostic 3: log-only watchdog, independent of the production one
+    // below. Reports whether OnAfterCreated has fired yet, plus the view's
+    // window hierarchy state at each tick.
+    __weak CEFBrowserView *diagWeakSelf = self;
+    for (NSNumber *delaySeconds in @[@2.0, @5.0]) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                      (int64_t)(delaySeconds.doubleValue * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            CEFBrowserView *strongSelf = diagWeakSelf;
+            if (!strongSelf) {
+                NSLog(@"[CEFDiag] CreateBrowser watchdog (%@s): view deallocated",
+                      delaySeconds);
+                return;
+            }
+            NSLog(@"[CEFDiag] CreateBrowser watchdog (%@s): OnAfterCreated fired=%@ "
+                  @"window=%@ superview=%@ frame=%@",
+                  delaySeconds, strongSelf.diagAfterCreatedFired ? @"YES" : @"NO",
+                  strongSelf.window, strongSelf.superview,
+                  NSStringFromRect(strongSelf.frame));
+        });
+    }
+#endif
+
+    [self _startCreationWatchdog];
+}
+
+/// Ships in Release — this is the real safety net, not a diagnostic. If
+/// `OnAfterCreated` hasn't fired within 3s of calling `CreateBrowser`,
+/// treat creation as failed so nothing downstream waits on a browser that
+/// will never materialise.
+- (void)_startCreationWatchdog {
+    [self.creationWatchdogTimer invalidate];
+    self.creationFailed = NO;
+    __weak CEFBrowserView *weakSelf = self;
+    self.creationWatchdogTimer = [NSTimer scheduledTimerWithTimeInterval:3.0
+                                                                  repeats:NO
+                                                                    block:^(NSTimer *timer) {
+        CEFBrowserView *strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (strongSelf->_browser) return;  // already materialised
+#if DEBUG
+        NSLog(@"[CEFDiag] Creation watchdog: OnAfterCreated did not fire within "
+              @"3.0s — treating creation as failed.");
+#endif
+        [strongSelf _notifyCreationFailed];
+    }];
+}
+#endif // GHOSTTIES_CEF_AVAILABLE
+
+- (void)retryCreateBrowser {
+#if GHOSTTIES_CEF_AVAILABLE
+    if (_browser) return;  // already succeeded
+    [self.creationWatchdogTimer invalidate];
+    self.creationWatchdogTimer = nil;
+    self.browserCreated = NO;
+    self.creationFailed = NO;
+    if (self.window && _client) {
+        [self _createBrowserNow];
+    }
+    // Else: -viewDidMoveToWindow will pick it up once the view lands in a
+    // window again.
+#else
+    // No CEF headers at all — nothing to retry. Re-notify so the caller's
+    // failure UI stays consistent.
+    __weak CEFBrowserView *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf _notifyCreationFailed];
+    });
 #endif
 }
 
@@ -500,14 +592,27 @@ private:
     }
 }
 
+- (void)_notifyCreationFailed {
+    self.creationFailed = YES;
+    if ([self.delegate respondsToSelector:@selector(browserViewDidFailToCreate:)]) {
+        [self.delegate browserViewDidFailToCreate:self];
+    }
+}
+
 #if GHOSTTIES_CEF_AVAILABLE
 - (void)_browserDidCreate:(CefRefPtr<CefBrowser>)browser {
 #if DEBUG
     self.diagAfterCreatedFired = YES;
 #endif
+    [self.creationWatchdogTimer invalidate];
+    self.creationWatchdogTimer = nil;
+    self.creationFailed = NO;
     _browser = browser;
     // Sync CEF's internal child view and compositor to our current bounds.
     [self _syncCefChildBounds];
+    if ([self.delegate respondsToSelector:@selector(browserViewDidCreate:)]) {
+        [self.delegate browserViewDidCreate:self];
+    }
 }
 
 - (void)_browserDidClose {


### PR DESCRIPTION
## Root cause (confirmed on `diag/cef-browser-shutdown`, two instrumented reproductions)

`CEFBrowserView.mm`'s `initWithFrame:url:` called `CefBrowserHost::CreateBrowser` with `windowInfo.SetAsChild((__bridge CefWindowHandle)self, ...)` — but `self` was a freshly-initialized `NSView`, never yet added to a superview or window. On macOS, `SetAsChild` requires a parent view already in a window. Creation was guaranteed to fail, and the process was torn down. The comment at the old call site explained why it was written that way ("Chromium's ProfileManager expects a browser window shortly after CefInitialize or it shuts down the process") — that's the trap: the call was moved earlier to dodge one shutdown path, into the one place where it's guaranteed to hit another.

Secondary finding (not resolved here, noted for the record): teardown bypasses both `atexit` and every signal handler, so it isn't a catchable Chromium `CHECK` or a plain `exit()` — it's `_exit()` or an external kill. A watchdog cannot intercept that; it protects against every failure where our process survives, which is the class we can actually defend.

## What changed

1. **Deferred creation.** `CreateBrowser` now runs from `-viewDidMoveToWindow`, only once `self.window != nil`, guarded by `browserCreated` so re-parenting or a window move can never create a second browser. The pending URL from `init` is retained and consumed at actual creation time.
2. **Creation watchdog.** After `CreateBrowser` is called, a 3s one-shot `NSTimer` starts. If `OnAfterCreated` hasn't fired by then, creation is treated as failed and the delegate is notified. Cancelled in `OnAfterCreated`. **Ships in Release**, not gated behind `#if DEBUG` — this is the real safety net, the `[CEFDiag]` logging around it stays Debug-only.
3. **Inline failure state.** `BrowserFailureStateView` renders inside the browser panel's content area (not a toast) with a message and a Retry button, wired to `CEFBrowserView.retryCreateBrowser`. Used for both the watchdog-timeout case and the pre-existing CEF-unavailable stub path (`scripts/download-cef.sh` not run), which previously rendered a silent blank panel with no explanation.

## Explicitly untouched

`no_sandbox`, `external_message_pump`, CEF cache paths, the 30Hz message-pump timer, singleton lock handling, and the browser start URL. All `Singleton*` files verified byte-identical before/after (both `com.seansmithdesign.ghostties` and `.dev` cache dirs — same mtimes, same symlink targets).

## Tests

I did not add a unit test that instantiates `CEFBrowserView` directly. `GhosttyTests` is app-hosted (`TEST_HOST` = the real `Ghostties(.dev).app`), and that app bundle includes the real CEF framework + helper processes. Constructing a `CEFBrowserView` — even off-window — unconditionally calls `CEFBridgeManager.initializeIfNeeded`, which is a full `CefInitialize` with real subprocess spawn and the same singleton-lock file this bug's diagnosis is built around. Pre-fix, that reliably kills the *host test process* within ~2s (per the diagnosis), which would take down the entire xctest run, not just one test — an unacceptable side effect to leave in the suite permanently. I verified the guard logic by inspection instead (walked through both the window-attach-once and re-parent-without-second-create paths against the diff below), and left CEF integration/manual verification (Sean clicking the globe) as the real gate. Flagging this as a deliberate deviation from the "tests must FAIL then PASS" ask in the brief, rather than silently skipping it.

Full unfiltered suite: **1021 total / 1019 passed / 1 failed / 1 skipped** — unchanged from baseline; the one failure is the documented flake `GitWorktreeCreationTests.raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes()`.

## Verification

- Debug build (`Ghostties Dev.app`) and Release build (`Ghostties.app`) both succeed via `xcodebuild ... -configuration {Debug,Release}`.
- No running Dev instance and no sibling-worktree Dev build present (checked via `pgrep` and a worktree scan) that could swallow a manual launch.
- Launch command (not run, per instructions): `open "macos/build/Build/Products/Debug/Ghostties Dev.app"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbcswCsPgiB9LFYZYBvJCu