### PR TITLE
docs(backlog): CEF fix proven insufficient — crash reproduced on the Release profile

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,26 +9,34 @@ unsupported profile downgrade — Chromium ends it with a deliberate `_exit` ~0.
 `docs/plans/cef-crash-strategy-2026-09-01.md`. A fresh overnight thread executes phases
 P0–P4 below unattended, T2 implementer + T1 reviewer per phase.
 
-- [ ] **P0 — Preconditions.** Prove the crash fixture is stable before touching anything:
-  capture the launchd/RunningBoard exit record for the last Release death, then reproduce
-  DIED 2/2 on the unfixed `main` lab build against a copy of the backed-up profile. Stop if
-  it survives — the fixture has decayed and needs re-deriving first.
-- [ ] **P1 — Observability + lab controls.** Add env-gated `[CEFBridge]`/`[CEFDiag]` logging
-  around `CefInitialize` (pre/post/alive-ticks), an app-support-dir override env var, and a
-  Release-mode auto-open-browser flag — all off by default, Release-safe. Accept: a lab
-  launch logs the new lines and `log show` confirms them; stop if Release still emits none.
-- [ ] **P2 — Experiments.** No source changes. Run the E0–E7 ladder from the plan's §2 on
-  copies of the backed-up profile to pin the exact death mechanism; report one arm-by-result
-  table with artefacts (backtrace, log excerpt, exit code). Stop and skip to P4 if the death
-  turns out to come from outside the process (signal, not a deliberate quit).
-- [ ] **P3 — Fix.** Add a pre-`CefInitialize` downgrade guard that moves a newer-version
-  profile aside and starts fresh, re-anchor the sentinel around `CefInitialize` instead of
-  `CreateBrowser`, and make the existing failure-state view actually render. Accept: fixed
-  lab build SURVIVES 3/3 against a fresh backup copy, a second launch on the same dir makes
-  no move, full unfiltered test suite passes. Stop on any DIED — no blind tuning.
-- [ ] **P4 — Ship.** Open a PR against `main` on `SeanSmithWorks/ghostties` carrying the
-  experiment table and P3 evidence, plus a screenshot proving a real (non-override) Release
-  build launches clean. Delete lab copies/worktrees and update `BACKLOG.md`.
+- [x] **P0 — Preconditions.** Done. RunningBoard recorded `termination reported by launchd
+  (0, 0, 1536)` for the original crash — exit status 0, no signal, confirming a deliberate
+  quit rather than a fault. Fixture verified stable at `last_chrome_version 150.0.7871.129`.
+- [x] **P1 — Observability + lab controls.** Done. `GHOSTTIES_CEF_APP_SUPPORT_DIR` override,
+  `[CEFBridge]` `os_log` probes with 250ms alive-ticks, `[CEFDiag]` moved to a runtime env
+  gate, auto-open un-gated for Release, `--allow-non-dev` added to the repro script. P1 ran
+  **before** P0's E0: an unfixed Release build had no non-GUI way to reach the fixture until
+  the lab controls existed.
+- [x] **P2 — Experiments.** Done. E0 baseline DIED 2/2 (0.53s, 0.41s). E3 (flip
+  `last_chrome_version` alone) DIED 2/2. E4 (replace `Default/Preferences` wholesale) DIED.
+  E2 (`exit_type` → Normal) DIED. E1 (lldb) abandoned — generic breakpoints matched 9–39
+  locations and fired continuously. E3 and E4 are why the remediation moves the whole
+  profile directory rather than patching a key or a file.
+- [x] **P3 — Fix.** Done, three rounds. Downgrade guard with a bounded version parse
+  (rejects, never clamps, applied to both the stamp and the `Preferences` fallback);
+  sentinel clear moved to a process-level 3s timer after `CefInitialize`; automatic reset
+  gated on the move actually succeeding; failure notice made visible. Fresh fixture copy +
+  fixed build SURVIVED 3/3. Suite 1040/1043, the two failures being the known pre-existing
+  flakes. 12 new parse-path tests, mutant-verified.
+- [x] **P4 — Ship.** Done. PR #162 against `main` on `SeanSmithWorks/ghostties`, carrying the
+  experiment table and evidence in `docs/plans/evidence/`. `/Applications/Ghostties-fix.app`
+  installed, 6 CEF symbols, adhoc-signed, not launched.
+- [ ] **OPEN — composer variant C still not visually confirmed.** The overnight run could
+  not screenshot it: the palette needs ⌘N and synthetic input is disallowed, `screencapture`
+  returns a black frame from a stale TCC grant, and `workspace.json` is not isolated from lab
+  launches so a second live instance was not safe to run. By binary the code is present (0
+  occurrences of the old `"Pick one from the branch picker"` string). To confirm: launch
+  `/Applications/Ghostties-fix.app` and press ⌘N.
 - [ ] **DECISION APPLIED BY DEFAULT (redline if wrong):** on downgrade, reset the profile
   silently and show one inline notice line — no button (Fable's recommendation; the button
   is a second failure surface, see the invisible-fallback item below).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,38 @@
 # Ghostties — Backlog
 
+## 2026-09-02 — CEF crash root-caused (Chromium 150→144 profile downgrade); overnight fix dispatched
+
+**Verdict (Fable 5.1):** Sean's Release CEF profile was written by Chromium 150; the Aug 1
+security pin (PR #60) fixed `vendor/cef` at 144, so every browser open since has been an
+unsupported profile downgrade — Chromium ends it with a deliberate `_exit` ~0.4s after
+`CefInitialize`, before the #159 sentinel is ever written. Full diagnosis and fix design:
+`docs/plans/cef-crash-strategy-2026-09-01.md`. A fresh overnight thread executes phases
+P0–P4 below unattended, T2 implementer + T1 reviewer per phase.
+
+- [ ] **P0 — Preconditions.** Prove the crash fixture is stable before touching anything:
+  capture the launchd/RunningBoard exit record for the last Release death, then reproduce
+  DIED 2/2 on the unfixed `main` lab build against a copy of the backed-up profile. Stop if
+  it survives — the fixture has decayed and needs re-deriving first.
+- [ ] **P1 — Observability + lab controls.** Add env-gated `[CEFBridge]`/`[CEFDiag]` logging
+  around `CefInitialize` (pre/post/alive-ticks), an app-support-dir override env var, and a
+  Release-mode auto-open-browser flag — all off by default, Release-safe. Accept: a lab
+  launch logs the new lines and `log show` confirms them; stop if Release still emits none.
+- [ ] **P2 — Experiments.** No source changes. Run the E0–E7 ladder from the plan's §2 on
+  copies of the backed-up profile to pin the exact death mechanism; report one arm-by-result
+  table with artefacts (backtrace, log excerpt, exit code). Stop and skip to P4 if the death
+  turns out to come from outside the process (signal, not a deliberate quit).
+- [ ] **P3 — Fix.** Add a pre-`CefInitialize` downgrade guard that moves a newer-version
+  profile aside and starts fresh, re-anchor the sentinel around `CefInitialize` instead of
+  `CreateBrowser`, and make the existing failure-state view actually render. Accept: fixed
+  lab build SURVIVES 3/3 against a fresh backup copy, a second launch on the same dir makes
+  no move, full unfiltered test suite passes. Stop on any DIED — no blind tuning.
+- [ ] **P4 — Ship.** Open a PR against `main` on `SeanSmithWorks/ghostties` carrying the
+  experiment table and P3 evidence, plus a screenshot proving a real (non-override) Release
+  build launches clean. Delete lab copies/worktrees and update `BACKLOG.md`.
+- [ ] **DECISION APPLIED BY DEFAULT (redline if wrong):** on downgrade, reset the profile
+  silently and show one inline notice line — no button (Fable's recommendation; the button
+  is a second failure surface, see the invisible-fallback item below).
+
 ## 2026-09-01 — composer ultra-minimal SHIPPED; CEF browser fix MERGED, Release profile still unverified
 
 `main` @ `bceb7a74a`. **PR #155 MERGED** — composer variant C (ultra-minimal): trailing
@@ -16,11 +49,11 @@ literal the round-1 fix had missed, round 3 found a comment the round-2 fix intr
   claim exactly; the failure is `GitWorktreeCreationTests/raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes()`,
   a `2.74 < 2.0` wall-clock flake unrelated to CEF), and all 6 `CEFBrowserSentinelTests` passed.
 
-- [ ] **OPEN, PRIMARY — the merged fix does NOT fix the crash. Reproduced on the Release
-  profile 2026-09-01 22:55.** Sean clicked the globe in a release-bundle-ID build carrying
-  the full #159 stack; `[CEFBridge] CEF initialized.` at `22:55:34.261`, last log line
-  `22:55:34.349`, process gone by `22:55:36`. No `.ips`, no signal, no further output.
-  **Next round: Fable 5.1 to analyse the flaw's source and the way past it.**
+- [x] **RESOLVED (root cause) — the merged fix does NOT fix the crash. Reproduced on the
+  Release profile 2026-09-01 22:55.** Sean clicked the globe in a release-bundle-ID build
+  carrying the full #159 stack; `[CEFBridge] CEF initialized.` at `22:55:34.261`, last log
+  line `22:55:34.349`, process gone by `22:55:36`. No `.ips`, no signal, no further output.
+  **Root cause and plan: see 2026-09-02 above.**
 
 - [ ] **OPEN — the sentinel is placed around the WRONG call, and the Dev bisection misled us.**
   `recordBrowserOpenAttempt` is called at `CEFBrowserView.mm:499`, before `CreateBrowser` at

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,16 +16,46 @@ literal the round-1 fix had missed, round 3 found a comment the round-2 fix intr
   claim exactly; the failure is `GitWorktreeCreationTests/raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes()`,
   a `2.74 < 2.0` wall-clock flake unrelated to CEF), and all 6 `CEFBrowserSentinelTests` passed.
 
-- [ ] **OPEN — the Release profile has never been exercised, so attribution is unresolved.**
-  `com.seansmithdesign.ghostties/CEF` is still 141M with `Local State` frozen at 2026-08-13.
-  The harness **cannot** reach it — `GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER` is `#if DEBUG`-gated,
-  so it only ever drives the Dev profile. Needs Sean clicking the globe in a Release build.
-  Note the sentinel's recovery path **never fired** during verification (no `CEF-broken-*`
-  anywhere, no leftover `browser-open-attempt`) — the browser simply worked, so what actually
-  fixed it is ambiguous between #157's window-attach fix and the Dev profile's state
-  decaying (it went 188M/dying → 130M/clean with no reset). Release profile backed up to
-  `com.seansmithdesign.ghostties/CEF-backup-2026-09-01` (141M) so the sentinel test is
-  zero-risk.
+- [ ] **OPEN, PRIMARY — the merged fix does NOT fix the crash. Reproduced on the Release
+  profile 2026-09-01 22:55.** Sean clicked the globe in a release-bundle-ID build carrying
+  the full #159 stack; `[CEFBridge] CEF initialized.` at `22:55:34.261`, last log line
+  `22:55:34.349`, process gone by `22:55:36`. No `.ips`, no signal, no further output.
+  **Next round: Fable 5.1 to analyse the flaw's source and the way past it.**
+
+- [ ] **OPEN — the sentinel is placed around the WRONG call, and the Dev bisection misled us.**
+  `recordBrowserOpenAttempt` is called at `CEFBrowserView.mm:499`, before `CreateBrowser` at
+  `:521`. After the crash above, **no `browser-open-attempt` file exists on disk** — so the
+  process died *before* line 499, i.e. during or just after `CefInitialize`, NOT at
+  `CreateBrowser`. The Dev-profile bisection's "dies ~460ms after `CreateBrowser`" does not
+  describe the Release-profile failure. Consequences: (a) the recovery UI never arms, because
+  its trigger is an uncleared sentinel that is never written; (b) the whole sentinel design
+  is anchored to the wrong point in the sequence. This reframes the fix rather than tuning it.
+
+- [ ] **OPEN — `[CEFDiag]` instrumentation is `#if DEBUG`-gated, so it emits nothing in a
+  release-bundle-ID build.** The only Release-visible line is the ungated
+  `[CEFBridge] CEF initialized.` NSLog. Pinning the exact death point needs that gating
+  relaxed, or an equivalent ungated probe.
+
+- [ ] **OPEN — `ReleaseLocal` can never produce a working browser (repo bug, independent of
+  the crash).** Its `HEADER_SEARCH_PATHS` omits `vendor/cef`, which Debug and Release both
+  carry. CEF availability is a compile-time `__has_include`, so the browser silently compiles
+  out to a no-op stub: **0 CEF symbols in the ReleaseLocal binary vs 4 in Release**, while the
+  288M framework still ships in the bundle. No error, no warning — the globe button just does
+  nothing. Anyone building that config to test the browser is testing a stub.
+
+- [ ] **OPEN — the graceful-fallback failure state is invisible.** On the failed opens,
+  `BrowserPanelView` / `BrowserTabBar` / `BrowserNavigationBar` / `BrowserFailureStateView`
+  were all constructed, AppKit logged four `Unable to simultaneously satisfy constraints`
+  conflicts naming `BrowserFailureStateView`, and Sean saw **nothing** on screen. The
+  fallback shipped in this stack does not communicate.
+
+- [x] **DONE — Release profile backed up** to `com.seansmithdesign.ghostties/CEF-backup-2026-09-01`
+  (141M, `Local State` preserved at Aug 13 15:31:26), so crash testing is zero-risk.
+
+- [ ] **CARRIED — Sean wants to visually confirm the composer** (variant C) in a working
+  build. By binary it IS current in every build made 2026-09-01 (0 occurrences of the old
+  `"Pick one from the branch picker"` string, 1 of the new shared constant; beta.24 still has
+  the old one). Not yet seen on screen in a build whose browser also works.
 
 - [ ] **CARRIED — Sean's 3 junk `New Template` rows still in `workspace.json`.** PR #155
   stops new ones; it does not purge existing. Delete in-app (right-click → Delete). All

--- a/docs/plans/cef-crash-strategy-2026-09-01.md
+++ b/docs/plans/cef-crash-strategy-2026-09-01.md
@@ -1,0 +1,63 @@
+# CEF crash — strategy and overnight plan (2026-09-01)
+
+**Verdict.** Sean's Release CEF profile was written by **Chromium 150** and is being opened by **Chromium 144**. The Aug 1 security pin (`b174f0937`, PR #60) swapped the "latest stable" CEF download for a fixed 144 build; Chromium does not support profile downgrades, and a 144 startup task against 150-era data ends in a deliberate process quit ~0.4s after `CefInitialize` returns — before `CreateBrowser`, so the merged sentinel (#159) never arms. Fix = a pre-init **downgrade guard** that moves a newer-version profile aside, plus the sentinel re-anchored around `CefInitialize`. The `exit_type: Crashed` hypothesis is dead.
+
+## 1. Diagnosis
+
+- **Confirmed — downgrade.** `CEF-backup-2026-09-01/Default/Preferences` → `extensions.last_chrome_version = "150.0.7871.129"`, mtime Aug 1 00:47 (frozen since). `vendor/cef/include/cef_version.h` → `CHROME_VERSION_MAJOR 144`. Pin commit text: the server "previously chose latest stable at build time". `Local State` `variations_crash_streak = 9`.
+- **Confirmed — Dev is not a fixture.** Dev profile reads `144.0.7559.258`, no crash streak: it was never downgraded. Its afternoon 3/3 death was a different, decayed poison. Only the Release backup is a stable fixture — and it is stable *because* 144 never lives long enough to rewrite `Preferences`.
+- **Confirmed — a deliberate quit, not a fault.** No `.ips`, no signal handler, no `atexit`, `runningboardd` `proc_exit` → `_exit`-class termination. Timeline (22:55:34): `.083` profile init inside `CefInitialize`; `.261` `CEF initialized.`; `.349` last Ghostties line; `.390` blockfile warning; `.702` helpers report "parent died". Death is asynchronous, on the UI thread our pump drives, after `initializeIfNeeded` returned and before `CEFBrowserView.mm:499`.
+- **Killed — `exit_type: Crashed`.** CEF's `chrome_runtime.patch` wraps `browser_creator_->Start(...)` in `#if !BUILDFLAG(ENABLE_CEF)`: session restore, crashed bubble and `StartupBrowserCreator` never run. `ExitTypeService` only reads/writes the pref. The on-disk value is the last successful flush, not the last run. `exited_cleanly = true` is noise: metrics recording is off under CEF.
+- **Inferred — mechanism (moderate on class, low on frame).** 150-era data makes a 144 startup task take and release a `KeepAlive` (web-app/extension reconciliation are the candidates) while zero `Browser` objects exist. CEF's Chrome bootstrap also removes `AppController` (the Mac keep-alive) and skips the startup browser, so the 1→0 edge reaches `BrowserProcessImpl::Unpin` → main-loop quit → shutdown → `_exit`. Experiment E1 pins the frame; the fix does not depend on it.
+- **Why #159 could never catch it:** the sentinel is written after `initializeIfNeeded` succeeds; the process is dead before line 499.
+
+## 2. Experiments (cheapest first; each against a fresh `cp -Rp` of the backup)
+
+Oracle per run: own PID alive at T+20s = SURVIVED; `ghostties-cef-internal.log` "parent died" + PID gone = DIED. Two runs per arm.
+
+- **E0 baseline** — untouched copy → must DIE 2/2, else stop (fixture decayed; re-derive before anything else).
+- **E1 mechanism** — launch the lab copy under `lldb` with `b _exit`, `b exit`, `b abort`, `b kill`; on stop, `bt 60`, `thread list`, `image list` → the frame that quits. Exit status vs signal also settles "was it SIGKILL". Free, decisive.
+- **E2 kill-check** — `profile.exit_type` → `"Normal"` only → still DIES (expected; if it survives, section 1 is wrong and E1's frame says why).
+- **E3 version flip** — `extensions.last_chrome_version` → `"144.0.7559.258"` only → SURVIVES = version string itself gates the path; DIES = other 150-era data does.
+- **E4 Preferences swap** — replace `Default/Preferences` with one from a fresh-144 run → SURVIVES = poison is in Preferences; DIES = elsewhere.
+- **E5 halving** — only if E4 dies: remove `Default/` vs everything-but-`Default/`, then halve inside the survivor. ≤6 arms.
+- **E6 switches** — only if E1 names a feature: `--disable-features=<it>` via `OnBeforeCommandLineProcessing`. Not a fix, a confirmation.
+- **E7 cefclient** — only if E1 is unreadable: build `vendor/cef/tests/cefclient` (needs `brew install cmake`, free) with `--cache-path=<copy>`; DIES = pure Chromium+data, SURVIVES = needs our no-browser window.
+
+## 3. Fix (one decision)
+
+- **Downgrade guard, before `CefInitialize`.** Own a stamp `<appsupport>/cef-profile-chromium-version` written after the first `OnAfterCreated`. On init: stamp major (fallback: `Default/Preferences` `extensions.last_chrome_version`) > `CHROME_VERSION_MAJOR` → move `CEF/` to `CEF-downgraded-<ts>/`, start fresh, `os_log` one `[CEFBridge]` line. Cookies-only data; no prompt.
+- **Re-anchor the sentinel** to bracket `CefInitialize`: write before it, clear on `OnAfterCreated` and in the 3s creation watchdog (process alive = not this crash). Keeps recovery for unknown poisons. Keep `resetProfileDirectoryPreservingDataError` and the recovery view, but make it render (the four constraint conflicts named in `BACKLOG.md`).
+- **Why not the alternatives.** Rewriting prefs pre-init treats one key while 150 wrote ~30 files. Command-line switches disable a Chromium feature we don't own and break on the next roll. Removing the sentinel discards the only net for poisons we haven't seen. Rolling CEF forward to 150 masks the class and reopens #60.
+
+## 4. Observability (Phase 1, ships in Release, env-gated)
+
+- `[CEFDiag]` probes: `#if DEBUG` → `getenv("GHOSTTIES_CEF_DIAG")`, `os_log` with `%{public}`. `atexit`/signal handlers stay Debug-only.
+- Add `[CEFBridge]` `os_log` at: pre-`CefInitialize`, post-return, every 250ms for 3s after (pump alive-ticks), guard decision, sentinel write/clear.
+- `GHOSTTIES_CEF_APP_SUPPORT_DIR` overrides `_appSupportBundleDirectory` (profile + sentinel + stamp move together); resolved path logged.
+- `GHOSTTIES_CEF_LOG_VERBOSE=1` → `LOGSEVERITY_VERBOSE` + `--vmodule=browser_shutdown=2,keep_alive_registry=2,browser_process_impl=2`.
+- `GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER=1` in `WorkspaceViewContainer.swift`: drop the `#if DEBUG`, keep the env gate. This is how a Release-signed build opens the browser with zero GUI driving.
+- Read back: `/usr/bin/log show --predicate 'eventMessage CONTAINS "[CEF"' --info --debug --start <t>`.
+
+## 5. Phases (T2 Sonnet implements, T1 Opus reviews each; overnight, unattended)
+
+**Constraints for every phase.** Never `killall ghostty`/`ghostties` — SIGTERM only the PID this run launched. Never synthetic input or AX driving; `screencapture` only. Never modify `.../ghostties/CEF-backup-2026-09-01` or `.../ghostties/CEF`; experiments run on copies under the scratchpad via `GHOSTTIES_CEF_APP_SUPPORT_DIR`. Public repo: never commit profile contents or logs with URLs/cookies. Commits and pushes to `origin` only; never `upstream`; no `gh release`, no prod. `pgrep`/`ps` cannot see Ghostties — use `osascript -e 'tell application "System Events" to get unix id of every process whose bundle identifier is "com.seansmithdesign.ghostties"'`. Build `Release` with `ARCHS=arm64`, never `ReleaseLocal`; re-sign the COPY: `codesign --force --sign - --entitlements macos/GhosttyReleaseLocal.entitlements <copy.app>` (lab copy adds `com.apple.security.get-task-allow` from a scratch entitlements file so lldb can attach). Verify every binary: `strings <app>/Contents/MacOS/ghostty | grep -c CefInitialize` ≠ 0. `xcodebuild` to a log file, `set -o pipefail`, assert exit 0. Before the first launch: assert no real Ghostties running (osascript above), `df -g /` ≥ 15, back up all non-`CEF*` files in the app-support dir; restore them after the last run if changed.
+
+**P0 — Preconditions (15 min).** Outcome: stable fixture proven. Touch nothing. Accept: launchd/RunningBoard exit record for pid 69891 captured (exit code vs signal, `/usr/bin/log show`); E0 DIED 2/2 on the *unfixed* `main` lab build. Stop: E0 survives → stop, report.
+
+**P1 — Observability + lab controls.** Files: `CEFBridge.mm`, `CEFBridge.h`, `CEFBrowserView.mm`, `WorkspaceViewContainer.swift`, `scripts/debug/cef-repro.sh` (accept Release copies; drop the `.dev` bundle-id refusal behind a flag). Off-limits: everything else. Accept: lab copy launched against an empty override dir logs pre/post-init lines and alive-ticks (`log show`); `Local State` appears under the override path (mtime); `strings` count ≠ 0. Stop: no `[CEF` lines in Release → fix gating before proceeding.
+
+**P2 — Experiments.** No source changes. Accept: one Markdown table in the PR body, arm × result × artefact (backtrace file path, log excerpt, exit code). E1 backtrace saved to scratchpad with paths/URLs scrubbed. Stop: E1 shows a signal from outside the process → section 1 is wrong; write findings, skip to P4 with observability only.
+
+**P3 — Fix.** Files: `CEFBridge.mm/.h`, `CEFBrowserView.mm`, `BrowserFailureStateView.swift`, `CEFBrowserSentinelTests.swift` (+ a version-compare test that names the production symbol and fails when the comparison is inverted). Off-limits: `download-cef.sh`, `vendor/`, entitlements, pbxproj. Accept: fresh backup copy + fixed lab build → SURVIVED 3/3 (`OnAfterCreated` logged, PID alive at T+20s), `CEF-downgraded-*` sibling exists, stamp file reads `144`; second launch on the same dir → no move, SURVIVED; `xcodebuild test` run unfiltered, totals reported via `xcresulttool`. Stop: any DIED → back to E1 with the fixed build; do not tune blind.
+
+**P4 — Ship.** Branch `fix/cef-downgrade-guard`, PR against `main` on `SeanSmithWorks/ghostties` with the E-table and P3 evidence; no screenshots of browser content. Build a second Release copy signed with the plain `GhosttyReleaseLocal.entitlements` at `/Applications/Ghostties-fix.app` (no override env → Sean's real profile). Screenshot the running window via `screencapture -l <CGWindowID>` to `docs/plans/evidence/` — if composer C needs a keystroke to appear, do not press it; leave Sean the recipe ("⌘N in Ghostties-fix.app"). Delete lab copies and worktrees; update `BACKLOG.md`. Accept: PR URL, `/Applications/Ghostties-fix.app` `strings` count ≠ 0, `git checkout main` clean.
+
+## 6. What would make this wrong
+
+- **It's the crash streak / safe-mode state, not the 150 data.** Separator: fresh-144 profile with only the backup's `Local State` dropped in → DIES = streak; SURVIVES = data.
+- **It's our zero-browser window, and any startup keep-alive edge would kill us regardless of version.** Separator: E7 — cefclient (browser created at `OnContextInitialized`) on the same copy SURVIVES while the app DIES.
+
+**Decision for Sean (recommended answer):** on downgrade, reset silently with one inline notice line (yes) vs. offer a button (no — the button is a second failure surface, see BACKLOG's invisible fallback).
+
+Demoted: Chromium source citations and the raw log excerpts live in the memory memos linked from `MEMORY.md § Browser / CEF`.


### PR DESCRIPTION
Records the result of actually testing #159 against the profile it was meant to fix.

## The crash reproduced

Clicking the globe in a release-bundle-ID build carrying the full #159 stack:

```
22:55:34.261  [CEFBridge] CEF initialized.
22:55:34.349  last log line
22:55:36      process gone — no .ips, no signal
```

**The merged fix does not fix the crash.**

## The reframe

`recordBrowserOpenAttempt` runs at `CEFBrowserView.mm:499`, *before* `CreateBrowser` at `:521`. After the crash, **no `browser-open-attempt` file exists on disk**. So death happens during or just after `CefInitialize`, not at `CreateBrowser`.

Two consequences:
1. The recovery UI can never arm — its trigger is a sentinel that is never written.
2. The Dev-profile bisection ("dies ~460ms after `CreateBrowser`") describes a different failure point than the Release profile does. The sentinel is anchored to the wrong call.

## Also logged

- **`ReleaseLocal` can never produce a working browser** — its `HEADER_SEARCH_PATHS` omits `vendor/cef`, which Debug and Release both carry. CEF availability is a compile-time `__has_include`, so the browser compiles out to a no-op stub: 0 CEF symbols vs 4 in Release, while the 288M framework still ships in the bundle.
- **The failure-state view renders invisibly** — four AppKit `Unable to simultaneously satisfy constraints` conflicts name `BrowserFailureStateView`; nothing appeared on screen.
- **`[CEFDiag]` probes are `#if DEBUG`-gated**, so a release-ID build is diagnostically blind.

Docs-only; no visual surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbcswCsPgiB9LFYZYBvJCu