### PR TITLE
fix(session): drop back to a shell instead of closing when an agent exits

### DIFF
--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -235,13 +235,18 @@ final class SessionCoordinator: ObservableObject {
             return result
         }()
 
-        // For agent templates, write a wrapper script that prints a banner
-        // then exec's into the real command. Direct `&&` chaining breaks because
-        // Ghostty wraps the command with `exec -l`, which replaces the process
-        // before the second command runs.
+        // Every resolved command (agent or otherwise) is written to a wrapper
+        // script, not `exec`'d directly. Direct `&&` chaining breaks because
+        // Ghostty wraps a bare command with `exec -l`, which replaces the
+        // process before a second command could run — the script is what
+        // lets a banner print first. Unlike the original version of this
+        // script, the resolved command itself is run in the foreground and
+        // is NOT the final `exec`'d process: when the agent exits, the
+        // script keeps going and `exec`s a fresh login shell, so the
+        // terminal surface survives and drops back to a normal interactive
+        // prompt instead of closing ("Process exited. Press any key...").
         let finalCommand: String? = {
             guard let cmd = resolvedCommand else { return nil }
-            guard let banner = template.launchBanner else { return cmd }
 
             let scriptDir = Self.launcherScriptDir
             let fm = FileManager.default
@@ -251,15 +256,12 @@ final class SessionCoordinator: ObservableObject {
                 ])
             }
             let scriptPath = (scriptDir as NSString).appendingPathComponent("\(session.id.uuidString).sh")
-            // Spawn banner: first output line confirms task context before Claude starts.
-            // Uses env vars set in config.environmentVariables so they're already in scope.
-            let spawnBannerEcho = #"echo "task: $GHOSTTIES_TASK_ID · file: $GHOSTTIES_TASK_FILE · cwd: $(pwd)""#
-            let script = "#!/bin/zsh -l\n. ~/.zshrc 2>/dev/null\n\(banner)\n\(spawnBannerEcho)\nexec \(cmd)\n"
+            let script = Self.launcherScript(command: cmd, banner: template.launchBanner)
             if (try? script.write(toFile: scriptPath, atomically: true, encoding: .utf8)) != nil {
                 try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: scriptPath)
                 return scriptPath
             }
-            return cmd // fallback: skip banner
+            return cmd // fallback: script write failed — Ghostty execs cmd directly (dies on exit)
         }()
 
         var config = Ghostty.SurfaceConfiguration()
@@ -1008,10 +1010,29 @@ final class SessionCoordinator: ObservableObject {
     }
 
     /// Delete a single session's launcher script at teardown. A no-op if the
-    /// session never got one (e.g. templates without a `launchBanner`).
+    /// session never got one (e.g. plain shell templates with no `command`,
+    /// which never go through the launcher-script path at all).
     nonisolated static func removeLauncherScript(for sessionId: UUID) {
         let path = (launcherScriptDir as NSString).appendingPathComponent("\(sessionId.uuidString).sh")
         try? FileManager.default.removeItem(atPath: path)
+    }
+
+    /// Builds the wrapper script content for a spawned agent session: prints
+    /// the banner (if any), runs `command` in the foreground, then `exec`s a
+    /// fresh login shell. The resolved command is deliberately NOT the
+    /// script's final `exec`'d process — when it exits, the script keeps
+    /// running and drops into a normal interactive prompt, so the terminal
+    /// surface survives the agent exiting instead of closing with it.
+    nonisolated static func launcherScript(command: String, banner: String?) -> String {
+        let bannerLines: String = {
+            guard let banner else { return "" }
+            // Spawn banner: first output line confirms task context before
+            // the agent starts. Uses env vars set in
+            // config.environmentVariables so they're already in scope.
+            let spawnBannerEcho = #"echo "task: $GHOSTTIES_TASK_ID · file: $GHOSTTIES_TASK_FILE · cwd: $(pwd)""#
+            return "\(banner)\n\(spawnBannerEcho)\n"
+        }()
+        return "#!/bin/zsh -l\n. ~/.zshrc 2>/dev/null\n\(bannerLines)\(command)\nexec /bin/zsh -l\n"
     }
 
     /// Assemble the environment for a spawned session: the template's own

--- a/macos/Tests/Ghostties/SessionCoordinatorLauncherScriptTests.swift
+++ b/macos/Tests/Ghostties/SessionCoordinatorLauncherScriptTests.swift
@@ -1,0 +1,78 @@
+// IDE-ONLY: not currently exercised in CI macos job (build-only).
+// Run via Xcode Cmd+U or xcodebuild test locally.
+import XCTest
+import GhosttiesCore
+@testable import Ghostty
+
+/// Guards the `fix/composer-return-to-shell` fix: a spawned session's
+/// resolved command must never be the wrapper script's final `exec`'d
+/// process. Before this fix, `SessionCoordinator.createSession` wrote
+/// `exec \(cmd)` as the script's last line, which replaced the script's
+/// process image with the agent — when the agent exited, nothing was left
+/// running, so Ghostty printed "Process exited. Press any key to close the
+/// terminal." instead of dropping back to a shell.
+final class SessionCoordinatorLauncherScriptTests: XCTestCase {
+
+    // MARK: - The fix: command is not the final process
+
+    func testCommandIsNotExecdAsFinalProcess() {
+        let script = SessionCoordinator.launcherScript(command: "/usr/local/bin/claude", banner: nil)
+
+        XCTAssertFalse(
+            script.contains("exec /usr/local/bin/claude"),
+            "the resolved command must run in the foreground, not be exec'd — exec'ing it replaces the " +
+            "process image and kills the terminal surface the instant the agent exits"
+        )
+    }
+
+    func testScriptExecsAFreshLoginShellAsItsFinalLine() {
+        let script = SessionCoordinator.launcherScript(command: "/usr/local/bin/claude", banner: nil)
+        let lines = script.split(separator: "\n", omittingEmptySubsequences: false)
+
+        XCTAssertEqual(
+            lines.last(where: { !$0.isEmpty }),
+            "exec /bin/zsh -l",
+            "the script's final process must be an interactive login shell, so exiting the agent " +
+            "lands the user on a normal prompt instead of closing the terminal"
+        )
+    }
+
+    func testCommandRunsBeforeTheFinalShellExec() {
+        let script = SessionCoordinator.launcherScript(command: "/usr/local/bin/claude", banner: nil)
+
+        guard let cmdRange = script.range(of: "/usr/local/bin/claude"),
+              let execRange = script.range(of: "exec /bin/zsh -l") else {
+            return XCTFail("expected both the command and the trailing shell exec to be present")
+        }
+        XCTAssertTrue(cmdRange.upperBound <= execRange.lowerBound, "command must run before the final shell exec")
+    }
+
+    // MARK: - Consistency: banner and no-banner paths both survive agent exit
+
+    func testNoBannerPathStillExecsAFreshShellAfterCommand() {
+        // Guards the second death path called out in the brief: when
+        // `template.launchBanner` is nil, the pre-fix code returned the bare
+        // command with no wrapper script at all, so Ghostty's own
+        // `exec -l <cmd>` wrapping killed the terminal on agent exit too.
+        // The fix routes both paths through the same wrapper script.
+        let script = SessionCoordinator.launcherScript(command: "/usr/local/bin/claude", banner: nil)
+
+        XCTAssertFalse(script.contains("exec /usr/local/bin/claude"))
+        XCTAssertTrue(script.hasSuffix("exec /bin/zsh -l\n"))
+    }
+
+    func testBannerPathAlsoExecsAFreshShellAfterCommand() {
+        let script = SessionCoordinator.launcherScript(command: "/usr/local/bin/claude", banner: "echo hi")
+
+        XCTAssertFalse(script.contains("exec /usr/local/bin/claude"))
+        XCTAssertTrue(script.hasSuffix("exec /bin/zsh -l\n"))
+        XCTAssertTrue(script.contains("echo hi"), "banner text must still be printed before the command runs")
+    }
+
+    // MARK: - Shell setup preserved
+
+    func testScriptStillSourcesZshrcForPathAndAliases() {
+        let script = SessionCoordinator.launcherScript(command: "/usr/local/bin/claude", banner: nil)
+        XCTAssertTrue(script.contains(". ~/.zshrc 2>/dev/null"))
+    }
+}


### PR DESCRIPTION
## What changes for the user
When an agent (Claude Code, etc.) exits inside a composer-launched session, the terminal now drops back to a normal interactive shell prompt instead of showing "Process exited. Press any key to close the terminal." Closing that terminal now works exactly like closing any other shell session.

## Root cause
`SessionCoordinator.createSession` built a per-session wrapper script whose last line was `exec \(cmd)` — this replaced the wrapper's process image with the agent, so when the agent exited nothing remained and Ghostty tore down the surface. A second, unbannered path (`template.launchBanner == nil`) skipped the wrapper script entirely and let Ghostty's own `exec -l <cmd>` do the same thing.

## The fix
Both paths now go through one wrapper script (`SessionCoordinator.launcherScript(command:banner:)`, extracted for testability) that runs the resolved command in the foreground, then `exec`s a fresh `/bin/zsh -l` afterward. The command is never the script's final `exec`'d process anymore, so the terminal's process survives the agent exiting.

Quoted commit history checked before making this change, per the brief:
- `dffde628d` (2026-03-24) introduced the wrapper script to solve `&&`-chaining being broken by Ghostty's `exec -l` wrapping — still applies, unchanged by this fix (the script is still what lets a banner print before the command runs).
- `e8dbf6ed7` (2026-04-27) restored `exec` specifically because without it, "zsh stayed alive and sessions remained `.running` permanently" — that reasoning was about `SessionStatus` never leaving `.running`, not about the terminal surface. This PR addresses that concern directly (see below) rather than relying on process death to trigger the status transition.

## The status/indicator question (from the brief)
- `SessionStatus.running` today only leaves via `setStatus(_:for:)`, called from `SessionCoordinator.swift:890`/`907` (`handleSurfaceClose`, driven by the surface closing) and `:663`/`:677` (`closeSession`). After this fix, that transition still fires correctly whenever the user actually closes the terminal (Cmd+W, `exit`, etc.) — it just no longer fires the instant the *agent* exits, since the shell it drops into keeps the surface alive.
- Verified this does **not** produce a stuck "running" lie in the sidebar: `indicatorState(for:)` (`SessionCoordinator.swift:1395`) already falls back to `.idle` for a silent agent-kind session with no positive "needs attention" signal (`SessionCoordinatorIndicatorStateTests.testAgentSessionSilentNotAtPromptNoPromptTitleIsIdle`, already shipped, unrelated to this PR). A session whose shell survives past agent exit reads as an idle terminal — the same indicator a brand-new idle shell session gets — not as a live "running" agent.
- Both indicator caches stay consistent because I didn't touch `setStatus(_:for:)`: it already writes `WorkspaceStore.shared`'s `globalStatuses`/`globalIndicatorStates` (what every view reads) and the coordinator's own `statuses`/`cachedIndicatorStates` (the 1Hz tick's change-comparator) together, per its existing doc comment.

## Tests
Added `macos/Tests/Ghostties/SessionCoordinatorLauncherScriptTests.swift`, covering `SessionCoordinator.launcherScript(command:banner:)` directly (a production symbol, not a re-declared literal):
- the resolved command is never `exec`'d as the final process
- the script's final line is `exec /bin/zsh -l`
- the command runs before that trailing exec
- both the banner and no-banner paths produce the same trailing-shell shape

## What I could not verify locally
This worktree is missing `GhosttyKit.xcframework`, `zig-out/`, and `vendor/cef` (all gitignored, not fetchable here), so `xcodebuild test` cannot run. I did not run the test suite and am not claiming a green run — the tests above are new, reference the real `SessionCoordinator.launcherScript` symbol, and were reasoned through by hand against the old vs. new script output, but not executed. Please run `xcodebuild test -project macos/Ghostties.xcodeproj -scheme Ghostties -destination 'platform=macOS,arch=arm64' ONLY_ACTIVE_ARCH=YES ARCHS=arm64 -only-testing:GhosttyTests/SessionCoordinatorLauncherScriptTests` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKoaP2pNaV1LHdbR94WEqZ