### PR TITLE
debug: unattended CEF browser-crash repro harness

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceViewContainer.swift
@@ -610,7 +610,32 @@ class WorkspaceViewContainer: NSView {
         if window.isKeyWindow {
             WorkspaceStore.shared.freezeSnapshot()
         }
+
+        // Debug-only automated CEF browser crash repro (see scripts/debug/cef-repro.sh).
+        // Fires `toggleBrowser()` — the exact same entry point the globe button's
+        // `#selector(toggleBrowser)` action uses — once the window and view
+        // hierarchy are established, so the repro is unattended but otherwise
+        // identical to a real click. Never compiled into Release.
+#if DEBUG
+        WorkspaceViewContainer.triggerDebugAutoOpenBrowserIfNeeded(on: self)
+#endif
     }
+
+#if DEBUG
+    /// Fires exactly once per process, guarded by `GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER=1`.
+    private static var didFireDebugAutoOpenBrowser = false
+    private static func triggerDebugAutoOpenBrowserIfNeeded(on container: WorkspaceViewContainer) {
+        guard !didFireDebugAutoOpenBrowser else { return }
+        guard ProcessInfo.processInfo.environment["GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER"] == "1" else { return }
+        didFireDebugAutoOpenBrowser = true
+        NSLog("[CEFDiag] GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER set — auto-triggering toggleBrowser() via the globe button's own action.")
+        // Dispatch to the next runloop turn so the window is fully key/on-screen
+        // before we drive the same path the globe button drives.
+        DispatchQueue.main.async { [weak container] in
+            container?.toggleBrowser()
+        }
+    }
+#endif
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()

--- a/macos/Sources/Helpers/CEF/CEFBridge.mm
+++ b/macos/Sources/Helpers/CEF/CEFBridge.mm
@@ -4,6 +4,7 @@
 
 #if DEBUG
 #import <SystemConfiguration/SystemConfiguration.h>
+#import <os/log.h>
 #include <unistd.h>
 #include <signal.h>
 #include <execinfo.h>
@@ -101,9 +102,15 @@ static void GhosttiesLogSingletonLockState(NSString *cacheDir) {
     char linkTarget[PATH_MAX] = {0};
     ssize_t linkLen = readlink(cLockPath, linkTarget, sizeof(linkTarget) - 1);
     if (linkLen < 0) {
-        NSLog(@"[CEFDiag] SingletonLock: absent or not a symlink at %@ (errno=%d %s). "
-              @"posixHostname=%@ bonjourLocalHostName=%@",
-              lockPath, errno, strerror(errno), posixHostname, bonjourLocalHostName);
+        // NSLog does not honor the `{public}` privacy annotation (it is only
+        // meaningful to os_log()/os_trace() — clang warns on this at the
+        // NSLog call site, and the unified log silently corrupts the
+        // argument decode rather than un-redacting it). os_log() is the
+        // mechanism that actually makes these values visible.
+        os_log(OS_LOG_DEFAULT,
+               "[CEFDiag] SingletonLock: absent or not a symlink at %{public}@ (errno=%d %{public}s). "
+               "posixHostname=%{public}@ bonjourLocalHostName=%{public}@",
+               lockPath, errno, strerror(errno), posixHostname, bonjourLocalHostName);
         return;
     }
     linkTarget[linkLen] = '\0';
@@ -124,12 +131,13 @@ static void GhosttiesLogSingletonLockState(NSString *cacheDir) {
         pidAlive = (kill(lockPid, 0) == 0);
     }
 
-    NSLog(@"[CEFDiag] SingletonLock target=%@ (lockHostname=%@ lockPid=%d pidAlive=%@) "
-          @"posixHostname=%@ bonjourLocalHostName=%@ hostnameMatch=%@",
-          target, lockHostname, lockPid, pidAlive ? @"YES" : @"NO",
-          posixHostname, bonjourLocalHostName,
-          ([lockHostname isEqualToString:posixHostname] ||
-           [lockHostname isEqualToString:bonjourLocalHostName]) ? @"YES" : @"NO");
+    os_log(OS_LOG_DEFAULT,
+           "[CEFDiag] SingletonLock target=%{public}@ (lockHostname=%{public}@ lockPid=%d pidAlive=%{public}@) "
+           "posixHostname=%{public}@ bonjourLocalHostName=%{public}@ hostnameMatch=%{public}@",
+           target, lockHostname, lockPid, pidAlive ? @"YES" : @"NO",
+           posixHostname, bonjourLocalHostName,
+           ([lockHostname isEqualToString:posixHostname] ||
+            [lockHostname isEqualToString:bonjourLocalHostName]) ? @"YES" : @"NO");
 }
 
 /// Logs a symbolized backtrace tagged [CEFDiag], one frame per line so it
@@ -140,14 +148,14 @@ static void GhosttiesLogBacktrace(const char *reason) {
     void *frames[64];
     int count = backtrace(frames, 64);
     char **symbols = backtrace_symbols(frames, count);
-    NSLog(@"[CEFDiag] %s — backtrace (%d frames):", reason, count);
+    os_log(OS_LOG_DEFAULT, "[CEFDiag] %{public}s — backtrace (%d frames):", reason, count);
     if (symbols) {
         for (int i = 0; i < count; i++) {
-            NSLog(@"[CEFDiag]   #%d %s", i, symbols[i]);
+            os_log(OS_LOG_DEFAULT, "[CEFDiag]   #%d %{public}s", i, symbols[i]);
         }
         free(symbols);
     } else {
-        NSLog(@"[CEFDiag]   (backtrace_symbols failed, errno=%d %s)", errno, strerror(errno));
+        os_log(OS_LOG_DEFAULT, "[CEFDiag]   (backtrace_symbols failed, errno=%d %{public}s)", errno, strerror(errno));
     }
 }
 
@@ -163,7 +171,7 @@ static void GhosttiesAtExitHandler(void) {
 /// crash still produces its normal report/termination — this only adds a
 /// log line ahead of it, it does not change what happens to the process.
 static void GhosttiesSignalHandler(int signo) {
-    // NSLog and backtrace_symbols are not async-signal-safe. This is a
+    // os_log() and backtrace_symbols are not async-signal-safe. This is a
     // Debug-only diagnostic build where "some evidence, maybe corrupted" beats
     // "no evidence" — acceptable tradeoff here, not for shipping code.
     GhosttiesLogBacktrace("signal handler fired");
@@ -305,7 +313,7 @@ static void GhosttiesInstallExitDiagnostics(void) {
     CefRefPtr<GhosttiesApp> app(new GhosttiesApp());
     bool success = CefInitialize(mainArgs, settings, app, nullptr);
 #if DEBUG
-    NSLog(@"[CEFDiag] CefInitialize returned %@", success ? @"true" : @"false");
+    os_log(OS_LOG_DEFAULT, "[CEFDiag] CefInitialize returned %{public}@", success ? @"true" : @"false");
 #endif
     if (!success) {
         NSLog(@"[CEFBridge] CefInitialize failed.");
@@ -367,8 +375,8 @@ static void GhosttiesInstallExitDiagnostics(void) {
 
 + (void)_appWillTerminate:(NSNotification *)note {
 #if DEBUG
-    NSLog(@"[CEFDiag] NSApplicationWillTerminateNotification fired at %@",
-          [NSDate date]);
+    os_log(OS_LOG_DEFAULT, "[CEFDiag] NSApplicationWillTerminateNotification fired at %{public}@",
+           [NSDate date]);
 #endif
     [self shutdown];
 }

--- a/macos/Sources/Helpers/CEF/CEFBrowserView.mm
+++ b/macos/Sources/Helpers/CEF/CEFBrowserView.mm
@@ -1,6 +1,9 @@
 #import "CEFBrowserView.h"
 #import "CEFBridge.h"
 #import <AppKit/AppKit.h>
+#if DEBUG
+#import <os/log.h>
+#endif
 
 // CEF headers are only available after running scripts/download-cef.sh.
 // When absent, the view compiles in stub mode — all methods are no-ops.
@@ -484,9 +487,14 @@ private:
 #if DEBUG
     // Diagnostic 4: the view's window state at the exact moment CreateBrowser
     // is called. Now guaranteed non-nil by the -viewDidMoveToWindow guard.
-    NSLog(@"[CEFDiag] Pre-CreateBrowser window state: window=%@ superview=%@ frame=%@",
-          self.window, self.superview, NSStringFromRect(self.frame));
-    NSLog(@"[CEFDiag] Calling CefBrowserHost::CreateBrowser (async) for url=%@", urlStr);
+    // NSLog does not honor `{public}` (that annotation only means something
+    // to os_log()/os_trace() — clang warns on the NSLog call site, and the
+    // unified log corrupts the argument decode instead of un-redacting it).
+    // os_log() is the mechanism that actually makes these values visible.
+    os_log(OS_LOG_DEFAULT,
+           "[CEFDiag] Pre-CreateBrowser window state: window=%{public}@ superview=%{public}@ frame=%{public}@",
+           self.window, self.superview, NSStringFromRect(self.frame));
+    os_log(OS_LOG_DEFAULT, "[CEFDiag] Calling CefBrowserHost::CreateBrowser (async) for url=%{public}@", urlStr);
 #endif
     CefBrowserHost::CreateBrowser(windowInfo, _client, cefURL, settings,
                                   nullptr, nullptr);
@@ -502,15 +510,16 @@ private:
                        dispatch_get_main_queue(), ^{
             CEFBrowserView *strongSelf = diagWeakSelf;
             if (!strongSelf) {
-                NSLog(@"[CEFDiag] CreateBrowser watchdog (%@s): view deallocated",
-                      delaySeconds);
+                os_log(OS_LOG_DEFAULT, "[CEFDiag] CreateBrowser watchdog (%{public}@s): view deallocated",
+                       delaySeconds);
                 return;
             }
-            NSLog(@"[CEFDiag] CreateBrowser watchdog (%@s): OnAfterCreated fired=%@ "
-                  @"window=%@ superview=%@ frame=%@",
-                  delaySeconds, strongSelf.diagAfterCreatedFired ? @"YES" : @"NO",
-                  strongSelf.window, strongSelf.superview,
-                  NSStringFromRect(strongSelf.frame));
+            os_log(OS_LOG_DEFAULT,
+                   "[CEFDiag] CreateBrowser watchdog (%{public}@s): OnAfterCreated fired=%{public}@ "
+                   "window=%{public}@ superview=%{public}@ frame=%{public}@",
+                   delaySeconds, strongSelf.diagAfterCreatedFired ? @"YES" : @"NO",
+                   strongSelf.window, strongSelf.superview,
+                   NSStringFromRect(strongSelf.frame));
         });
     }
 #endif

--- a/scripts/debug/cef-repro.sh
+++ b/scripts/debug/cef-repro.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+#
+# cef-repro.sh — Unattended reproduction harness for the CEF embedded-browser
+# crash (main process dies ~460ms after CefBrowserHost::CreateBrowser).
+#
+# Drives the SAME code path as a real click on the globe button
+# (WorkspaceViewContainer.toggleBrowser()), triggered by an env var that only
+# exists in Debug builds — no synthetic keystrokes, no accessibility driving.
+#
+# Usage:
+#   scripts/debug/cef-repro.sh [--runs N] [--timeout SECONDS] [--app PATH]
+#
+# Exit code: 0 if the LAST run SURVIVED, 1 if it DIED (or on a setup error).
+# With --runs > 1, the exit code reflects the last run only; the printed
+# tally is the authoritative summary across all runs.
+#
+# HARD RULE: this script must never `killall ghostty` / `killall ghostties`.
+# Cleanup only ever SIGTERMs the exact PID this script itself launched, and
+# only after verifying that PID's executable path points at the Dev bundle
+# we launched.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+APP_PATH="${GHOSTTIES_DEV_APP:-$REPO_ROOT/macos/build/Build/Products/Debug/Ghostties Dev.app}"
+TIMEOUT_SECONDS=30
+RUNS=1
+
+usage() {
+  cat <<'EOF'
+Usage: cef-repro.sh [--runs N] [--timeout SECONDS] [--app PATH]
+
+  --runs N        Repeat the reproduction N times and report a tally (default 1).
+  --timeout SEC   Seconds to wait for DIED/SURVIVED per run (default 30).
+  --app PATH      Path to "Ghostties Dev.app" (default: macos/build/Build/Products/Debug).
+
+Exit code 0 if the last run SURVIVED, 1 if it DIED, 2 on a setup/preflight error.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs)
+      RUNS="$2"; shift 2 ;;
+    --timeout)
+      TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --app)
+      APP_PATH="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2 ;;
+  esac
+done
+
+BUNDLE_EXEC="$APP_PATH/Contents/MacOS/ghostty"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "ERROR: app bundle not found at: $APP_PATH" >&2
+  echo "Build it first: xcodebuild -project macos/Ghostties.xcodeproj -scheme Ghostties -configuration Debug -derivedDataPath macos/build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build" >&2
+  exit 2
+fi
+
+if [[ ! -x "$BUNDLE_EXEC" ]]; then
+  echo "ERROR: no executable at: $BUNDLE_EXEC" >&2
+  exit 2
+fi
+
+BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$INFO_PLIST" 2>/dev/null || true)"
+if [[ -z "$BUNDLE_ID" ]]; then
+  echo "ERROR: could not read CFBundleIdentifier from $INFO_PLIST" >&2
+  exit 2
+fi
+
+# Refuse to run against a non-Debug build. Debug Dev builds carry the
+# ".dev" bundle-id suffix (see CEFBridge.mm's cache-dir comment); Release
+# does not build the auto-open trigger at all (it's `#if DEBUG`-gated), so
+# this bundle-id check is the cheap first gate and the strings(1) check
+# below is the real one.
+case "$BUNDLE_ID" in
+  *.dev) ;;
+  *)
+    echo "ERROR: refusing to run against a non-Debug build (bundle id: $BUNDLE_ID)." >&2
+    echo "This harness only works against a Debug 'Ghostties Dev.app' build." >&2
+    exit 2
+    ;;
+esac
+
+# The trigger's string literal lives in the Swift debug dylib
+# (ghostty.debug.dylib), not the thin launcher executable, on a Debug build
+# with dynamic linking — so check both. Write to a temp file rather than
+# piping straight into `grep -q`: with `set -o pipefail`, grep -q's early
+# exit on match sends SIGPIPE back up to `strings` on a 40MB+ dylib, and
+# that non-zero signal-exit status propagates through the pipeline.
+DEBUG_DYLIB="$APP_PATH/Contents/MacOS/ghostty.debug.dylib"
+_strings_tmp="$(mktemp -t cef-repro-strings)"
+/usr/bin/strings "$BUNDLE_EXEC" >"$_strings_tmp" 2>/dev/null
+[[ -f "$DEBUG_DYLIB" ]] && /usr/bin/strings "$DEBUG_DYLIB" >>"$_strings_tmp" 2>/dev/null
+if ! grep -q 'GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER' "$_strings_tmp"; then
+  rm -f "$_strings_tmp"
+  echo "ERROR: no GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER support found in $BUNDLE_EXEC or $DEBUG_DYLIB." >&2
+  echo "Rebuild after WorkspaceViewContainer.swift's debug auto-open trigger lands." >&2
+  exit 2
+fi
+rm -f "$_strings_tmp"
+
+CACHE_DIR="$HOME/Library/Application Support/$BUNDLE_ID/CEF"
+CEF_INTERNAL_LOG="$CACHE_DIR/ghostties-cef-internal.log"
+
+echo "== cef-repro.sh =="
+echo "App:        $APP_PATH"
+echo "Bundle ID:  $BUNDLE_ID"
+echo "CEF cache:  $CACHE_DIR"
+echo "Runs:       $RUNS"
+echo "Timeout:    ${TIMEOUT_SECONDS}s per run"
+echo
+
+# ---------------------------------------------------------------------------
+# One repro run.
+#
+# Sets globals: RUN_VERDICT ("SURVIVED" or "DIED"), RUN_DIED_MS (empty if
+# SURVIVED), RUN_CEFDIAG_LOG (path to this run's captured [CEFDiag] lines),
+# RUN_LAUNCHED_PID.
+# ---------------------------------------------------------------------------
+run_once() {
+  local run_idx="$1"
+  echo "--- Run $run_idx/$RUNS ---"
+
+  # Snapshot the CEF internal log's size BEFORE launch, so we can tail only
+  # what this run appended.
+  local cef_log_before_size=0
+  if [[ -f "$CEF_INTERNAL_LOG" ]]; then
+    cef_log_before_size=$(stat -f%z "$CEF_INTERNAL_LOG")
+  fi
+
+  # Stream [CEFDiag]-tagged unified log lines from this process to a temp
+  # file, started BEFORE launch so nothing is missed. `log stream` attaches
+  # asynchronously; give it a beat before we launch.
+  local diag_log
+  diag_log="$(mktemp -t cef-repro-diag)"
+  /usr/bin/log stream --style compact \
+    --predicate 'eventMessage contains "[CEFDiag]"' \
+    >"$diag_log" 2>/dev/null &
+  local log_stream_pid=$!
+  sleep 0.5
+
+  # Launch directly (bypasses `open`'s async PID-hunting problem — we get
+  # the exact PID from $! and know its executable path is $BUNDLE_EXEC
+  # because we just exec'd it ourselves).
+  GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER=1 "$BUNDLE_EXEC" >/dev/null 2>&1 &
+  local pid=$!
+
+  echo "Launched PID $pid ($BUNDLE_EXEC)"
+
+  # Verify the env var actually arrived in the child's environment.
+  sleep 0.5
+  local env_check
+  env_check="$(ps eww -p "$pid" 2>/dev/null | grep -o 'GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER=1' || true)"
+  if [[ -z "$env_check" ]]; then
+    echo "WARNING: could not confirm GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER=1 in PID $pid's environment via ps eww (process may have already died, or ps may not expose environ for this process)."
+  else
+    echo "Confirmed: $env_check present in PID $pid's environment."
+  fi
+
+  # Poll for up to TIMEOUT_SECONDS for either the process dying or
+  # OnAfterCreated appearing in the streamed diagnostics. Wall-clock
+  # timestamps come from python3 (millisecond precision) rather than the
+  # unified log's own timestamps — `date`(1) on macOS has no sub-second
+  # format specifier, and the CreateBrowser-to-death window is sub-second.
+  local now_ms
+  now_ms() { python3 -c 'import time; print(int(time.time() * 1000))'; }
+
+  local deadline_epoch_s=$(( $(date +%s) + TIMEOUT_SECONDS ))
+  local verdict="SURVIVED"
+  local create_seen=0
+  local create_ms=""
+  while [[ $(date +%s) -lt $deadline_epoch_s ]]; do
+    if [[ "$create_seen" -eq 0 ]] && grep -q 'Calling CefBrowserHost::CreateBrowser' "$diag_log" 2>/dev/null; then
+      create_seen=1
+      create_ms="$(now_ms)"
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      verdict="DIED"
+      break
+    fi
+    if grep -q 'OnAfterCreated fired' "$diag_log" 2>/dev/null; then
+      verdict="SURVIVED"
+      break
+    fi
+    sleep 0.1
+  done
+  local end_ms
+  end_ms="$(now_ms)"
+
+  local died_ms=""
+  if [[ "$verdict" == "DIED" && -n "$create_ms" ]]; then
+    died_ms=$(( end_ms - create_ms ))
+  fi
+
+  # Give the log stream a moment to flush the last lines (e.g. the six
+  # helper "Mach rendezvous failed" lines land shortly after main-process
+  # death), then stop it.
+  sleep 1
+  kill "$log_stream_pid" 2>/dev/null
+  wait "$log_stream_pid" 2>/dev/null
+
+  # ---- Cleanup: SIGTERM only OUR launched PID, only after verifying its
+  # executable path matches the bundle we launched. Never killall. ----
+  if kill -0 "$pid" 2>/dev/null; then
+    local exec_path
+    exec_path="$(ps -o comm= -p "$pid" 2>/dev/null || true)"
+    if [[ "$exec_path" == "$BUNDLE_EXEC" ]]; then
+      kill "$pid" 2>/dev/null
+      sleep 0.3
+      kill -9 "$pid" 2>/dev/null
+    else
+      echo "WARNING: PID $pid's executable path ($exec_path) no longer matches $BUNDLE_EXEC — skipping cleanup kill to avoid targeting the wrong process." >&2
+    fi
+  fi
+
+  echo
+  if [[ "$verdict" == "DIED" ]]; then
+    if [[ -n "$died_ms" ]]; then
+      echo "VERDICT: DIED after ${died_ms}ms from CreateBrowser"
+    else
+      echo "VERDICT: DIED (could not compute ms-from-CreateBrowser — see raw log below)"
+    fi
+  else
+    echo "VERDICT: SURVIVED"
+  fi
+
+  echo
+  echo "[CEFDiag] lines (run $run_idx):"
+  if [[ -s "$diag_log" ]]; then
+    cat "$diag_log"
+  else
+    echo "(none captured)"
+  fi
+
+  echo
+  echo "CEF internal log tail (new bytes this run):"
+  if [[ -f "$CEF_INTERNAL_LOG" ]]; then
+    local cef_log_after_size
+    cef_log_after_size=$(stat -f%z "$CEF_INTERNAL_LOG")
+    if [[ "$cef_log_after_size" -gt "$cef_log_before_size" ]]; then
+      tail -c $(( cef_log_after_size - cef_log_before_size )) "$CEF_INTERNAL_LOG"
+    else
+      echo "(no new bytes appended to $CEF_INTERNAL_LOG)"
+    fi
+  else
+    echo "(no CEF internal log at $CEF_INTERNAL_LOG)"
+  fi
+  echo
+
+  RUN_VERDICT="$verdict"
+  RUN_DIED_MS="$died_ms"
+  rm -f "$diag_log"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+SURVIVED_COUNT=0
+DIED_COUNT=0
+
+for ((i = 1; i <= RUNS; i++)); do
+  run_once "$i"
+  if [[ "$RUN_VERDICT" == "SURVIVED" ]]; then
+    SURVIVED_COUNT=$((SURVIVED_COUNT + 1))
+  else
+    DIED_COUNT=$((DIED_COUNT + 1))
+  fi
+  echo "=================================================="
+  echo
+done
+
+if [[ "$RUNS" -gt 1 ]]; then
+  echo "== Tally =="
+  echo "SURVIVED: $SURVIVED_COUNT/$RUNS"
+  echo "DIED:     $DIED_COUNT/$RUNS"
+  echo
+fi
+
+if [[ "$RUN_VERDICT" == "SURVIVED" ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Un-redacts every `[CEFDiag]` diagnostic. `NSLog`'s `%{public}` annotation is a no-op (clang warns `using 'public' format specifier annotation outside of os_log()/os_trace()`; the unified log corrupted the argument decode into `<decode: missing data>` instead of un-redacting it). Migrated these Debug-only sites from `NSLog` to `os_log()`, which actually honors the privacy annotation.
- Adds a Debug-only `GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER=1` env-var trigger in `WorkspaceViewContainer.viewDidMoveToWindow()` that calls `toggleBrowser()` — the exact same method the globe button's `#selector(toggleBrowser)` action calls — once the window and view hierarchy are established. No synthetic keystrokes, no AX driving; `#if DEBUG`-gated, compiled out of Release.
- Adds `scripts/debug/cef-repro.sh`: launches a Debug `Ghostties Dev.app` build with the trigger set, streams `[CEFDiag]` unified-log lines, polls for the process dying or `OnAfterCreated` firing, prints a `SURVIVED`/`DIED after <ms>` verdict plus the diagnostic lines and CEF internal log tail, and supports `--runs N` for a tally. Exit 0 on SURVIVED, 1 on DIED.
- Does **not** attempt to fix the crash — no changes to CEF settings, message pump, cache paths, start URL, sandbox flags, or singleton-lock handling.

## Result
3/3 runs **DIED** 439–596ms after `CreateBrowser`, consistent with the previously-documented ~460ms window (deterministic, not intermittent, at this sample size). Real values are now visible instead of `<private>`:

```
[CEFDiag] SingletonLock target=seans-mbp.lan-68974 (lockHostname=seans-mbp.lan lockPid=68974 pidAlive=NO) posixHostname=seans-mbp.lan bonjourLocalHostName=Seans-MacBook-Pro hostnameMatch=YES
[CEFDiag] CefInitialize returned true
[CEFDiag] Pre-CreateBrowser window state: window=<Ghostty.TerminalWindow: 0x78b30d5b00> superview=<NSView: 0x78b2ae5b80> frame={{0, 0}, {800, 600}}
[CEFDiag] Calling CefBrowserHost::CreateBrowser (async) for url=https://www.google.com
```

Window/superview are non-nil (confirms #157's fix holds), lock hostname/PID match cleanly (rules out stale-lock hypothesis again with real data), and the target URL loads over HTTPS — nothing here points at scheme, sandbox, or singleton-lock as the cause. Next debugging round should look at what happens between `CreateBrowser` and process death in that ~450-600ms window (subprocess spawn, IPC/Mach setup) now that the harness can iterate on it unattended.

## Test plan
- [x] `xcodebuild build` succeeds (Debug, arm64)
- [x] `bash scripts/debug/cef-repro.sh --runs 3` — 3/3 DIED, real values visible, verdict + tally printed
- [x] Full unfiltered suite: 1021 total / 1019 passed / 1 failed (known flake `GitWorktreeCreationTests.raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes()`) / 1 skipped — matches baseline exactly
- [x] `Singleton*` file set unchanged before/after (script never references `Singleton*`)
- [x] No `killall`; cleanup only signals the exact PID this script launched, after verifying its executable path

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>