### PR TITLE
test(ui): visual-pass capture rig + CI visual-pass experiment

### DIFF
--- a/.github/workflows/test-ghostties.yml
+++ b/.github/workflows/test-ghostties.yml
@@ -182,6 +182,7 @@ jobs:
             -derivedDataPath build \
             -only-testing:GhosttyUITests/VisualPassUITests \
             ONLY_ACTIVE_ARCH=YES \
+            TEST_RUNNER_GHOSTTIES_UI_CAPTURE=1 \
             ARCHS=arm64 \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/test-ghostties.yml
+++ b/.github/workflows/test-ghostties.yml
@@ -173,6 +173,8 @@ jobs:
         working-directory: macos
         continue-on-error: true
         timeout-minutes: 15
+        env:
+          TEST_RUNNER_GHOSTTIES_UI_CAPTURE: "1"
         run: |
           set -o pipefail
           xcodebuild test-without-building \
@@ -182,7 +184,6 @@ jobs:
             -derivedDataPath build \
             -only-testing:GhosttyUITests/VisualPassUITests \
             ONLY_ACTIVE_ARCH=YES \
-            TEST_RUNNER_GHOSTTIES_UI_CAPTURE=1 \
             ARCHS=arm64 \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/test-ghostties.yml
+++ b/.github/workflows/test-ghostties.yml
@@ -25,7 +25,12 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      visual_pass:
+        description: "Run the VisualPassUITests capture experiment on the runner"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -163,13 +168,15 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       # Experiment: does GhosttyUITests/VisualPassUITests launch on a
-      # headless GitHub runner? The comment above documents that the
-      # XCTest host reliably hangs ~6 min on this runner class when
-      # launching Ghostties Dev.app; this may hang the same way. The step
-      # is continue-on-error and time-boxed so a hang never reddens the
-      # compile gate above — the answer comes from this step's own log and
-      # the uploaded artifact, not from job status.
+      # headless GitHub runner? Run 34016193346 (2026-09-06) showed the
+      # runner launches the app host, but the XCTest accessibility
+      # connection never establishes ("has not loaded accessibility" after
+      # a 60s wait per test), which burns the full 15-minute step timeout.
+      # Gated behind workflow_dispatch with visual_pass=true so pushes
+      # stop paying for it. Next experiment: ad-hoc signing
+      # (CODE_SIGN_IDENTITY=-) instead of CODE_SIGNING_ALLOWED=NO.
       - name: Visual pass (experiment)
+        if: github.event_name == 'workflow_dispatch' && inputs.visual_pass == true
         working-directory: macos
         continue-on-error: true
         timeout-minutes: 15
@@ -189,7 +196,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Collect visual-pass captures
-        if: always()
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.visual_pass == true
         run: |
           mkdir -p "$GITHUB_WORKSPACE/visual-pass-captures"
           if [ -d "$TMPDIR/ghostties-visual-pass" ]; then
@@ -199,7 +206,7 @@ jobs:
           fi
 
       - name: Upload visual-pass captures
-        if: always()
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.visual_pass == true
         uses: actions/upload-artifact@v4
         with:
           name: visual-pass-captures

--- a/.github/workflows/test-ghostties.yml
+++ b/.github/workflows/test-ghostties.yml
@@ -156,7 +156,50 @@ jobs:
             -scheme Ghostties \
             -configuration Debug \
             -destination 'platform=macOS' \
+            -derivedDataPath build \
             ONLY_ACTIVE_ARCH=YES \
             ARCHS=arm64 \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO
+
+      # Experiment: does GhosttyUITests/VisualPassUITests launch on a
+      # headless GitHub runner? The comment above documents that the
+      # XCTest host reliably hangs ~6 min on this runner class when
+      # launching Ghostties Dev.app; this may hang the same way. The step
+      # is continue-on-error and time-boxed so a hang never reddens the
+      # compile gate above — the answer comes from this step's own log and
+      # the uploaded artifact, not from job status.
+      - name: Visual pass (experiment)
+        working-directory: macos
+        continue-on-error: true
+        timeout-minutes: 15
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building \
+            -scheme Ghostties \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -derivedDataPath build \
+            -only-testing:GhosttyUITests/VisualPassUITests \
+            ONLY_ACTIVE_ARCH=YES \
+            ARCHS=arm64 \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Collect visual-pass captures
+        if: always()
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/visual-pass-captures"
+          if [ -d "$TMPDIR/ghostties-visual-pass" ]; then
+            cp -R "$TMPDIR/ghostties-visual-pass/." "$GITHUB_WORKSPACE/visual-pass-captures/"
+          else
+            echo "no captures at $TMPDIR/ghostties-visual-pass"
+          fi
+
+      - name: Upload visual-pass captures
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-pass-captures
+          path: visual-pass-captures
+          if-no-files-found: warn

--- a/macos/Ghostties.xcodeproj/project.pbxproj
+++ b/macos/Ghostties.xcodeproj/project.pbxproj
@@ -931,7 +931,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TEST_TARGET_NAME = Ghostty;
+				TEST_TARGET_NAME = Ghostties;
 			};
 			name = Debug;
 		};
@@ -954,7 +954,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TEST_TARGET_NAME = Ghostty;
+				TEST_TARGET_NAME = Ghostties;
 			};
 			name = Release;
 		};
@@ -977,7 +977,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TEST_TARGET_NAME = Ghostty;
+				TEST_TARGET_NAME = Ghostties;
 			};
 			name = ReleaseLocal;
 		};

--- a/macos/GhosttyUITests/MarketingCaptureUITests.swift
+++ b/macos/GhosttyUITests/MarketingCaptureUITests.swift
@@ -1,0 +1,124 @@
+import XCTest
+
+/// Produces the four 2x window PNGs the ghostties.org app section ships:
+/// Sessions tab (light/dark) and Projects tab (light/dark). Driven by
+/// `scripts/capture-marketing.sh` — see that script for the build +
+/// convert-to-WebP pipeline this test's output feeds into.
+///
+/// Deliberately NOT gated behind the `IDE_DISABLED_OS_ACTIVITY_DT_MODE`
+/// guard other UI tests in this file use — same reasoning as
+/// `MarketingCaptureSpikeUITests`: this must run from a plain `xcodebuild
+/// test` CLI invocation, which is exactly how the capture script drives it.
+///
+/// Every launch sets `GHOSTTIES_CAPTURE_FIXTURE=1` in the launch
+/// environment (see `CaptureFixture`), so the captured window shows an
+/// invented project/session cast and a canned terminal transcript — never
+/// Sean's real workspace. See `BACKLOG.md` @ 2026-08-21 for why this
+/// replaced the HTML replica.
+final class MarketingCaptureUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCaptureSessionsLight() throws {
+        try capture(tab: "sessions", appearance: .light, name: "sessions-light")
+    }
+
+    func testCaptureSessionsDark() throws {
+        try capture(tab: "sessions", appearance: .dark, name: "sessions-dark")
+    }
+
+    func testCaptureProjectsLight() throws {
+        try capture(tab: "projects", appearance: .light, name: "projects-light")
+    }
+
+    func testCaptureProjectsDark() throws {
+        try capture(tab: "projects", appearance: .dark, name: "projects-dark")
+    }
+
+    private func capture(tab: String, appearance: XCUIDevice.Appearance, name: String) throws {
+        // Sandboxed runner — write inside its own temp container, print the
+        // resolved path so `capture-marketing.sh` can copy it out.
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghostties-marketing-capture", isDirectory: true)
+        try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+
+        let app = XCUIApplication()
+        // Only drive our own freshly-launched instance — never attach to an
+        // already-running Ghostty/Ghostties process.
+        //
+        // `GHOSTTIES_CAPTURE_FIXTURE` is passed as an environment variable,
+        // not a `-key value` launch argument: Ghostty's own core CLI parser
+        // scans argv for config directives and pops a user-facing
+        // "Configuration Errors" dialog on any token it doesn't recognize —
+        // verified by hand against `-GhosttiesCaptureFixture 1` (6 errors,
+        // one per unrecognized argv token). See `CaptureFixture.isActive`.
+        app.launchArguments.append(contentsOf: ["-ApplePersistenceIgnoreState", "YES"])
+        app.launchEnvironment["GHOSTTIES_CAPTURE_FIXTURE"] = "1"
+        app.launch()
+
+        XCTAssertTrue(
+            app.windows.firstMatch.waitForExistence(timeout: 10),
+            "Main window should exist after launch"
+        )
+        Thread.sleep(forTimeInterval: 1.5)
+
+        // Set appearance after launch, not before — `XCUIDevice.shared.appearance`
+        // drives a real system-wide dark/light switch, and setting it before
+        // `app.launch()` was observed to make accessibility loading far less
+        // reliable during manual verification of this test.
+        XCUIDevice.shared.appearance = appearance
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Switch sidebar tab via the real keyboard shortcuts
+        // (Cmd+Shift+1 = Projects, Cmd+Shift+2 = Sessions — see
+        // `AppDelegate`'s "Sidebar View" submenu) rather than a launch
+        // argument, for the same argv reason as above.
+        if tab == "projects" {
+            app.typeKey("1", modifierFlags: [.command, .shift])
+        } else {
+            app.typeKey("2", modifierFlags: [.command, .shift])
+        }
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Projects tab: the fixture's `switchboard` project starts collapsed
+        // (matches real launch behavior — nothing auto-expands), so expand it
+        // first to reveal its session rows.
+        if tab == "projects" {
+            let projectRow = app.staticTexts["switchboard"].firstMatch
+            if projectRow.waitForExistence(timeout: 5) {
+                projectRow.click()
+                Thread.sleep(forTimeInterval: 0.4)
+            }
+        }
+
+        // Spawn a live session so the terminal pane shows the canned
+        // transcript instead of an empty state — right-click the fixture's
+        // "processing" session and choose Relaunch, the same path a real
+        // user takes to resume a session that shows as exited after
+        // restart (persisted sessions never carry a live runtime across
+        // launches — see `AgentSession`'s doc comment).
+        let sessionRow = app.staticTexts["Claude Code 4"].firstMatch
+        if sessionRow.waitForExistence(timeout: 5) {
+            sessionRow.rightClick()
+            let relaunch = app.menuItems["Relaunch"].firstMatch
+            if relaunch.waitForExistence(timeout: 2) {
+                relaunch.click()
+            } else {
+                app.typeKey(.escape, modifierFlags: [])
+            }
+        }
+        // Let the transcript script render and the terminal settle.
+        Thread.sleep(forTimeInterval: 2.0)
+
+        let window = app.windows.firstMatch
+        let windowShot = window.screenshot()
+        let outputPath = outputDir.appendingPathComponent("\(name).png")
+        try windowShot.pngRepresentation.write(to: outputPath)
+        print("CAPTURE_OUTPUT: \(outputPath.path)")
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputPath.path))
+
+        app.terminate()
+    }
+}

--- a/macos/GhosttyUITests/MarketingCaptureUITests.swift
+++ b/macos/GhosttyUITests/MarketingCaptureUITests.swift
@@ -5,10 +5,11 @@ import XCTest
 /// `scripts/capture-marketing.sh` — see that script for the build +
 /// convert-to-WebP pipeline this test's output feeds into.
 ///
-/// Deliberately NOT gated behind the `IDE_DISABLED_OS_ACTIVITY_DT_MODE`
-/// guard other UI tests in this file use — same reasoning as
-/// `MarketingCaptureSpikeUITests`: this must run from a plain `xcodebuild
-/// test` CLI invocation, which is exactly how the capture script drives it.
+/// Skipped unless `GHOSTTIES_UI_CAPTURE=1` reaches the test runner — an
+/// unfiltered `xcodebuild test` must never launch the app. From the CLI pass
+/// `TEST_RUNNER_GHOSTTIES_UI_CAPTURE=1` to `xcodebuild` (the `TEST_RUNNER_`
+/// prefix is how xcodebuild forwards env to the runner), combined with
+/// `-only-testing:GhosttyUITests/MarketingCaptureUITests`.
 ///
 /// Every launch sets `GHOSTTIES_CAPTURE_FIXTURE=1` in the launch
 /// environment (see `CaptureFixture`), so the captured window shows an
@@ -16,6 +17,14 @@ import XCTest
 /// Sean's real workspace. See `BACKLOG.md` @ 2026-08-21 for why this
 /// replaced the HTML replica.
 final class MarketingCaptureUITests: XCTestCase {
+    override class var defaultTestSuite: XCTestSuite {
+        if ProcessInfo.processInfo.environment["GHOSTTIES_UI_CAPTURE"] == "1" {
+            return XCTestSuite(forTestCaseClass: Self.self)
+        } else {
+            return XCTestSuite(name: "Skipping \(className()) (set GHOSTTIES_UI_CAPTURE=1 to run)")
+        }
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = false
     }

--- a/macos/GhosttyUITests/VisualPassUITests.swift
+++ b/macos/GhosttyUITests/VisualPassUITests.swift
@@ -40,7 +40,16 @@ final class VisualPassUITests: XCTestCase {
         extraEnvironment: [String: String] = [:]
     ) throws -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments.append(contentsOf: ["-ApplePersistenceIgnoreState", "YES"])
+        // `-ghostties.hasSeenOnboarding YES` — the standard NSUserDefaults CLI
+        // override (same pattern `TaskSidebarSmokeUITests` uses for
+        // `-ghostties.sidebarViewMode`). Without it, a Dev-domain profile
+        // with no prior manual launch shows `OnboardingSheet` as a modal
+        // sheet over the whole window, hiding the fixture content the
+        // assertion below checks for.
+        app.launchArguments.append(contentsOf: [
+            "-ApplePersistenceIgnoreState", "YES",
+            "-ghostties.hasSeenOnboarding", "YES",
+        ])
         app.launchEnvironment["GHOSTTIES_CAPTURE_FIXTURE"] = "1"
         for (key, value) in extraEnvironment {
             app.launchEnvironment[key] = value
@@ -53,9 +62,20 @@ final class VisualPassUITests: XCTestCase {
         )
         Thread.sleep(forTimeInterval: 1.0)
 
-        let hasFixtureMarker = app.staticTexts["switchboard"].firstMatch.waitForExistence(timeout: 5)
+        // The sidebar's Projects/Sessions tab selection is a real, persisted
+        // preference (not stubbed by `CaptureFixture`), so a launch can land
+        // on either tab depending on this Dev profile's prior state. On the
+        // Sessions tab, "switchboard" is only ever a substring inside a
+        // compound row label ("Claude Code 4, in switchboard, ..."), never
+        // its own `StaticText` — so the fixture assertion below can only find
+        // it reliably on the Projects tab. Force Projects (⌘⇧1) before
+        // asserting; individual tests switch tabs again afterward as needed.
+        app.typeKey("1", modifierFlags: [.command, .shift])
+        Thread.sleep(forTimeInterval: 0.5)
+
+        let hasFixtureMarker = element(labelContains: "switchboard", in: app).waitForExistence(timeout: 5)
         let leakedRealNames = ["ghostties", "brukas", "Career-ops", "seansmithdesign"].contains {
-            app.staticTexts[$0].firstMatch.exists
+            element(labelContains: $0, in: app).exists
         }
 
         guard hasFixtureMarker, !leakedRealNames else {
@@ -80,6 +100,19 @@ final class VisualPassUITests: XCTestCase {
         print("CAPTURE_UNREACHABLE: \(state) — \(reason)")
     }
 
+    /// Guess, verified against a real run's accessibility dump: sidebar rows
+    /// in this build don't expose plain-text names as standalone
+    /// `StaticText` elements. Project rows are `Button`s labeled
+    /// `"<name> project, collapsed/expanded"`; session rows are non-button
+    /// elements labeled `"<name>, in <project>, last output <age>"`. Every
+    /// query below therefore matches by label substring across ALL element
+    /// kinds rather than by exact `staticTexts[...]` lookup.
+    private func element(labelContains substring: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS[c] %@", substring))
+            .firstMatch
+    }
+
     // MARK: - 1-2. Projects tab
 
     func testProjectsLaunch() throws {
@@ -90,7 +123,7 @@ final class VisualPassUITests: XCTestCase {
 
     func testProjectsExpanded() throws {
         let app = try launchFixtureApp(state: "projects-expanded")
-        let projectRow = app.staticTexts["switchboard"].firstMatch
+        let projectRow = element(labelContains: "switchboard", in: app)
         if projectRow.waitForExistence(timeout: 5) {
             projectRow.click()
             Thread.sleep(forTimeInterval: 0.4)
@@ -104,7 +137,7 @@ final class VisualPassUITests: XCTestCase {
     func testProjectsExpandedAlt() throws {
         let app = try launchFixtureApp(state: "projects-expanded-alt")
         let originalAppearance = XCUIDevice.shared.appearance
-        let projectRow = app.staticTexts["switchboard"].firstMatch
+        let projectRow = element(labelContains: "switchboard", in: app)
         if projectRow.waitForExistence(timeout: 5) {
             projectRow.click()
             Thread.sleep(forTimeInterval: 0.4)
@@ -146,7 +179,7 @@ final class VisualPassUITests: XCTestCase {
         let app = try launchFixtureApp(state: "session-context-menu")
         app.typeKey("2", modifierFlags: [.command, .shift])
         Thread.sleep(forTimeInterval: 0.5)
-        let sessionRow = app.staticTexts["Claude Code 4"].firstMatch
+        let sessionRow = element(labelContains: "Claude Code 4", in: app)
         guard sessionRow.waitForExistence(timeout: 5) else {
             unreachable("session-context-menu", "'Claude Code 4' row not found on Sessions tab")
             app.terminate()
@@ -156,12 +189,15 @@ final class VisualPassUITests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.4)
         // Guess: the context menu surfaces as a standard NSMenu; query the
         // first menu element rather than a specific item, since item titles
-        // aren't documented for this row.
-        let menu = app.menus.firstMatch
-        if menu.waitForExistence(timeout: 2) {
-            try capture(menu, state: "session-context-menu-menu")
+        // aren't documented for this row. `app.menus.firstMatch` alone
+        // matched the menu-bar's own (hidden, zero-frame) Apple menu instead
+        // of the popped-up context menu — filter for a menu with a
+        // non-degenerate frame instead.
+        let visibleMenu = app.menus.allElementsBoundByIndex.first { $0.frame.width > 0 && $0.frame.height > 0 }
+        if let visibleMenu {
+            try capture(visibleMenu, state: "session-context-menu-menu")
         } else {
-            unreachable("session-context-menu-menu", "no menu element found after right-click")
+            unreachable("session-context-menu-menu", "no menu element with a non-empty frame found after right-click")
         }
         try capture(app.windows.firstMatch, state: "session-context-menu")
         app.typeKey(.escape, modifierFlags: [])
@@ -220,9 +256,12 @@ final class VisualPassUITests: XCTestCase {
         app.typeKey("t", modifierFlags: [.command])
         Thread.sleep(forTimeInterval: 0.5)
         // Guess: "New template" is an in-list row (no ellipsis per
-        // SessionComposerPalette.swift), so query it as static text within
-        // the composer's idle list.
-        let newTemplateRow = app.staticTexts["New template"].firstMatch
+        // SessionComposerPalette.swift). Matched by label substring, not
+        // exact `staticTexts[...]`, since sidebar rows in this build turned
+        // out to wrap plain text in compound-labeled container elements
+        // (see `element(labelContains:in:)`'s doc comment) — assume the
+        // composer's rows may do the same.
+        let newTemplateRow = element(labelContains: "New template", in: app)
         guard newTemplateRow.waitForExistence(timeout: 3) else {
             unreachable("new-template", "'New template' row not found in composer idle list")
             app.typeKey(.escape, modifierFlags: [])

--- a/macos/GhosttyUITests/VisualPassUITests.swift
+++ b/macos/GhosttyUITests/VisualPassUITests.swift
@@ -1,0 +1,402 @@
+import XCTest
+
+/// Visual & usage pass — captures the app's main surfaces across 18 states in
+/// fixture mode, for the 2026-09-05 audit. Modeled on `MarketingCaptureUITests`:
+/// same launch environment, same fixture assertion, same sandboxed temp-dir
+/// output with `CAPTURE_OUTPUT: <path>` lines. NOT gated behind
+/// `IDE_DISABLED_OS_ACTIVITY_DT_MODE` — must run from a plain `xcodebuild test`
+/// CLI invocation.
+///
+/// Each test method is independent (fresh launch) and captures exactly one
+/// state. Where a state cannot be reached with element queries, the test
+/// prints `CAPTURE_UNREACHABLE: <state> — <reason>` and passes — an
+/// unreachable state is a finding, not a failure.
+///
+/// The fork's own views declare no accessibility identifiers, so every query
+/// below is by static text or menu title. Places that had to guess are
+/// annotated inline.
+final class VisualPassUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private var outputDir: URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghostties-visual-pass", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - Launch helper
+
+    /// Launches a fresh instance in fixture mode and asserts the fixture
+    /// assertion from the brief: `switchboard` exists, none of the real
+    /// project names do. On failure, terminates the app, deletes any PNG
+    /// already written for `state`, and re-throws so the whole run stops
+    /// (XCTest fails fast via `continueAfterFailure = false`).
+    @discardableResult
+    private func launchFixtureApp(
+        state: String,
+        extraEnvironment: [String: String] = [:]
+    ) throws -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments.append(contentsOf: ["-ApplePersistenceIgnoreState", "YES"])
+        app.launchEnvironment["GHOSTTIES_CAPTURE_FIXTURE"] = "1"
+        for (key, value) in extraEnvironment {
+            app.launchEnvironment[key] = value
+        }
+        app.launch()
+
+        XCTAssertTrue(
+            app.windows.firstMatch.waitForExistence(timeout: 10),
+            "Main window should exist after launch"
+        )
+        Thread.sleep(forTimeInterval: 1.0)
+
+        let hasFixtureMarker = app.staticTexts["switchboard"].firstMatch.waitForExistence(timeout: 5)
+        let leakedRealNames = ["ghostties", "brukas", "Career-ops", "seansmithdesign"].contains {
+            app.staticTexts[$0].firstMatch.exists
+        }
+
+        guard hasFixtureMarker, !leakedRealNames else {
+            app.terminate()
+            let path = outputDir.appendingPathComponent("\(state).png")
+            try? FileManager.default.removeItem(at: path)
+            XCTFail("FIXTURE ASSERTION FAILED for state \(state): hasFixtureMarker=\(hasFixtureMarker) leakedRealNames=\(leakedRealNames) — stopping run")
+            throw XCTSkip("fixture assertion failed")
+        }
+
+        return app
+    }
+
+    private func capture(_ element: XCUIElement, state: String) throws {
+        let shot = element.screenshot()
+        let path = outputDir.appendingPathComponent("\(state).png")
+        try shot.pngRepresentation.write(to: path)
+        print("CAPTURE_OUTPUT: \(path.path)")
+    }
+
+    private func unreachable(_ state: String, _ reason: String) {
+        print("CAPTURE_UNREACHABLE: \(state) — \(reason)")
+    }
+
+    // MARK: - 1-2. Projects tab
+
+    func testProjectsLaunch() throws {
+        let app = try launchFixtureApp(state: "projects-launch")
+        try capture(app.windows.firstMatch, state: "projects-launch")
+        app.terminate()
+    }
+
+    func testProjectsExpanded() throws {
+        let app = try launchFixtureApp(state: "projects-expanded")
+        let projectRow = app.staticTexts["switchboard"].firstMatch
+        if projectRow.waitForExistence(timeout: 5) {
+            projectRow.click()
+            Thread.sleep(forTimeInterval: 0.4)
+        }
+        try capture(app.windows.firstMatch, state: "projects-expanded")
+        app.terminate()
+    }
+
+    // MARK: - 3. Projects tab, other appearance
+
+    func testProjectsExpandedAlt() throws {
+        let app = try launchFixtureApp(state: "projects-expanded-alt")
+        let originalAppearance = XCUIDevice.shared.appearance
+        let projectRow = app.staticTexts["switchboard"].firstMatch
+        if projectRow.waitForExistence(timeout: 5) {
+            projectRow.click()
+            Thread.sleep(forTimeInterval: 0.4)
+        }
+        let altAppearance: XCUIDevice.Appearance = originalAppearance == .dark ? .light : .dark
+        XCUIDevice.shared.appearance = altAppearance
+        Thread.sleep(forTimeInterval: 0.6)
+        try capture(app.windows.firstMatch, state: "projects-expanded-alt")
+        XCUIDevice.shared.appearance = originalAppearance
+        app.terminate()
+    }
+
+    // MARK: - 4-5. Sessions tab
+
+    func testSessions() throws {
+        let app = try launchFixtureApp(state: "sessions")
+        app.typeKey("2", modifierFlags: [.command, .shift])
+        Thread.sleep(forTimeInterval: 0.5)
+        try capture(app.windows.firstMatch, state: "sessions")
+        app.terminate()
+    }
+
+    func testSessionsAlt() throws {
+        let app = try launchFixtureApp(state: "sessions-alt")
+        let originalAppearance = XCUIDevice.shared.appearance
+        app.typeKey("2", modifierFlags: [.command, .shift])
+        Thread.sleep(forTimeInterval: 0.5)
+        let altAppearance: XCUIDevice.Appearance = originalAppearance == .dark ? .light : .dark
+        XCUIDevice.shared.appearance = altAppearance
+        Thread.sleep(forTimeInterval: 0.6)
+        try capture(app.windows.firstMatch, state: "sessions-alt")
+        XCUIDevice.shared.appearance = originalAppearance
+        app.terminate()
+    }
+
+    // MARK: - 6. Session context menu
+
+    func testSessionContextMenu() throws {
+        let app = try launchFixtureApp(state: "session-context-menu")
+        app.typeKey("2", modifierFlags: [.command, .shift])
+        Thread.sleep(forTimeInterval: 0.5)
+        let sessionRow = app.staticTexts["Claude Code 4"].firstMatch
+        guard sessionRow.waitForExistence(timeout: 5) else {
+            unreachable("session-context-menu", "'Claude Code 4' row not found on Sessions tab")
+            app.terminate()
+            return
+        }
+        sessionRow.rightClick()
+        Thread.sleep(forTimeInterval: 0.4)
+        // Guess: the context menu surfaces as a standard NSMenu; query the
+        // first menu element rather than a specific item, since item titles
+        // aren't documented for this row.
+        let menu = app.menus.firstMatch
+        if menu.waitForExistence(timeout: 2) {
+            try capture(menu, state: "session-context-menu-menu")
+        } else {
+            unreachable("session-context-menu-menu", "no menu element found after right-click")
+        }
+        try capture(app.windows.firstMatch, state: "session-context-menu")
+        app.typeKey(.escape, modifierFlags: [])
+        app.terminate()
+    }
+
+    // MARK: - 7-10. Composer
+
+    func testComposerEmpty() throws {
+        let app = try launchFixtureApp(state: "composer-empty")
+        app.typeKey("t", modifierFlags: [.command])
+        Thread.sleep(forTimeInterval: 0.5)
+        try capture(app.windows.firstMatch, state: "composer-empty")
+        app.typeKey(.escape, modifierFlags: [])
+        app.terminate()
+    }
+
+    func testComposerTyped() throws {
+        let app = try launchFixtureApp(state: "composer-typed")
+        app.typeKey("t", modifierFlags: [.command])
+        Thread.sleep(forTimeInterval: 0.3)
+        app.typeText("swi")
+        Thread.sleep(forTimeInterval: 0.5)
+        try capture(app.windows.firstMatch, state: "composer-typed")
+        app.typeKey(.escape, modifierFlags: [])
+        app.terminate()
+    }
+
+    func testComposerChevron() throws {
+        let app = try launchFixtureApp(state: "composer-chevron")
+        app.typeKey("t", modifierFlags: [.command])
+        Thread.sleep(forTimeInterval: 0.3)
+        app.typeText("switchboard > feat/demo")
+        Thread.sleep(forTimeInterval: 0.5)
+        try capture(app.windows.firstMatch, state: "composer-chevron")
+        app.typeKey(.escape, modifierFlags: [])
+        app.terminate()
+    }
+
+    func testComposerTab() throws {
+        let app = try launchFixtureApp(state: "composer-tab")
+        app.typeKey("t", modifierFlags: [.command])
+        Thread.sleep(forTimeInterval: 0.3)
+        app.typeText("swi")
+        app.typeKey(.tab, modifierFlags: [])
+        Thread.sleep(forTimeInterval: 0.3)
+        try capture(app.windows.firstMatch, state: "composer-tab")
+        app.typeKey(.escape, modifierFlags: [])
+        app.terminate()
+    }
+
+    // MARK: - 11. New template
+
+    func testNewTemplate() throws {
+        let app = try launchFixtureApp(state: "new-template")
+        app.typeKey("t", modifierFlags: [.command])
+        Thread.sleep(forTimeInterval: 0.5)
+        // Guess: "New template" is an in-list row (no ellipsis per
+        // SessionComposerPalette.swift), so query it as static text within
+        // the composer's idle list.
+        let newTemplateRow = app.staticTexts["New template"].firstMatch
+        guard newTemplateRow.waitForExistence(timeout: 3) else {
+            unreachable("new-template", "'New template' row not found in composer idle list")
+            app.typeKey(.escape, modifierFlags: [])
+            app.terminate()
+            return
+        }
+        newTemplateRow.click()
+        Thread.sleep(forTimeInterval: 0.5)
+        // Guess: a sheet, if presented, is queryable as app.sheets.firstMatch.
+        let sheet = app.sheets.firstMatch
+        if sheet.waitForExistence(timeout: 2) {
+            try capture(sheet, state: "new-template")
+        } else {
+            try capture(app.windows.firstMatch, state: "new-template")
+        }
+        app.typeKey(.escape, modifierFlags: [])
+        app.terminate()
+    }
+
+    // MARK: - 12-13. Sidebar closed / overlay
+
+    func testSidebarClosed() throws {
+        let app = try launchFixtureApp(state: "sidebar-closed")
+        app.typeKey("e", modifierFlags: [.command, .shift])
+        Thread.sleep(forTimeInterval: 0.6)
+        try capture(app.windows.firstMatch, state: "sidebar-closed")
+        app.terminate()
+    }
+
+    func testSidebarOverlay() throws {
+        let app = try launchFixtureApp(state: "sidebar-overlay")
+        app.typeKey("e", modifierFlags: [.command, .shift])
+        Thread.sleep(forTimeInterval: 0.6)
+        let window = app.windows.firstMatch
+        let edgeCoordinate = window.coordinate(withNormalizedOffset: CGVector(dx: 0.01, dy: 0.5))
+        edgeCoordinate.hover()
+        Thread.sleep(forTimeInterval: 0.6)
+        try capture(window, state: "sidebar-overlay")
+        app.terminate()
+    }
+
+    // MARK: - 14. Task-first
+
+    func testTaskFirst() throws {
+        let taskDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghostties-visual-pass-tasks-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: taskDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: taskDir) }
+
+        let now = ISO8601DateFormatter().string(from: Date())
+        let fixtures: [(String, String)] = [
+            ("task-1", "status: inbox"),
+            ("task-2", "status: backlog"),
+            ("task-3", "status: running"),
+            ("task-4", "status: needs-you"),
+        ]
+        for (name, statusLine) in fixtures {
+            let content = """
+            ---
+            title: \(name) fixture
+            \(statusLine)
+            created: \(now)
+            project: switchboard
+            source: unknown
+            ---
+            ## Goal
+
+            Visual-pass fixture task.
+            """
+            try? content.write(
+                to: taskDir.appendingPathComponent("\(name).md"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let defaultsDomain = "com.seansmithdesign.ghostties.dev"
+        let setResult = Process()
+        setResult.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        setResult.arguments = ["write", defaultsDomain, "ghostties.sidebarViewMode", "taskFirst"]
+        try? setResult.run()
+        setResult.waitUntilExit()
+
+        defer {
+            let deleteResult = Process()
+            deleteResult.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+            deleteResult.arguments = ["delete", defaultsDomain, "ghostties.sidebarViewMode"]
+            try? deleteResult.run()
+            deleteResult.waitUntilExit()
+        }
+
+        let app = try launchFixtureApp(
+            state: "task-first",
+            extraEnvironment: ["GHOSTTIES_TASKS_DIR": taskDir.path]
+        )
+        Thread.sleep(forTimeInterval: 0.5)
+        try capture(app.windows.firstMatch, state: "task-first")
+        app.terminate()
+    }
+
+    // MARK: - 15. Browser
+
+    func testBrowser() throws {
+        let cefDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghostties-visual-pass-cef-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cefDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: cefDir) }
+
+        let app = try launchFixtureApp(
+            state: "browser",
+            extraEnvironment: [
+                "GHOSTTIES_DEBUG_AUTO_OPEN_BROWSER": "1",
+                "GHOSTTIES_CEF_APP_SUPPORT_DIR": cefDir.path,
+            ]
+        )
+        Thread.sleep(forTimeInterval: 4.0)
+
+        guard app.state == .runningForeground else {
+            unreachable("browser", "app died or backgrounded after auto-open-browser; state=\(app.state.rawValue)")
+            return
+        }
+        try capture(app.windows.firstMatch, state: "browser")
+        app.terminate()
+    }
+
+    // MARK: - 16. Menu bar
+
+    func testMenuBar() throws {
+        let app = try launchFixtureApp(state: "menu-bar")
+        let statusItem = app.statusItems.firstMatch
+        guard statusItem.waitForExistence(timeout: 3) else {
+            unreachable("menu-bar", "no status item queryable via app.statusItems")
+            app.terminate()
+            return
+        }
+        statusItem.click()
+        Thread.sleep(forTimeInterval: 0.5)
+        let popover = app.popovers.firstMatch
+        if popover.waitForExistence(timeout: 2) {
+            try capture(popover, state: "menu-bar")
+        } else {
+            unreachable("menu-bar", "status item clicked but no popover element found")
+        }
+        app.terminate()
+    }
+
+    // MARK: - 17. Onboarding
+
+    func testOnboarding() throws {
+        // OnboardingSheet is presented from `WorkspaceSidebarView` based on a
+        // persisted `hasSeenOnboarding` flag, not from any AppDelegate menu
+        // item — grep of AppDelegate found no onboarding reference.
+        unreachable("onboarding", "not reachable from a menu item; gated by a persisted hasSeenOnboarding flag with no menu trigger")
+    }
+
+    // MARK: - 18. Window min width
+
+    func testWindowMinWidth() throws {
+        let app = try launchFixtureApp(state: "window-min-width")
+        let window = app.windows.firstMatch
+        let originalFrame = window.frame
+        // Guess: drag the bottom-right corner toward the top-left to force
+        // the window to its minimum width, using normalized coordinates.
+        let bottomRight = window.coordinate(withNormalizedOffset: CGVector(dx: 0.999, dy: 0.999))
+        let target = window.coordinate(withNormalizedOffset: CGVector(dx: 0.05, dy: 0.999))
+        bottomRight.press(forDuration: 0.1, thenDragTo: target)
+        Thread.sleep(forTimeInterval: 0.5)
+        let newFrame = window.frame
+        guard newFrame.width < originalFrame.width else {
+            unreachable("window-min-width", "drag-resize did not reduce window width (before=\(originalFrame.width), after=\(newFrame.width))")
+            app.terminate()
+            return
+        }
+        try capture(window, state: "window-min-width")
+        app.terminate()
+    }
+}

--- a/macos/GhosttyUITests/VisualPassUITests.swift
+++ b/macos/GhosttyUITests/VisualPassUITests.swift
@@ -3,9 +3,13 @@ import XCTest
 /// Visual & usage pass — captures the app's main surfaces across 18 states in
 /// fixture mode, for the 2026-09-05 audit. Modeled on `MarketingCaptureUITests`:
 /// same launch environment, same fixture assertion, same sandboxed temp-dir
-/// output with `CAPTURE_OUTPUT: <path>` lines. NOT gated behind
-/// `IDE_DISABLED_OS_ACTIVITY_DT_MODE` — must run from a plain `xcodebuild test`
-/// CLI invocation.
+/// output with `CAPTURE_OUTPUT: <path>` lines.
+///
+/// Skipped unless `GHOSTTIES_UI_CAPTURE=1` reaches the test runner — an
+/// unfiltered `xcodebuild test` must never launch the app. From the CLI pass
+/// `TEST_RUNNER_GHOSTTIES_UI_CAPTURE=1` to `xcodebuild` (the `TEST_RUNNER_`
+/// prefix is how xcodebuild forwards env to the runner), combined with
+/// `-only-testing:GhosttyUITests/VisualPassUITests`.
 ///
 /// Each test method is independent (fresh launch) and captures exactly one
 /// state. Where a state cannot be reached with element queries, the test
@@ -16,6 +20,14 @@ import XCTest
 /// below is by static text or menu title. Places that had to guess are
 /// annotated inline.
 final class VisualPassUITests: XCTestCase {
+    override class var defaultTestSuite: XCTestSuite {
+        if ProcessInfo.processInfo.environment["GHOSTTIES_UI_CAPTURE"] == "1" {
+            return XCTestSuite(forTestCaseClass: Self.self)
+        } else {
+            return XCTestSuite(name: "Skipping \(className()) (set GHOSTTIES_UI_CAPTURE=1 to run)")
+        }
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = false
     }

--- a/macos/Sources/Features/Ghostties/BuildInfoBadgeView.swift
+++ b/macos/Sources/Features/Ghostties/BuildInfoBadgeView.swift
@@ -121,7 +121,12 @@ struct BuildInfoBadgeView: View {
     private let info = BuildInfoSnapshot.current
 
     var body: some View {
-        if isEnabled {
+        // Force-hidden under the marketing-capture fixture regardless of the
+        // AppStorage default — a captured screenshot must never be able to
+        // leak the version/build-date/uptime readout, even if a future
+        // caller forgets to also pass the AppStorage override launch
+        // argument. See `CaptureFixture`.
+        if isEnabled && !CaptureFixture.isActive {
             Text(justCopied ? "Copied build info" : info.shortLabel)
                 .font(.system(size: 9))
                 .foregroundColor(colorScheme == .dark ? WorkspaceLayout.textSecondaryDark : WorkspaceLayout.textSecondaryLight)

--- a/macos/Sources/Features/Ghostties/CaptureFixture.swift
+++ b/macos/Sources/Features/Ghostties/CaptureFixture.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+/// Marketing-capture fixture mode — the data source for automated screenshots
+/// of the app used on ghostties.org (`scripts/capture-marketing.sh`).
+///
+/// Activated **only** by the `GHOSTTIES_CAPTURE_FIXTURE=1` launch
+/// environment variable (never a `-key value` launch argument — see
+/// `isActive`'s doc comment for why argv doesn't work for this app). When
+/// active:
+///   - `WorkspaceStore.shared` is seeded with an invented project/session
+///     cast instead of loading the real `~/Library/Application
+///     Support/Ghostties/workspace.json` — see `WorkspaceStore.shared`.
+///   - `SessionCoordinator.createSession` runs a canned terminal transcript
+///     instead of the user's real login shell — see the fixture branch
+///     there.
+///   - `BuildInfoBadgeView` force-hides regardless of the
+///     `ghostties.devBuildInfoBadge.enabled` default — see that view.
+///
+/// This is privacy-critical: a spike capture (pre-fixture) leaked Sean's real
+/// project names, his `seansmith@macbookpro` hostname, and the dev build
+/// badge into a saved PNG. Every one of those paths is gated behind
+/// `isActive`, which defaults to `false` — without the environment variable
+/// this file changes nothing about the app's behavior.
+enum CaptureFixture {
+    /// Whether fixture mode is active for this process launch.
+    ///
+    /// Read from an **environment variable**
+    /// (`app.launchEnvironment["GHOSTTIES_CAPTURE_FIXTURE"] = "1"`), not a
+    /// `-key value` launch argument. Ghostty's own core CLI parser scans
+    /// `argv` for config directives and pops a "Configuration Errors" dialog
+    /// on any token it doesn't recognize — verified by hand: passing
+    /// `-GhosttiesCaptureFixture 1` produced a 6-error dialog (one per
+    /// argv token across three attempted flags), even though
+    /// `-ApplePersistenceIgnoreState YES` alone (a recognized system launch
+    /// argument) is silently accepted. The environment-variable channel is
+    /// the same one `GhosttyCustomConfigCase.ghosttyApplication()` already
+    /// uses for `GHOSTTY_CONFIG_PATH` / `GHOSTTY_USER_DEFAULTS_SUITE`, and
+    /// never reaches argv at all.
+    static let isActive: Bool = ProcessInfo.processInfo.environment["GHOSTTIES_CAPTURE_FIXTURE"] == "1"
+
+    // MARK: - Canned Workspace
+
+    #if DEBUG
+
+    /// Deterministic UUID so repeated captures produce byte-stable ghost
+    /// assignments and ordering — never `UUID()`, which would reshuffle the
+    /// sidebar (and the ghost pick) on every relaunch.
+    private static func fixedId(_ tail: String) -> UUID {
+        let padded = String(repeating: "0", count: max(0, 12 - tail.count)) + tail
+        return UUID(uuidString: "CAFEFEED-0000-4000-8000-\(padded)")!
+    }
+
+    /// Invented project cast — same names already used as the invented cast
+    /// in `docs/design/web-redesign/rebuild/index.html` (switchboard,
+    /// atlas-api, fieldwork, pendulum, silo, trove, wren). Never Sean's real
+    /// projects. `rootPath` points at a real, writable directory created
+    /// under the sandbox's own temp container — see
+    /// `fixtureWorkingDirectory(for:)` — so a canned session's shell `cd`
+    /// succeeds without inventing (or touching) a path on Sean's disk.
+    private struct FixtureProject {
+        let name: String
+        let ghost: GhostCharacter
+        let isPinned: Bool
+    }
+
+    private static let fixtureProjects: [FixtureProject] = [
+        FixtureProject(name: "atlas-api", ghost: .banshee, isPinned: true),
+        FixtureProject(name: "fieldwork", ghost: .clyde, isPinned: true),
+        FixtureProject(name: "pendulum", ghost: .ember, isPinned: true),
+        FixtureProject(name: "silo", ghost: .haunt, isPinned: true),
+        FixtureProject(name: "switchboard", ghost: .pinky, isPinned: true),
+        FixtureProject(name: "trove", ghost: .specter, isPinned: true),
+        FixtureProject(name: "wren", ghost: .wisp, isPinned: true),
+    ]
+
+    /// A real, writable directory under the sandbox temp container so a
+    /// canned session's `cd` succeeds. Created lazily on first access;
+    /// idempotent (`withIntermediateDirectories: true`).
+    static func fixtureWorkingDirectory(for projectName: String) -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ghostties-capture-fixture", isDirectory: true)
+            .appendingPathComponent(projectName, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.path
+    }
+
+    static let projects: [Project] = fixtureProjects.map { fp in
+        Project(
+            id: fixedId(String(format: "%04d", fixtureProjects.firstIndex { $0.name == fp.name }! + 1)),
+            name: fp.name,
+            rootPath: fixtureWorkingDirectory(for: fp.name),
+            isPinned: fp.isPinned,
+            ghostCharacter: fp.ghost,
+            lastActiveAt: Date()
+        )
+    }
+
+    private static func projectId(_ name: String) -> UUID {
+        projects.first { $0.name == name }!.id
+    }
+
+    /// `(name, project, ghost, indicator state)` — mirrors the rebuild
+    /// reference's session cast: switchboard has 4 live sessions (2 waiting,
+    /// 2 processing), fieldwork 1 waiting, plus a couple of idle/archived
+    /// entries elsewhere so neither sidebar tab reads as empty.
+    private struct FixtureSession {
+        let name: String
+        let project: String
+        let ghost: GhostCharacter
+        let state: SessionIndicatorState
+        let hoursAgo: Double
+    }
+
+    private static let fixtureSessions: [FixtureSession] = [
+        FixtureSession(name: "Claude Code 4", project: "switchboard", ghost: .mist, state: .processing, hoursAgo: 0),
+        FixtureSession(name: "Claude Code 3", project: "switchboard", ghost: .gloom, state: .processing, hoursAgo: 0.02),
+        FixtureSession(name: "Claude Code 2", project: "switchboard", ghost: .polter, state: .waiting, hoursAgo: 0.05),
+        FixtureSession(name: "Claude Code 1", project: "switchboard", ghost: .wraith, state: .waiting, hoursAgo: 0.07),
+        FixtureSession(name: "Claude Code 1", project: "fieldwork", ghost: .shade, state: .waiting, hoursAgo: 0.1),
+        FixtureSession(name: "Claude Code 5", project: "pendulum", ghost: .spike, state: .inactive, hoursAgo: 2),
+        FixtureSession(name: "docs pass", project: "silo", ghost: .drift, state: .inactive, hoursAgo: 24),
+        FixtureSession(name: "release notes", project: "trove", ghost: .clyde, state: .inactive, hoursAgo: 72),
+        FixtureSession(name: "icon pass", project: "wren", ghost: .pinky, state: .inactive, hoursAgo: 168),
+    ]
+
+    static let sessions: [AgentSession] = fixtureSessions.enumerated().map { index, fs in
+        let now = Date()
+        return AgentSession(
+            id: fixedId(String(format: "%04d", 100 + index)),
+            name: fs.name,
+            templateId: AgentTemplate.claudeCode.id,
+            projectId: projectId(fs.project),
+            sortOrder: index,
+            lastActiveAt: now.addingTimeInterval(-fs.hoursAgo * 3600),
+            lastOutputAt: now.addingTimeInterval(-fs.hoursAgo * 3600),
+            isNamePinned: true,
+            ghostCharacter: fs.ghost
+        )
+    }
+
+    /// Build the seeded `WorkspaceStore` and apply the canned indicator
+    /// states — indicator state is separate, ephemeral, non-persisted
+    /// per-window state, so it can't be baked into the `AgentSession`
+    /// records above and has to be pushed in after construction.
+    @MainActor
+    static func makeStore() -> WorkspaceStore {
+        let store = WorkspaceStore(
+            testingProjects: projects,
+            testingSessions: sessions,
+            hasShownPinMigrationNotice: true,
+            hasDismissedPinMigrationNotice: true
+        )
+        for (fs, session) in zip(fixtureSessions, sessions) {
+            store.updateIndicatorState(id: session.id, state: fs.state)
+        }
+        return store
+    }
+
+    #endif
+
+    // MARK: - Transcript Script Writer
+
+    /// Writes `transcriptScript` to a uniquely-named launcher script under
+    /// `~/.ghostties/cache/launchers` (the same directory and permissions
+    /// the real launch-banner script mechanism already uses — see
+    /// `SessionCoordinator.captureFixtureCommand(for:)` and
+    /// `createSession`'s banner-script block) and returns its path. Shared
+    /// by every surface-creation call site that needs to substitute the
+    /// canned transcript for a real shell while fixture mode is active:
+    /// `SessionCoordinator.createSession` (session rows) and
+    /// `TerminalController.init` (the default/untitled window opened at
+    /// cold launch, before any Ghosties project or session is picked).
+    /// Falls back to `/bin/true` (an inert, silent no-op) if the write
+    /// fails, so a broken fixture never accidentally falls through to a
+    /// real shell and leaks real state.
+    static func writeTranscriptScript(id: String) -> String {
+        let scriptDir = ("~/.ghostties/cache/launchers" as NSString).expandingTildeInPath
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: scriptDir) {
+            try? fm.createDirectory(atPath: scriptDir, withIntermediateDirectories: true, attributes: [
+                .posixPermissions: 0o700,
+            ])
+        }
+        let scriptPath = (scriptDir as NSString).appendingPathComponent("capture-fixture-\(id).sh")
+        guard (try? transcriptScript.write(toFile: scriptPath, atomically: true, encoding: .utf8)) != nil else {
+            return "/bin/true"
+        }
+        try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: scriptPath)
+        return scriptPath
+    }
+
+    // MARK: - Canned Terminal Transcript
+
+    /// A dense, plausible Claude Code session transcript — real chrome, real
+    /// rendering, staged data only. No real hostname or path appears; the
+    /// engineering problem is invented and scoped to the `switchboard`
+    /// fixture project. Deliberately NOT near-empty — the site's previous
+    /// replica was rejected specifically for a sparse-looking terminal pane.
+    static let transcriptScript: String = #"""
+        #!/bin/zsh
+        clear
+        printf '\033[1m╭─────────────────────────────────────────╮\033[0m\n'
+        printf '\033[1m│ \033[35m✻\033[0m\033[1m Claude Code\033[0m                              │\n'
+        printf '\033[1m╰─────────────────────────────────────────╯\033[0m\n'
+        printf '\n'
+        printf '\033[1m> \033[0mFix the race condition in the reconnect handler and add a regression test\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Read(sync/reconnect.go)\n'
+        printf '  \033[2m⎿  Read 142 lines\033[0m\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m I see it — the retry loop swaps the socket without holding the\n'
+        printf '  connection lock, so a concurrent Send() can grab a half-closed fd.\n'
+        printf '  Checking the call sites before widening the lock scope.\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Search(pattern: "reconnect(", path: "sync/")\n'
+        printf '  \033[2m⎿  Found 3 matches across 2 files\033[0m\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Edit(sync/reconnect.go)\n'
+        printf '  \033[2m⎿  Updated sync/reconnect.go with 8 additions and 2 removals\033[0m\n'
+        printf '  \033[2m     41\033[0m   func (c *Client) reconnect(ctx context.Context) error {\n'
+        printf '  \033[2m42\033[0m \033[31m-\033[0m    c.socket = nil\n'
+        printf '  \033[2m43\033[0m \033[32m+\033[0m    c.mu.Lock()\n'
+        printf '  \033[2m44\033[0m \033[32m+\033[0m    defer c.mu.Unlock()\n'
+        printf '  \033[2m45\033[0m \033[32m+\033[0m    old := c.socket\n'
+        printf '  \033[2m46\033[0m \033[32m+\033[0m    c.socket = nil\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Bash(go test ./sync/... -run TestReconnect -v)\n'
+        printf '  \033[2m⎿  === RUN   TestReconnect_ConcurrentSend\033[0m\n'
+        printf '  \033[2m   --- PASS: TestReconnect_ConcurrentSend (0.04s)\033[0m\n'
+        printf '  \033[2m   PASS\033[0m\n'
+        printf '  \033[2m   ok      switchboard/sync    0.312s\033[0m\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Tests pass. The lock now covers the full swap, so Send() either sees\n'
+        printf '  the old live socket or blocks until the new one is ready — no\n'
+        printf '  half-closed window. Want me to open a PR?\n'
+        printf '\n'
+        printf '\033[1m> \033[0myes, and add a one-line changelog entry\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Write(CHANGELOG.md)\n'
+        printf '  \033[2m⎿  Wrote 1 line\033[0m\n'
+        printf '\n'
+        printf '\033[35m⏺\033[0m Bash(gh pr create --title "fix: hold connection lock across socket swap")\n'
+        printf '  \033[2m⎿  https://github.com/example/switchboard/pull/412\033[0m\n'
+        printf '\n'
+        exec cat > /dev/null
+        """#
+}

--- a/macos/Sources/Features/Ghostties/SessionCoordinator.swift
+++ b/macos/Sources/Features/Ghostties/SessionCoordinator.swift
@@ -264,7 +264,9 @@ final class SessionCoordinator: ObservableObject {
 
         var config = Ghostty.SurfaceConfiguration()
         config.workingDirectory = template.workingDirectory ?? project.rootPath
-        config.command = finalCommand
+        config.command = CaptureFixture.isActive
+            ? Self.captureFixtureCommand(for: session.id)
+            : finalCommand
         config.environmentVariables = Self.spawnEnvironment(
             template: template,
             taskFilePath: sourceTaskFilePath,
@@ -995,6 +997,14 @@ final class SessionCoordinator: ObservableObject {
         }
 
         return command
+    }
+
+    // MARK: - Marketing Capture Fixture
+
+    /// The command every fixture-mode session runs instead of a real shell —
+    /// see `CaptureFixture.writeTranscriptScript(id:)`.
+    nonisolated private static func captureFixtureCommand(for sessionId: UUID) -> String {
+        CaptureFixture.writeTranscriptScript(id: sessionId.uuidString)
     }
 
     // MARK: - Launcher Script Lifecycle

--- a/macos/Sources/Features/Ghostties/WorkspaceStore.swift
+++ b/macos/Sources/Features/Ghostties/WorkspaceStore.swift
@@ -11,7 +11,24 @@ import GhosttiesCore
 @MainActor
 final class WorkspaceStore: ObservableObject {
     /// Shared instance used by all windows. Created once on first access.
-    static let shared = WorkspaceStore()
+    ///
+    /// When the marketing-capture fixture is active (`GHOSTTIES_CAPTURE_FIXTURE=1`
+    /// launch environment variable — see `CaptureFixture`), this is seeded with an
+    /// invented project/session cast instead of loading the real
+    /// `workspace.json`, so an automated screenshot can never contain Sean's
+    /// real project or session names. The DEBUG gate mirrors
+    /// `CaptureFixture.makeStore()`'s own gate — the capture rig always
+    /// builds the Debug configuration (see the `Ghostties` scheme's
+    /// `TestAction`), and this branch leans on `WorkspaceStore`'s DEBUG-only
+    /// test initializer, so it cannot exist in a Release build regardless.
+    static let shared: WorkspaceStore = {
+        #if DEBUG
+        if CaptureFixture.isActive {
+            return CaptureFixture.makeStore()
+        }
+        #endif
+        return WorkspaceStore()
+    }()
 
     /// `sectionedProjects`/`sessionGroups(forProject:)` below are memoized —
     /// invalidating on every mutation via `didSet` (rather than scattering

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -45,17 +45,33 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
          withSurfaceTree tree: SplitTree<Ghostty.SurfaceView>? = nil,
          parent: NSWindow? = nil
     ) {
+        // Marketing-capture fixture: this path also covers the default
+        // "untitled" window macOS opens at cold launch (before any Ghosties
+        // project/session is picked) plus every other `newWindow(ghostty)`
+        // call site that passes no explicit base config — none of those go
+        // through `SessionCoordinator.createSession`, so without this a
+        // fixture-mode capture would still show the user's real login shell
+        // (hostname, real cwd) in a freshly opened window. Only applies to
+        // genuinely fresh windows (`tree == nil`) — never overrides a real
+        // split-tree restoration. See `CaptureFixture`.
+        let resolvedBase: Ghostty.SurfaceConfiguration? = {
+            guard CaptureFixture.isActive, tree == nil else { return base }
+            var config = base ?? Ghostty.SurfaceConfiguration()
+            config.command = CaptureFixture.writeTranscriptScript(id: "default-window")
+            return config
+        }()
+
         // The window we manage is not restorable if we've specified a command
         // to execute. We do this because the restored window is meaningless at the
         // time of writing this: it'd just restore to a shell in the same directory
         // as the script. We may want to revisit this behavior when we have scrollback
         // restoration.
-        self.restorable = (base?.command ?? "") == ""
+        self.restorable = (resolvedBase?.command ?? "") == ""
 
         // Setup our initial derived config based on the current app config
         self.derivedConfig = DerivedConfig(ghostty.config)
 
-        super.init(ghostty, baseConfig: base, surfaceTree: tree)
+        super.init(ghostty, baseConfig: resolvedBase, surfaceTree: tree)
 
         // Setup our notifications for behaviors
         let center = NotificationCenter.default


### PR DESCRIPTION
This lands the visual-pass capture rig (session-10, 2026-09-05) on `main`, plus a CI experiment.

**Fixture mode** (`GHOSTTIES_CAPTURE_FIXTURE=1`) stubs `WorkspaceStore` with a synthetic cast — no real session data, no real preset/template names, no real hostname. `VisualPassUITests` drives fixture mode through 18 sidebar/session states and writes screenshots to `$TMPDIR/ghostties-visual-pass`.

The pbxproj hunk fixes `TEST_TARGET_NAME` from stale `Ghostty` to `Ghostties` (3 configs), which arms `GhosttyUITests` to actually run under `-only-testing`. That's safe here: every GUI-driving upstream class in `macos/GhosttyUITests/` subclasses `GhosttyCustomConfigCase` (IDE-env gated), and `TaskSidebarSmokeUITests` carries its own gate — audited file-by-file before this PR.

**CI experiment result:** the runner launches the app host — 12 tests executed, 11 failed on `has not loaded accessibility` after a 60s wait each, no captures produced. The step is now opt-in via a `workflow_dispatch` input, `visual_pass`. Getting even that far required moving `TEST_RUNNER_*` into the step's own `env:` block — the first run without that executed 0 tests and went green.

Known rig limits (carried over, not fixed here): the fixture cast has no "needs you" (waiting) session state; `task-first.png` capture was a prior false positive; opening the embedded browser hangs `app.terminate()`.

**Update:** `VisualPassUITests` and `MarketingCaptureUITests` are now opt-in via `GHOSTTIES_UI_CAPTURE=1` (gated with the same `defaultTestSuite` mechanism the other classes here use), so an unfiltered local `xcodebuild test` launches nothing. CI now passes `TEST_RUNNER_GHOSTTIES_UI_CAPTURE=1` to arm the experiment step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTkv1EBKi7qnmC4TqZjpx9


