### PR TITLE
feat(demo): one-command demo rig — never-stale capture app

### DIFF
--- a/examples/demo-workspace/CAPTURE.md
+++ b/examples/demo-workspace/CAPTURE.md
@@ -1,0 +1,311 @@
+# Ghostties Screen-Capture Runbook
+
+Concrete, copy-paste instructions for recording the Ghostties demo workspace. Designed to be executed in ~30 minutes and reshootable on any future session. This same setup and shotlist feeds both the portfolio case study and social-media promo clips.
+
+---
+
+## 1. Scene Setup
+
+Consistency matters because reshoots need to line up with earlier frames — same window position, same chrome, same wallpaper — so clips cut together cleanly without visible jumps.
+
+### Load the fixture
+
+Ghostties discovers any directory that contains a `.ghostties/tasks/` subfolder. Open each of the seven project folders individually in Ghostties (navigate to or open each path):
+
+```
+examples/demo-workspace/atlas-api/
+examples/demo-workspace/pendulum/
+examples/demo-workspace/silo/
+examples/demo-workspace/wren/
+examples/demo-workspace/switchboard/
+examples/demo-workspace/fieldwork/
+examples/demo-workspace/trove/
+```
+
+When loaded correctly you should see:
+- 7 named pixel-art ghosts in the project rail
+- All six zones populated: Inbox, Backlog, Running, Needs You, Review, Graveyard
+- 6 tasks in "Needs You" — cards appear in terracotta (#C97350)
+- 5 running tasks with branch/worktree/files-staged metadata
+
+### Window and environment
+
+| Setting | Target |
+|---------|--------|
+| Window size | 1440 x 900 pt logical (renders 2880 x 1800 at 2x retina) |
+| Color mode | Light |
+| Desktop wallpaper | Solid neutral — cool stone `#E8E4DE` or plain white; no patterns |
+| Desktop icons | Hidden — `defaults write com.apple.finder CreateDesktop false; killall Finder` |
+| Menu bar | Notification badges cleared; other app icons hidden or minimal; Ghostties status item visible |
+| Terminal theme | Cool stone palette: dark-on-light, no bright syntax colors competing with Ghostties chrome |
+| Dock | Autohide on, or slide off-screen before recording |
+
+**Window position:** top-left corner snapped to `(0, 25)` (below menu bar). Exact position reproducible with:
+
+```bash
+# Set Ghostties window to 1440x900 at top-left (adjust app name if different)
+osascript -e 'tell application "Ghostties" to set bounds of front window to {0, 25, 1440, 925}'
+```
+
+---
+
+## 2. The Shotlist
+
+Five shots minimum. Capture in this order — the hero last, after you have verified all zones look right.
+
+---
+
+### Shot 1 — HERO (motion, 8-12s silent loop)
+
+**What is on screen:** Full Ghostties workspace. Ghost rail on the left with all 7 project ghosts visible and labeled. The active project (use `switchboard` — it has a running task, a needs-you card, and a review task) shows all six zone columns with cards. A Needs You card sits terracotta in the center column. The right panel shows a terminal pane with a `gt` command running. The menu bar status item is lit.
+
+**Why it earns its place:** This is the thesis in one frame. Rail + zones + terracotta + live terminal = the whole product story before anyone reads a word.
+
+**How to capture:**
+
+1. Open a terminal pane inside Ghostties showing the `switchboard` project.
+2. Run `gt list` (or whatever the CLI command is to list tasks) so the terminal has live output visible.
+3. Trigger a "Needs You" card flip if the app supports it (or ensure `replay-dead-letter.md` is visible in the Needs You zone).
+4. Use `Cmd-Shift-5`, choose "Record Selected Portion", drag to the Ghostties window (1440 x 900), click Record.
+5. Let it run 10-15 seconds while you slowly hover across ghost rail icons.
+6. Stop recording. Trim to 8-12s in QuickTime (Edit > Trim) and export as `.mp4`.
+
+**Capture command (scripted alternative with ffmpeg):**
+
+```bash
+# Capture region x=0,y=25,w=1440,h=900 for 15 seconds at 30fps
+ffmpeg -f avfoundation -framerate 30 -capture_cursor 1 \
+  -video_size 1440x900 -i "1:none" \
+  -vf "crop=1440:900:0:25" \
+  -t 15 -c:v libx264 -crf 18 -preset slow \
+  ~/Desktop/ghostties-hero-raw.mp4
+```
+
+> Note: `avfoundation` device index `1` is typically the built-in display. Run `ffmpeg -f avfoundation -list_devices true -i ""` first to confirm your display index.
+
+**Output:** `ghostties-hero-raw.mp4` on Desktop. Trim and rename to `ghostties-hero.mp4`.
+
+---
+
+### Shot 2 — The Terracotta "Needs You" Moment (motion 3-5s, or sharp still)
+
+**What is on screen:** Tight crop on the sidebar/zone panel. A task card in the Needs You column is rendered in terracotta (`#C97350`). The Ghostties menu bar status item is simultaneously lit with a count badge. The two signals in sync — this is the core loop.
+
+**Why it earns its place:** Shows the blocking-question mechanic and the ambient status item working together. The color is the signal.
+
+**Still (clean, fast):**
+
+```bash
+# Single window capture with shadow — click the Ghostties window when prompted
+screencapture -iw ~/Desktop/ghostties-needs-you.png
+```
+
+**Region crop (if you want tighter framing on just the zone panel, e.g. 600x500 crop starting at left-center):**
+
+```bash
+# Adjust x,y,w,h to frame just the Needs You column + menu bar
+screencapture -o -R 720,25,480,500 ~/Desktop/ghostties-needs-you-crop.png
+```
+
+**Motion (if capturing the card flip in the app):**
+
+```bash
+ffmpeg -f avfoundation -framerate 60 -capture_cursor 0 \
+  -video_size 480x500 -i "1:none" \
+  -vf "crop=480:500:720:25" \
+  -t 5 -c:v libx264 -crf 16 -preset slow \
+  ~/Desktop/ghostties-needs-you-raw.mp4
+```
+
+---
+
+### Shot 3 — The Ghost Rail Isolated (still)
+
+**What is on screen:** Only the project rail — the 7 named pixel-art ghosts stacked vertically with project labels. Crop tight so each ghost and its label is readable. No zone columns in frame.
+
+**Why it earns its place:** The brand IP in one frame. The ghost rail is the visual identity of the product. One still can carry a blog post, a tweet, or an App Store screenshot.
+
+**Capture:**
+
+```bash
+# Tight region crop — adjust x,y to match your exact rail width (~60px) and height
+screencapture -o -R 0,25,80,900 ~/Desktop/ghostties-rail.png
+```
+
+Or use the interactive picker to click and drag just the rail:
+
+```bash
+screencapture -si ~/Desktop/ghostties-rail.png
+```
+
+---
+
+### Shot 4 — Status Without Focus (still or 4s clip)
+
+**What is on screen:** Ghostties window is behind another app (e.g. push a Finder window or a terminal in front of it). The Ghostties window is visible but unfocused. The macOS menu bar status item still shows the terracotta count badge in the menu bar.
+
+**Why it earns its place:** This is the key ambient-mode pitch. Ghostties tells you something needs your attention even when you're not looking at it. The status item in the menu bar does the work.
+
+**Still:**
+
+```bash
+screencapture -iw ~/Desktop/ghostties-unfocused.png
+```
+
+Click the window behind Ghostties (not the Ghostties window itself) so you capture the frontmost app, but the menu bar with Ghostties' status item is still visible.
+
+**Region crop to get menu bar + status item zoomed:**
+
+```bash
+# Capture just the menu bar strip where the status item lives (~200px wide, 25px tall)
+screencapture -o -R 1200,0,240,25 ~/Desktop/ghostties-menubar-status.png
+```
+
+---
+
+### Shot 5 — One Source of Truth, Three Ways In (still)
+
+**What is on screen:** The same task visible simultaneously in three places — (1) the task card in the Ghostties sidebar, (2) a `gt` CLI invocation in a terminal pane showing the same task's details, and (3) the underlying Markdown task file (`replay-dead-letter.md` or `confirm-token-expiry.md`) open in a text editor or `cat`-ed in a second terminal pane.
+
+**Why it earns its place:** The thesis of the underlying data model in one frame. No proprietary sync cloud — it's a Markdown file in your project folder. This is the differentiator shot for the case study.
+
+**Suggested layout before capturing:**
+- Left third: Ghostties sidebar showing the task card
+- Center third: Terminal running `gt show replay-dead-letter` (or equivalent)
+- Right third: Another terminal running `cat examples/demo-workspace/switchboard/.ghostties/tasks/replay-dead-letter.md`
+
+**Capture:**
+
+```bash
+# Full window capture of the composed layout
+screencapture -iw ~/Desktop/ghostties-three-ways.png
+```
+
+---
+
+## 3. Capture Commands Reference
+
+### Stills
+
+```bash
+# Single window with drop shadow (click the target window when crosshair appears)
+screencapture -iw ~/Desktop/out.png
+
+# Interactive drag selection (no shadow, exact region)
+screencapture -si ~/Desktop/out.png
+
+# Tight region by coordinates — no click required
+# Format: x=left-edge, y=top-edge, w=width, h=height (all in logical points)
+screencapture -o -R 0,25,1440,900 ~/Desktop/ghostties-full.png
+
+# Practical example: just the zone columns area (right of the rail)
+screencapture -o -R 80,25,1360,900 ~/Desktop/ghostties-zones.png
+
+# Practical example: menu bar status item (far right)
+screencapture -o -R 1200,0,240,25 ~/Desktop/ghostties-menubar.png
+```
+
+### Motion
+
+**Built-in (no dependencies):** `Cmd-Shift-5` > Record Selected Portion > drag to Ghostties window > Record. Produces a `.mov` in `~/Desktop`. Trim in QuickTime (Edit > Trim).
+
+**ffmpeg region capture (one concrete example):**
+
+```bash
+# Prerequisites: brew install ffmpeg
+# List available capture devices first:
+ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep -E "\[AVFoundation"
+
+# Capture full Ghostties window (1440x900 at top-left below menu bar) for 15s
+ffmpeg -f avfoundation \
+  -framerate 30 \
+  -capture_cursor 1 \
+  -video_size 2880x1800 \
+  -i "1:none" \
+  -vf "crop=2880:1800:0:50,scale=1440:900" \
+  -t 15 \
+  -c:v libx264 -crf 18 -preset slow \
+  -pix_fmt yuv420p \
+  ~/Desktop/ghostties-hero-raw.mp4
+```
+
+> The `-video_size 2880x1800` captures at retina resolution; the `scale=1440:900` brings it back to logical pixels for a clean 1x output. Omit the scale step if you want the full retina master.
+
+Capture 10-15s, then trim/loop in QuickTime or iMovie. Target 8-12s for the hero loop.
+
+---
+
+## 4. Encode and Wire into the Portfolio
+
+The encode pipeline lives in the **portfolio repo** (`~/Code/seansmithdesign.com/`), not here. Move your raw captures there:
+
+```bash
+# Move raw captures to the portfolio repo
+mv ~/Desktop/ghostties-hero.mp4 ~/Code/seansmithdesign.com/public/videos/ghostties-hero.mp4
+mv ~/Desktop/ghostties-needs-you.png ~/Code/seansmithdesign.com/public/images/ghostties/ghostties-needs-you.webp
+mv ~/Desktop/ghostties-rail.png ~/Code/seansmithdesign.com/public/images/ghostties/ghostties-rail.webp
+mv ~/Desktop/ghostties-unfocused.png ~/Code/seansmithdesign.com/public/images/ghostties/ghostties-unfocused.webp
+mv ~/Desktop/ghostties-three-ways.png ~/Code/seansmithdesign.com/public/images/ghostties/ghostties-three-ways.webp
+```
+
+Convert PNGs to WebP before moving (saves ~70% file size):
+
+```bash
+# Requires: brew install webp
+for f in ~/Desktop/ghostties-*.png; do
+  cwebp -q 90 "$f" -o "${f%.png}.webp"
+done
+```
+
+**Encode the WebM sibling** (required for Chrome/Firefox) then verify all media in the portfolio repo:
+
+```bash
+cd ~/Code/seansmithdesign.com
+./scripts/encode-video.sh public/videos/ghostties-hero.mp4
+npm run check:media
+```
+
+### Asset framing spec (Ghostties is a Landscape demo)
+
+Per `docs/ASSETS.md`, Ghostties is a **macOS desktop app** — use the **Landscape demo** safe frame, NOT phone-bezel framing:
+
+| Property | Value |
+|----------|-------|
+| Frame | **1200 x 900** (4:3) |
+| `fit` | `"contain"` |
+| Letterbox color | Cool stone (`--color-stone` or `#E8E4DE`) with terracotta (`#C97350`) as spot accent |
+| Window chrome | macOS shadow from `-iw` is the frame — no artificial device bezels |
+| Poster | First frame of the loop, exported as `ghostties-hero-poster.jpg` |
+
+### Naming convention (mirrors Brukas pattern)
+
+```
+public/videos/ghostties-hero.mp4          # hero loop
+public/videos/ghostties-hero.webm         # WebM sibling (auto-generated)
+public/images/ghostties/ghostties-hero-poster.jpg     # first-frame poster
+public/images/ghostties/ghostties-needs-you.webp      # Shot 2
+public/images/ghostties/ghostties-rail.webp           # Shot 3
+public/images/ghostties/ghostties-unfocused.webp      # Shot 4
+public/images/ghostties/ghostties-three-ways.webp     # Shot 5
+```
+
+### Wire into project data
+
+In `src/data/projects.ts`, update the Ghostties entry:
+
+```ts
+video: {
+  sources: [
+    { src: "/videos/ghostties-hero.webm", type: "video/webm" },
+    { src: "/videos/ghostties-hero.mp4",  type: "video/mp4"  },
+  ],
+  poster: "/images/ghostties/ghostties-hero-poster.jpg",
+  fit: "contain",
+},
+```
+
+---
+
+## 5. Reuse Note
+
+This fixture and runbook are the source for social-media promo clips — the same scene, same terracotta moment, same three-ways shot. Keep `examples/demo-workspace/` task content and this CAPTURE.md in sync as the app evolves so every reseed produces consistent captures.

--- a/examples/demo-workspace/CAPTURE.md
+++ b/examples/demo-workspace/CAPTURE.md
@@ -10,20 +10,20 @@ Consistency matters because reshoots need to line up with earlier frames — sam
 
 ### Load the fixture
 
-Ghostties discovers any directory that contains a `.ghostties/tasks/` subfolder. Open each of the seven project folders individually in Ghostties (navigate to or open each path):
+Don't open project folders from this checkout directly — run the demo rig scripts instead. See
+`scripts/demo/README.md` for the full procedure; in short:
 
+```bash
+./scripts/demo/refresh-demo.sh          # produce/refresh Ghostties Demo.app
+./scripts/demo/seed-demo-workspace.sh   # copy the 10 fixtures into the demo's workspace
 ```
-examples/demo-workspace/atlas-api/
-examples/demo-workspace/pendulum/
-examples/demo-workspace/silo/
-examples/demo-workspace/wren/
-examples/demo-workspace/switchboard/
-examples/demo-workspace/fieldwork/
-examples/demo-workspace/trove/
-```
+
+`seed-demo-workspace.sh` copies each fixture in `examples/demo-workspace/` into
+`~/Library/Application Support/Ghostties Demo/repos/<name>/`, turns it into a real git repo, and
+points the demo app's `workspace.json` at those copies.
 
 When loaded correctly you should see:
-- 7 named pixel-art ghosts in the project rail
+- 10 named pixel-art ghosts in the project rail
 - All six zones populated: Inbox, Backlog, Running, Needs You, Review, Graveyard
 - 6 tasks in "Needs You" — cards appear in terracotta (#C97350)
 - 5 running tasks with branch/worktree/files-staged metadata
@@ -57,7 +57,7 @@ Five shots minimum. Capture in this order — the hero last, after you have veri
 
 ### Shot 1 — HERO (motion, 8-12s silent loop)
 
-**What is on screen:** Full Ghostties workspace. Ghost rail on the left with all 7 project ghosts visible and labeled. The active project (use `switchboard` — it has a running task, a needs-you card, and a review task) shows all six zone columns with cards. A Needs You card sits terracotta in the center column. The right panel shows a terminal pane with a `gt` command running. The menu bar status item is lit.
+**What is on screen:** Full Ghostties workspace. Ghost rail on the left with all 10 project ghosts visible and labeled. The active project (use `switchboard` — it has a running task, a needs-you card, and a review task) shows all six zone columns with cards. A Needs You card sits terracotta in the center column. The right panel shows a terminal pane with a `gt` command running. The menu bar status item is lit.
 
 **Why it earns its place:** This is the thesis in one frame. Rail + zones + terracotta + live terminal = the whole product story before anyone reads a word.
 
@@ -121,7 +121,7 @@ ffmpeg -f avfoundation -framerate 60 -capture_cursor 0 \
 
 ### Shot 3 — The Ghost Rail Isolated (still)
 
-**What is on screen:** Only the project rail — the 7 named pixel-art ghosts stacked vertically with project labels. Crop tight so each ghost and its label is readable. No zone columns in frame.
+**What is on screen:** Only the project rail — the 10 named pixel-art ghosts stacked vertically with project labels. Crop tight so each ghost and its label is readable. No zone columns in frame.
 
 **Why it earns its place:** The brand IP in one frame. The ghost rail is the visual identity of the product. One still can carry a blog post, a tweet, or an App Store screenshot.
 
@@ -172,7 +172,7 @@ screencapture -o -R 1200,0,240,25 ~/Desktop/ghostties-menubar-status.png
 **Suggested layout before capturing:**
 - Left third: Ghostties sidebar showing the task card
 - Center third: Terminal running `gt show replay-dead-letter` (or equivalent)
-- Right third: Another terminal running `cat examples/demo-workspace/switchboard/.ghostties/tasks/replay-dead-letter.md`
+- Right third: Another terminal running `cat "~/Library/Application Support/Ghostties Demo/repos/switchboard/.ghostties/tasks/replay-dead-letter.md"`
 
 **Capture:**
 

--- a/examples/demo-workspace/CAPTURE.md
+++ b/examples/demo-workspace/CAPTURE.md
@@ -10,17 +10,23 @@ Consistency matters because reshoots need to line up with earlier frames — sam
 
 ### Load the fixture
 
-Don't open project folders from this checkout directly — run the demo rig scripts instead. See
-`scripts/demo/README.md` for the full procedure; in short:
+Don't open project folders from this checkout directly, and don't run `refresh-demo.sh` /
+`seed-demo-workspace.sh` by hand — start with the preflight entrypoint, which makes it
+structurally impossible to shoot from a stale build:
 
 ```bash
-./scripts/demo/refresh-demo.sh          # produce/refresh Ghostties Demo.app
-./scripts/demo/seed-demo-workspace.sh   # copy the 10 fixtures into the demo's workspace
+./scripts/demo/demo-ready.sh   # step 0: ensures a current Ghostties Demo.app + reseeds fixtures
 ```
 
-`seed-demo-workspace.sh` copies each fixture in `examples/demo-workspace/` into
-`~/Library/Application Support/Ghostties Demo/repos/<name>/`, turns it into a real git repo, and
-points the demo app's `workspace.json` at those copies.
+See `scripts/demo/README.md` for the full procedure. `demo-ready.sh` resolves the newest release
+tag, refreshes the demo app only if it's stale or missing, always reseeds the 10 fixtures in
+`examples/demo-workspace/` into `~/Library/Application Support/Ghostties Demo/repos/<name>/` as
+real git repos, and points the demo app's `workspace.json` at those copies — not at this checkout,
+so the demo doesn't break when this repo changes branch.
+
+**Every capture run must copy the manifest** it writes at
+`~/Library/Application Support/Ghostties Demo/demo-manifest.json` alongside the produced assets —
+it's what lets a stale screenshot be traced back to the build that made it later.
 
 When loaded correctly you should see:
 - 10 named pixel-art ghosts in the project rail

--- a/examples/demo-workspace/README.md
+++ b/examples/demo-workspace/README.md
@@ -1,0 +1,66 @@
+# Demo Workspace
+
+Anonymized demo content for screen-recording, portfolio case studies, and social media promos. All project names, task titles, team references, and company names are fictional. Safe for public screenshots and video.
+
+## Projects
+
+Seven fictional projects across different domains:
+
+| Directory | Domain |
+|---|---|
+| `atlas-api/` | Backend API service |
+| `pendulum/` | Time-tracking mobile app |
+| `silo/` | File storage and sync tool |
+| `wren/` | Note-taking and writing app |
+| `switchboard/` | Developer dashboard / webhook tool |
+| `fieldwork/` | Location and field data capture app |
+| `trove/` | Personal knowledge base app |
+
+## How to load in Ghostties
+
+Ghostties discovers projects automatically. Any directory containing a `.ghostties/tasks/` subfolder is recognized as a project — no registration required.
+
+To load the demo workspace, open (or navigate to) each project folder in Ghostties:
+
+```
+examples/demo-workspace/atlas-api/
+examples/demo-workspace/pendulum/
+examples/demo-workspace/silo/
+examples/demo-workspace/wren/
+examples/demo-workspace/switchboard/
+examples/demo-workspace/fieldwork/
+examples/demo-workspace/trove/
+```
+
+Or open `examples/demo-workspace/` as a workspace root if Ghostties supports nested discovery from a parent.
+
+## What this enables
+
+| Capture moment | Coverage |
+|---|---|
+| Full ghost rail | 7 projects, each auto-assigned a named pixel-art ghost |
+| All six zones | Inbox, Backlog, Running, Needs You, Review, Graveyard all populated |
+| Terracotta Needs You cards | 4 tasks across 4 projects, each with a realistic blocking question |
+| Running tasks with branches | 5 tasks with `branch:`, `worktree:`, `files-staged:` fields |
+| Review tasks with PRs | 4 tasks with PR numbers, states, and URLs |
+| Mixed sources | Linear (`ATL-*`, `PND-*`, `SWB-*`, `TRV-*`, `FWK-*`, `SLO-*`, `WRN-*`), GitHub (`GH-*`), Shell |
+| Done / Graveyard | 4 completed tasks with timestamps |
+
+## Task count by zone
+
+| Zone | Count |
+|---|---|
+| Running | 5 |
+| Needs You | 4 |
+| Review | 4 |
+| Inbox | 3 |
+| Backlog | 2 |
+| Done / Graveyard | 4 |
+| **Total** | **22** |
+
+## Assumptions
+
+- Project discovery walks up from the opened directory, so each project folder must be opened individually if the app doesn't support recursive workspace scanning from a parent.
+- The `worktree:` paths use `~` expansion (`~/Code/<project>`). If the app resolves these, they point to non-existent directories — this is expected for a fixture.
+- PR URLs point to `github.com/example-org/*` which are fictional. These will 404 if opened in a browser.
+- All dates are in the April–June 2026 range.

--- a/examples/demo-workspace/README.md
+++ b/examples/demo-workspace/README.md
@@ -4,7 +4,7 @@ Anonymized demo content for screen-recording, portfolio case studies, and social
 
 ## Projects
 
-Seven fictional projects across different domains:
+Ten fictional projects across different domains:
 
 | Directory | Domain |
 |---|---|
@@ -15,30 +15,23 @@ Seven fictional projects across different domains:
 | `switchboard/` | Developer dashboard / webhook tool |
 | `fieldwork/` | Location and field data capture app |
 | `trove/` | Personal knowledge base app |
+| `brukas/` | Booking / quoting app |
+| `annotie/` | Document annotation and review tool |
+| `ghostties/` | Ghostties itself, dogfooded as a fixture |
 
 ## How to load in Ghostties
 
-Ghostties discovers projects automatically. Any directory containing a `.ghostties/tasks/` subfolder is recognized as a project — no registration required.
-
-To load the demo workspace, open (or navigate to) each project folder in Ghostties:
-
-```
-examples/demo-workspace/atlas-api/
-examples/demo-workspace/pendulum/
-examples/demo-workspace/silo/
-examples/demo-workspace/wren/
-examples/demo-workspace/switchboard/
-examples/demo-workspace/fieldwork/
-examples/demo-workspace/trove/
-```
-
-Or open `examples/demo-workspace/` as a workspace root if Ghostties supports nested discovery from a parent.
+These fixtures aren't opened directly from this checkout. `scripts/demo/seed-demo-workspace.sh`
+copies each one into `~/Library/Application Support/Ghostties Demo/repos/<name>/`, turns it into
+a real git repo, and points the demo app's `workspace.json` at those copies — so the demo doesn't
+depend on this checkout's branch. See `scripts/demo/README.md` for the full refresh + seed
+procedure.
 
 ## What this enables
 
 | Capture moment | Coverage |
 |---|---|
-| Full ghost rail | 7 projects, each auto-assigned a named pixel-art ghost |
+| Full ghost rail | 10 projects, each auto-assigned a named pixel-art ghost |
 | All six zones | Inbox, Backlog, Running, Needs You, Review, Graveyard all populated |
 | Terracotta Needs You cards | 4 tasks across 4 projects, each with a realistic blocking question |
 | Running tasks with branches | 5 tasks with `branch:`, `worktree:`, `files-staged:` fields |
@@ -60,7 +53,6 @@ Or open `examples/demo-workspace/` as a workspace root if Ghostties supports nes
 
 ## Assumptions
 
-- Project discovery walks up from the opened directory, so each project folder must be opened individually if the app doesn't support recursive workspace scanning from a parent.
 - The `worktree:` paths use `~` expansion (`~/Code/<project>`). If the app resolves these, they point to non-existent directories — this is expected for a fixture.
 - PR URLs point to `github.com/example-org/*` which are fictional. These will 404 if opened in a browser.
 - All dates are in the April–June 2026 range.

--- a/examples/demo-workspace/annotie/.ghostties/tasks/comment-thread-resolution.md
+++ b/examples/demo-workspace/annotie/.ghostties/tasks/comment-thread-resolution.md
@@ -1,0 +1,23 @@
+---
+title: "Add resolve/reopen flow for comment threads"
+status: running
+created: 2026-06-10T09:00:00Z
+project: annotie
+source: linear
+source-id: ANT-51
+priority: high
+branch: feat/comment-resolution
+worktree: ~/Code/annotie
+files-staged: 3
+---
+
+## Goal
+Let reviewers mark a comment thread as resolved so it collapses out of the active annotation list, with the option to reopen it if the concern resurfaces.
+
+## Notes
+Resolved threads still stored in the DB with `resolved_at` timestamp — never deleted. UI filters them to a "Resolved" section accessible via toggle. Resolving broadcasts a presence event so collaborators see the change without refresh. The annotation highlight for a resolved thread dims to 40% opacity in the viewer to signal it's been addressed.
+
+## Activity
+- 2026-06-10T09:00:00Z — DB schema updated: `resolved_at`, `resolved_by` columns on `comment_threads`
+- 2026-06-12T14:30:00Z — Resolve button implemented, presence event broadcasting
+- 2026-06-14T10:00:00Z — Highlight dimming on resolved threads applied in canvas layer

--- a/examples/demo-workspace/annotie/.ghostties/tasks/document-version-history.md
+++ b/examples/demo-workspace/annotie/.ghostties/tasks/document-version-history.md
@@ -1,0 +1,20 @@
+---
+title: "Surface document version history with annotation diffs"
+status: needs-you
+created: 2026-06-13T10:00:00Z
+project: annotie
+source: linear
+source-id: ANT-57
+priority: medium
+needs: "Should version history be tied to explicit saves (user clicks 'Save version') or automatic snapshots on a time interval? Explicit saves are less surprising but rely on users remembering to save; automatic snapshots are seamless but could create a lot of noise for active documents."
+---
+
+## Goal
+Let users browse previous versions of a document and see which annotations were added, modified, or resolved between versions — without losing the current state.
+
+## Notes
+Annotation store already writes immutable event records, so reconstructing historical state is feasible. The open question is what triggers a new version entry in the history index. Once that's settled, the diff view is a straightforward before/after comparison of annotation sets keyed by `annotation_id`.
+
+## Activity
+- 2026-06-13T10:00:00Z — Versioning approach designed; blocked on save-trigger decision
+- 2026-06-13T17:00:00Z — Mockups shared in Linear; both models mocked, awaiting product call

--- a/examples/demo-workspace/annotie/.ghostties/tasks/export-annotations-json.md
+++ b/examples/demo-workspace/annotie/.ghostties/tasks/export-annotations-json.md
@@ -1,0 +1,24 @@
+---
+title: "Export annotations as structured JSON for API consumers"
+status: review
+created: 2026-06-06T11:00:00Z
+project: annotie
+source: github
+source-id: GH-62
+priority: medium
+pr: 62
+pr-state: open
+pr-url: https://github.com/example-org/annotie/pull/62
+branch: feat/annotation-json-export
+---
+
+## Goal
+Expose a `/documents/:id/annotations/export` endpoint that returns all annotations for a document as a typed JSON payload — type, page, bounding box, text, author, timestamps — so external tools can consume Annotie data without screen-scraping.
+
+## Notes
+Schema versioned from the start (`"schema_version": "1"`) to leave room for breaking changes. Highlights carry the selected text if available. Bounding boxes are in normalized coordinates (0.0–1.0 relative to page dimensions) so they're zoom-independent. Author is returned as a public-profile object — no email addresses in the export.
+
+## Activity
+- 2026-06-06T11:00:00Z — Endpoint scaffolded, schema designed
+- 2026-06-09T14:00:00Z — All annotation types covered, tests written
+- 2026-06-11T10:30:00Z — Opened PR; added schema_version field after reviewer request

--- a/examples/demo-workspace/annotie/.ghostties/tasks/keyboard-annotation-shortcuts.md
+++ b/examples/demo-workspace/annotie/.ghostties/tasks/keyboard-annotation-shortcuts.md
@@ -1,0 +1,18 @@
+---
+title: "Add keyboard shortcuts for common annotation actions"
+status: backlog
+created: 2026-05-27T13:00:00Z
+project: annotie
+source: linear
+source-id: ANT-40
+priority: low
+---
+
+## Goal
+Let power users create highlights, underlines, and sticky notes without leaving the keyboard — improving review speed for documents with many annotations.
+
+## Notes
+Shortcut map: `H` = highlight selection, `U` = underline selection, `N` = add note at cursor, `Escape` = deselect / close annotation panel, `Enter` = submit comment. Needs to be inactive when focus is inside a text input. Conflict check against browser defaults required before finalizing the map.
+
+## Activity
+- 2026-05-27T13:00:00Z — Added to backlog after user research session flagged slow annotation flow for power users

--- a/examples/demo-workspace/annotie/.ghostties/tasks/mention-notifications.md
+++ b/examples/demo-workspace/annotie/.ghostties/tasks/mention-notifications.md
@@ -1,0 +1,17 @@
+---
+title: "Notify users when @mentioned in annotation comments"
+status: inbox
+created: 2026-06-17T11:00:00Z
+project: annotie
+source: shell
+priority: medium
+---
+
+## Goal
+Send an in-app and email notification when a user is @mentioned inside an annotation comment thread so reviewers don't miss direct questions buried in long documents.
+
+## Notes
+Not started. Mention parsing would extract `@username` tokens from comment text at save time. In-app notification via existing notification center. Email notification uses Resend with a 15-minute debounce to batch multiple mentions in the same session into one digest. Need to confirm whether workspace guests (view-only role) can be @mentioned.
+
+## Activity
+- 2026-06-17T11:00:00Z — Requested by three separate beta teams; added to inbox

--- a/examples/demo-workspace/annotie/.ghostties/tasks/pdf-annotation-layer.md
+++ b/examples/demo-workspace/annotie/.ghostties/tasks/pdf-annotation-layer.md
@@ -1,0 +1,26 @@
+---
+title: "Render annotation layer on top of PDF viewer"
+status: done
+created: 2026-05-02T10:00:00Z
+project: annotie
+source: linear
+source-id: ANT-29
+priority: high
+pr: 29
+pr-state: merged
+pr-url: https://github.com/example-org/annotie/pull/29
+completed: 2026-05-20T15:00:00Z
+updated: 2026-05-20T15:00:00Z
+---
+
+## Goal
+Overlay a transparent canvas on the PDF viewer so annotations (highlights, underlines, notes) composite correctly on top of the document without modifying the underlying PDF bytes.
+
+## Notes
+PDF rendered via pdf.js into a canvas element. Annotation layer is a second canvas positioned absolutely over it with `pointer-events: none` when not in edit mode. Z-index management was the main complexity — toolbar and annotation canvas needed separate stacking contexts. Hit-testing for selection uses the annotation store coordinates, not DOM events on the canvas.
+
+## Activity
+- 2026-05-02T10:00:00Z — Evaluated canvas vs. SVG overlay; canvas chosen for performance
+- 2026-05-08T13:00:00Z — Overlay positioning stable across zoom levels
+- 2026-05-14T11:00:00Z — Hit-testing implemented for annotation selection
+- 2026-05-20T15:00:00Z — Merged after final review on scroll position edge case

--- a/examples/demo-workspace/atlas-api/.ghostties/tasks/auth-interceptor.md
+++ b/examples/demo-workspace/atlas-api/.ghostties/tasks/auth-interceptor.md
@@ -1,0 +1,23 @@
+---
+title: "Wire token refresh interceptor"
+status: running
+created: 2026-05-14T09:00:00Z
+project: atlas-api
+source: linear
+source-id: ATL-28
+priority: high
+branch: feat/auth-interceptor
+worktree: ~/Code/atlas-api
+files-staged: 3
+---
+
+## Goal
+Implement an Axios interceptor that silently refreshes the access token on 401 responses and retries the original request with the new token.
+
+## Notes
+Using a request queue pattern to avoid parallel refresh calls racing each other. Interceptor lives in `src/api/interceptors/auth.ts`.
+
+## Activity
+- 2026-05-14T09:00:00Z — Scaffolded interceptor file, wired into Axios instance
+- 2026-05-15T10:30:00Z — Added queue drain logic for concurrent requests during refresh
+- 2026-05-16T14:12:00Z — Unit tests passing, integration test still flaky on fast refresh sequences

--- a/examples/demo-workspace/atlas-api/.ghostties/tasks/confirm-token-expiry.md
+++ b/examples/demo-workspace/atlas-api/.ghostties/tasks/confirm-token-expiry.md
@@ -1,0 +1,20 @@
+---
+title: "Confirm token expiry behavior with backend"
+status: needs-you
+created: 2026-05-14T09:22:00Z
+project: atlas-api
+source: linear
+source-id: ATL-31
+priority: high
+needs: "Do we silently refresh or force re-auth after 24h? Need to know before I wire the interceptor logic for long sessions."
+---
+
+## Goal
+Clarify token refresh strategy so the auth interceptor handles long-lived sessions correctly.
+
+## Notes
+Two options on the table: silent refresh via refresh token, or hard re-auth modal at expiry. Backend team needs to decide before I branch the interceptor logic.
+
+## Activity
+- 2026-05-14T09:22:00Z — Opened question with backend team in Slack
+- 2026-05-14T11:05:00Z — Blocked, awaiting response from @jared

--- a/examples/demo-workspace/atlas-api/.ghostties/tasks/openapi-codegen.md
+++ b/examples/demo-workspace/atlas-api/.ghostties/tasks/openapi-codegen.md
@@ -1,0 +1,18 @@
+---
+title: "Set up OpenAPI codegen pipeline"
+status: backlog
+created: 2026-04-30T08:00:00Z
+project: atlas-api
+source: linear
+source-id: ATL-19
+priority: medium
+---
+
+## Goal
+Automate TypeScript type generation from the OpenAPI spec so the SDK stays in sync with the server contract without manual updates.
+
+## Notes
+Evaluating `openapi-typescript` vs `orval`. Need to decide whether to check in generated files or gitignore and generate on `postinstall`.
+
+## Activity
+- 2026-04-30T08:00:00Z — Added to backlog after v1 type drift caused a prod incident

--- a/examples/demo-workspace/atlas-api/.ghostties/tasks/rate-limit-headers.md
+++ b/examples/demo-workspace/atlas-api/.ghostties/tasks/rate-limit-headers.md
@@ -1,0 +1,24 @@
+---
+title: "Parse and expose rate-limit headers"
+status: review
+created: 2026-05-18T11:00:00Z
+project: atlas-api
+source: github
+source-id: GH-47
+priority: medium
+pr: 47
+pr-state: open
+pr-url: https://github.com/example-org/atlas-api/pull/47
+branch: feat/rate-limit-headers
+---
+
+## Goal
+Read `X-RateLimit-Remaining` and `X-RateLimit-Reset` from API responses and surface them through the SDK client so callers can implement backoff logic.
+
+## Notes
+Headers are inconsistently named across v1 and v2 endpoints. Added a normalization layer in the response transformer. PR includes regression tests for both versions.
+
+## Activity
+- 2026-05-18T11:00:00Z — Implemented header parsing in response transformer
+- 2026-05-19T09:45:00Z — Added tests, opened PR
+- 2026-05-20T10:10:00Z — Addressed review comment on null handling when headers are absent

--- a/examples/demo-workspace/brukas/.ghostties/tasks/booking-confirmation-email.md
+++ b/examples/demo-workspace/brukas/.ghostties/tasks/booking-confirmation-email.md
@@ -1,0 +1,26 @@
+---
+title: "Send booking confirmation emails with job summary"
+status: done
+created: 2026-05-14T09:00:00Z
+project: brukas
+source: linear
+source-id: BRK-44
+priority: high
+pr: 44
+pr-state: merged
+pr-url: https://github.com/example-org/brukas/pull/44
+completed: 2026-05-28T16:00:00Z
+updated: 2026-05-28T16:00:00Z
+---
+
+## Goal
+Trigger a transactional email to the customer immediately after a booking is confirmed, including job date, time window, assigned technician, and total quote.
+
+## Notes
+Built with Resend. Template uses React Email components so the markup stays maintainable. Technician headshot is pulled from the staff profile if one exists; falls back to a generic avatar. Unsubscribe link is required for CAN-SPAM — routed through a preference page, not a one-click pixel.
+
+## Activity
+- 2026-05-14T09:00:00Z — Scaffolded Resend integration and React Email template
+- 2026-05-19T13:00:00Z — Added technician photo fallback logic
+- 2026-05-23T10:30:00Z — Preference center wired, unsubscribe tested
+- 2026-05-28T16:00:00Z — Merged and verified in production send

--- a/examples/demo-workspace/brukas/.ghostties/tasks/cancellation-policy-enforcement.md
+++ b/examples/demo-workspace/brukas/.ghostties/tasks/cancellation-policy-enforcement.md
@@ -1,0 +1,20 @@
+---
+title: "Enforce 24-hour cancellation policy with partial refund"
+status: needs-you
+created: 2026-06-14T09:00:00Z
+project: brukas
+source: linear
+source-id: BRK-67
+priority: high
+needs: "Should the 24-hour window be measured from job start time or from when the booking was originally confirmed? Late-confirmed bookings (e.g. same-day emergency slots) create an edge case where the customer immediately falls inside the no-refund window."
+---
+
+## Goal
+Block full refunds for cancellations made fewer than 24 hours before the scheduled job start, and issue a 50% partial refund through Stripe instead.
+
+## Notes
+Stripe refund API is straightforward. The tricky part is the edge case around same-day bookings confirmed within the cancellation window — need a product decision before implementing the time comparison logic. Refund receipts should be sent automatically via the existing Resend integration.
+
+## Activity
+- 2026-06-14T09:00:00Z — Cancellation route exists but currently issues full refunds unconditionally
+- 2026-06-14T16:00:00Z — Blocked on window-measurement question for same-day bookings

--- a/examples/demo-workspace/brukas/.ghostties/tasks/quote-pdf-export.md
+++ b/examples/demo-workspace/brukas/.ghostties/tasks/quote-pdf-export.md
@@ -1,0 +1,25 @@
+---
+title: "Generate downloadable PDF quote for customers"
+status: review
+created: 2026-06-05T10:00:00Z
+project: brukas
+source: github
+source-id: GH-58
+priority: medium
+pr: 58
+pr-state: open
+pr-url: https://github.com/example-org/brukas/pull/58
+branch: feat/quote-pdf
+---
+
+## Goal
+Let customers download a branded PDF of their quote from the booking detail page so they can share it with a landlord or file it for reimbursement.
+
+## Notes
+Using `@react-pdf/renderer` server-side to keep fonts consistent. PDF includes company logo, line-item breakdown, labor and materials subtotals, tax, and a "valid for 30 days" footer. Quote number is stamped at generation time and stored on the `quotes` table for audit trail. Font licensing checked — Inter is OFL licensed, safe to embed.
+
+## Activity
+- 2026-06-05T10:00:00Z — PDF template built, line items rendering correctly
+- 2026-06-09T13:30:00Z — Logo embedding resolved (was encoding as base64 inline)
+- 2026-06-12T11:00:00Z — Opened PR, screenshots of generated PDF in description
+- 2026-06-13T15:00:00Z — Addressed review comment on tax line formatting

--- a/examples/demo-workspace/brukas/.ghostties/tasks/repeat-customer-discount.md
+++ b/examples/demo-workspace/brukas/.ghostties/tasks/repeat-customer-discount.md
@@ -1,0 +1,17 @@
+---
+title: "Apply automatic discount for returning customers"
+status: inbox
+created: 2026-06-16T14:00:00Z
+project: brukas
+source: shell
+priority: low
+---
+
+## Goal
+Automatically apply a 10% loyalty discount on the second and subsequent bookings for a returning customer account.
+
+## Notes
+Not started. Would check `bookings` count for the customer's account at quote time. Discount displayed as a line item on the quote and receipt. Need to confirm whether the discount stacks with any promo codes or is mutually exclusive.
+
+## Activity
+- 2026-06-16T14:00:00Z — Raised by ops team after customer feedback; added to inbox for triage

--- a/examples/demo-workspace/brukas/.ghostties/tasks/service-area-radius-check.md
+++ b/examples/demo-workspace/brukas/.ghostties/tasks/service-area-radius-check.md
@@ -1,0 +1,18 @@
+---
+title: "Validate customer address against service area radius"
+status: backlog
+created: 2026-05-20T11:00:00Z
+project: brukas
+source: linear
+source-id: BRK-52
+priority: medium
+---
+
+## Goal
+Block booking attempts from addresses outside the configured service radius so dispatch doesn't get requests they can't fulfill.
+
+## Notes
+Each franchisee has a center lat/lng and radius in miles stored in `service_areas`. Haversine calculation on the server at quote-request time. Error state returns a user-friendly "We don't serve your area yet" message with a mailing-list signup. Edge case: customers on the exact boundary — round down (exclude) to keep dispatch manageable.
+
+## Activity
+- 2026-05-20T11:00:00Z — Added to backlog after multiple out-of-area bookings slipped through

--- a/examples/demo-workspace/brukas/.ghostties/tasks/technician-schedule-view.md
+++ b/examples/demo-workspace/brukas/.ghostties/tasks/technician-schedule-view.md
@@ -1,0 +1,23 @@
+---
+title: "Build technician day-view schedule screen"
+status: running
+created: 2026-06-09T08:30:00Z
+project: brukas
+source: linear
+source-id: BRK-61
+priority: high
+branch: feat/tech-schedule-view
+worktree: ~/Code/brukas
+files-staged: 4
+---
+
+## Goal
+Give technicians a native mobile screen showing their jobs for the day — time slots, customer address, job type, and a one-tap nav button — so they don't need to call dispatch for their schedule.
+
+## Notes
+Timeline component renders 30-minute slots from 7am–7pm. Jobs snap to their start time and show duration as a colored block. Color encodes job category (plumbing = blue, electrical = orange, general = gray). Pulling schedule data from the existing `bookings` table filtered by `assigned_tech_id` and `date`. Conflict detection (overlapping jobs) will be a follow-up; out of scope here.
+
+## Activity
+- 2026-06-09T08:30:00Z — Timeline component scaffolded in React Native
+- 2026-06-11T14:00:00Z — Job blocks rendering, category colors applied
+- 2026-06-13T09:45:00Z — Nav deeplink to Apple Maps working on device

--- a/examples/demo-workspace/choreograph.sh
+++ b/examples/demo-workspace/choreograph.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# =============================================================================
+# choreograph.sh — Ghostties Demo Sidebar Choreography
+# =============================================================================
+#
+# Drives the demo task fixtures through a lifecycle sequence so the live
+# Ghostties sidebar animates cards between zones. Designed for screen recording.
+#
+# HARD RULE: This script NEVER captures the screen. Recording is separate —
+# use Cmd-Shift-5 in macOS to record, then stop your recording before pressing
+# Enter when prompted. This script only mutates fixture Markdown files.
+#
+# MODES:
+#   ./choreograph.sh              — Live mode. Real hold times. Waits for Enter
+#                                   before restoring so you can stop recording.
+#   ./choreograph.sh --dry-run    — Verification mode. Short holds (0.3s).
+#                                   Prints a labeled lane snapshot after each
+#                                   beat. Restores fixture at the end.
+#   ./choreograph.sh --restore    — Emergency reset. Reverts the switchboard
+#                                   tasks dir to its committed git state.
+#
+# EDITING THE BEAT SEQUENCE:
+#   Beats are defined in the BEATS array near the bottom of this file.
+#   Each beat is a colon-separated record:
+#     BEAT_TYPE:LABEL:HOLD_SECONDS:EXTRA_ARGS
+#   Types:
+#     hold          — pause only; no file mutations
+#     create        — write a new task file (EXTRA_ARGS = filename without .md)
+#     set_status    — rewrite status: field  (EXTRA_ARGS = filename:new_status)
+#
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# PATHS
+# =============================================================================
+
+REPO_ROOT="/Users/seansmith/Code/ghostties"
+TASKS_DIR="${REPO_ROOT}/examples/demo-workspace/switchboard/.ghostties/tasks"
+GT_BIN="${REPO_ROOT}/cli/.build/release/gt"
+SWITCHBOARD_DIR="${REPO_ROOT}/examples/demo-workspace/switchboard"
+
+# =============================================================================
+# BEAT SEQUENCE CONFIGURATION
+# =============================================================================
+#
+# Format per entry:  "TYPE:LABEL:HOLD_SECONDS:EXTRA"
+#
+#   hold        "hold:Rest label:SECONDS:"
+#   create      "create:Label:SECONDS:FILENAME_WITHOUT_EXTENSION"
+#   set_status  "set_status:Label:SECONDS:FILENAME_WITHOUT_EXTENSION:NEW_STATUS"
+#
+# HOLDS: real-time durations used in live mode.
+# In --dry-run mode all holds are replaced with 0.3s.
+#
+# Keep webhook-signature-verify in `running` throughout (never touch it) so
+# the Running lane stays populated even while the new task travels through lanes.
+
+BEATS=(
+  "hold:Rest — all six lanes populated:2.0:"
+  "create:New task lands in Inbox:2.0:oauth-scope-validation"
+  "set_status:Agent starts work (Inbox → Running):2.5:oauth-scope-validation:running"
+  "set_status:Agent is blocked — needs you (terracotta):3.0:oauth-scope-validation:needs-you"
+  "hold:Settle — Needs You lane showing both blocked tasks:2.0:"
+)
+
+# =============================================================================
+# DRY-RUN HOLD OVERRIDE (seconds)
+# =============================================================================
+
+DRY_RUN_HOLD="0.3"
+
+# =============================================================================
+# SNAPSHOT / RESTORE HELPERS
+# =============================================================================
+
+SNAPSHOT_DIR=""
+
+snapshot_tasks() {
+  SNAPSHOT_DIR="$(mktemp -d)"
+  cp -R "${TASKS_DIR}/." "${SNAPSHOT_DIR}/"
+  echo "[choreograph] Snapshot saved to ${SNAPSHOT_DIR}"
+}
+
+restore_from_snapshot() {
+  if [[ -z "${SNAPSHOT_DIR}" || ! -d "${SNAPSHOT_DIR}" ]]; then
+    return
+  fi
+  echo ""
+  echo "[choreograph] Restoring fixture from snapshot…"
+  # Remove all current files in the tasks dir and copy the snapshot back
+  find "${TASKS_DIR}" -mindepth 1 -maxdepth 1 -delete
+  cp -R "${SNAPSHOT_DIR}/." "${TASKS_DIR}/"
+  echo "[choreograph] Fixture restored."
+}
+
+restore_from_git() {
+  echo "[choreograph] Restoring switchboard tasks from git…"
+  git -C "${REPO_ROOT}" checkout -- "examples/demo-workspace/switchboard/.ghostties/tasks/"
+  git -C "${REPO_ROOT}" clean -fd "examples/demo-workspace/switchboard/.ghostties/tasks/" > /dev/null
+  echo "[choreograph] Restore complete."
+}
+
+# =============================================================================
+# FILE MUTATION HELPERS
+# =============================================================================
+
+set_status() {
+  local filename="$1"   # without .md
+  local new_status="$2"
+  local filepath="${TASKS_DIR}/${filename}.md"
+
+  if [[ ! -f "${filepath}" ]]; then
+    echo "[choreograph] ERROR: File not found: ${filepath}" >&2
+    return 1
+  fi
+
+  # BSD sed (macOS): in-place replacement, no backup
+  sed -i '' -E "s/^status:.*/status: ${new_status}/" "${filepath}"
+}
+
+create_oauth_scope_validation() {
+  local filepath="${TASKS_DIR}/oauth-scope-validation.md"
+  cat > "${filepath}" <<'TASKEOF'
+---
+title: "Add OAuth scope validation to webhook registration API"
+status: inbox
+created: 2026-06-12T09:00:00Z
+project: switchboard
+source: github
+source-id: GH-79
+priority: medium
+branch: feat/oauth-scope-validation
+worktree: ~/Code/switchboard
+---
+
+## Goal
+Validate that the OAuth token used when registering a new webhook endpoint carries the required `webhooks:write` scope. Reject registrations with insufficient permissions before the endpoint is persisted, returning a 403 with a descriptive error body.
+
+## Notes
+Current registration handler checks token validity (expiry, signature) but skips scope inspection entirely. The scope claim lives in the JWT payload as `scope` (space-delimited string). Need a scope-parser utility and a middleware layer so the check is reusable by future permission-gated routes. Token refresh flow is out of scope — callers with expired tokens get a 401 via the existing auth middleware.
+
+## Activity
+- 2026-06-12T09:00:00Z — Discovered gap during security review of webhook registration endpoint
+TASKEOF
+}
+
+# =============================================================================
+# GT SNAPSHOT DISPLAY
+# =============================================================================
+
+print_lane_snapshot() {
+  local label="$1"
+
+  # Run gt list from the switchboard project dir (it walks up to find .ghostties/tasks/)
+  local gt_output
+  gt_output="$(cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list 2>/dev/null)" || true
+
+  echo ""
+  echo "  ┌─────────────────────────────────────────────────────────────────────┐"
+  printf  "  │ %-69s │\n" "${label}"
+  echo "  ├──────────────┬──────────────────────────────────────────────────────┤"
+
+  # Build one variable per lane using awk (bash 3.2-safe, no associative arrays)
+  local lane_inbox lane_backlog lane_running lane_needs_you lane_review lane_graveyard
+  lane_inbox=""
+  lane_backlog=""
+  lane_running=""
+  lane_needs_you=""
+  lane_review=""
+  lane_graveyard=""
+
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    # gt list columns: SOURCE-ID   STATUS   TITLE   [project: ...]
+    local id task_status
+    id="$(echo "${line}" | awk '{print $1}')"
+    task_status="$(echo "${line}" | awk '{print $2}')"
+
+    case "${task_status}" in
+      inbox)
+        lane_inbox="${lane_inbox:+${lane_inbox}, }${id}" ;;
+      backlog)
+        lane_backlog="${lane_backlog:+${lane_backlog}, }${id}" ;;
+      running)
+        lane_running="${lane_running:+${lane_running}, }${id}" ;;
+      needs-you)
+        lane_needs_you="${lane_needs_you:+${lane_needs_you}, }${id}" ;;
+      review)
+        lane_review="${lane_review:+${lane_review}, }${id}" ;;
+      graveyard)
+        lane_graveyard="${lane_graveyard:+${lane_graveyard}, }${id}" ;;
+    esac
+  done <<< "${gt_output}"
+
+  printf "  │ %-12s │ %-54s │\n" "inbox"     "${lane_inbox}"
+  printf "  │ %-12s │ %-54s │\n" "backlog"   "${lane_backlog}"
+  printf "  │ %-12s │ %-54s │\n" "running"   "${lane_running}"
+  printf "  │ %-12s │ %-54s │\n" "needs-you" "${lane_needs_you}"
+  printf "  │ %-12s │ %-54s │\n" "review"    "${lane_review}"
+  printf "  │ %-12s │ %-54s │\n" "graveyard" "${lane_graveyard}"
+
+  echo "  └──────────────┴──────────────────────────────────────────────────────┘"
+  echo ""
+}
+
+# =============================================================================
+# BEAT EXECUTION
+# =============================================================================
+
+run_beats() {
+  local is_dry_run="$1"  # "true" or "false"
+
+  for beat in "${BEATS[@]}"; do
+    # Parse the colon-delimited beat record
+    local beat_type label hold_secs extra
+    beat_type="${beat%%:*}"
+    local rest="${beat#*:}"
+    label="${rest%%:*}"
+    rest="${rest#*:}"
+    hold_secs="${rest%%:*}"
+    extra="${rest#*:}"
+
+    # In dry-run mode, override hold with the short dry-run hold
+    local effective_hold="${hold_secs}"
+    if [[ "${is_dry_run}" == "true" ]]; then
+      effective_hold="${DRY_RUN_HOLD}"
+    fi
+
+    # Print the beat label
+    echo ""
+    echo ">>> BEAT: ${label}"
+
+    # Execute the beat action
+    case "${beat_type}" in
+      hold)
+        # No file mutation — just hold
+        ;;
+
+      create)
+        local filename="${extra}"
+        case "${filename}" in
+          oauth-scope-validation)
+            create_oauth_scope_validation
+            echo "    Created ${filename}.md (status: inbox)"
+            ;;
+          *)
+            echo "[choreograph] ERROR: Unknown create target: ${filename}" >&2
+            return 1
+            ;;
+        esac
+        ;;
+
+      set_status)
+        # extra format: "FILENAME:NEW_STATUS"
+        local fname nstatus
+        fname="${extra%%:*}"
+        nstatus="${extra#*:}"
+        set_status "${fname}" "${nstatus}"
+        echo "    Set ${fname}.md → status: ${nstatus}"
+        ;;
+
+      *)
+        echo "[choreograph] ERROR: Unknown beat type: ${beat_type}" >&2
+        return 1
+        ;;
+    esac
+
+    # In dry-run mode, print the lane snapshot after each beat
+    if [[ "${is_dry_run}" == "true" ]]; then
+      print_lane_snapshot "${label}"
+    fi
+
+    # Hold
+    sleep "${effective_hold}"
+  done
+}
+
+# =============================================================================
+# MODES
+# =============================================================================
+
+mode_restore() {
+  restore_from_git
+  echo "[choreograph] Done. Switchboard tasks dir is clean."
+}
+
+mode_dry_run() {
+  # Guard: make sure required paths exist
+  if [[ ! -d "${TASKS_DIR}" ]]; then
+    echo "[choreograph] ERROR: Tasks dir not found: ${TASKS_DIR}" >&2
+    exit 1
+  fi
+  if [[ ! -x "${GT_BIN}" ]]; then
+    echo "[choreograph] ERROR: gt binary not found or not executable: ${GT_BIN}" >&2
+    exit 1
+  fi
+
+  echo "[choreograph] DRY-RUN mode — holds are ${DRY_RUN_HOLD}s, fixture will be restored at exit."
+  snapshot_tasks
+
+  # Always restore on exit (handles Ctrl-C too)
+  trap restore_from_snapshot EXIT
+
+  run_beats "true"
+
+  echo ""
+  echo "========================================================================="
+  echo "  PASS — All beats completed. Fixture will be restored on exit."
+  echo "========================================================================="
+}
+
+mode_live() {
+  # Guard: make sure required paths exist
+  if [[ ! -d "${TASKS_DIR}" ]]; then
+    echo "[choreograph] ERROR: Tasks dir not found: ${TASKS_DIR}" >&2
+    exit 1
+  fi
+  if [[ ! -x "${GT_BIN}" ]]; then
+    echo "[choreograph] ERROR: gt binary not found or not executable: ${GT_BIN}" >&2
+    exit 1
+  fi
+
+  echo "[choreograph] LIVE mode — real hold times, recording-ready."
+  echo "[choreograph] Start your screen recording NOW (Cmd-Shift-5), then the beats begin."
+  echo ""
+  echo "         REMEMBER: This script does not capture the screen."
+  echo "         Use Cmd-Shift-5 to record. Stop your recording before"
+  echo "         pressing Enter at the end of the sequence."
+  echo ""
+  sleep 1
+
+  snapshot_tasks
+
+  # Always restore on exit (handles Ctrl-C too)
+  trap restore_from_snapshot EXIT
+
+  run_beats "false"
+
+  echo ""
+  echo "========================================================================="
+  echo "  All beats complete. The fixture is LIVE at its final state."
+  echo "  Stop your screen recording now (Cmd-Shift-5 > Stop), then press Enter."
+  echo "========================================================================="
+  read -r -p "  > Press Enter to restore fixture and exit: "
+}
+
+# =============================================================================
+# ENTRY POINT
+# =============================================================================
+
+MODE="${1:-}"
+
+case "${MODE}" in
+  --dry-run)
+    mode_dry_run
+    ;;
+  --restore)
+    mode_restore
+    ;;
+  "")
+    mode_live
+    ;;
+  *)
+    echo "[choreograph] Unknown flag: ${MODE}" >&2
+    echo "Usage: $0 [--dry-run | --restore]" >&2
+    exit 1
+    ;;
+esac

--- a/examples/demo-workspace/fieldwork/.ghostties/tasks/form-schema-versioning.md
+++ b/examples/demo-workspace/fieldwork/.ghostties/tasks/form-schema-versioning.md
@@ -1,0 +1,17 @@
+---
+title: "Form schema versioning for offline installs"
+status: inbox
+created: 2026-06-08T09:00:00Z
+project: fieldwork
+source: shell
+priority: low
+---
+
+## Goal
+When a form schema is updated on the server, devices running the old schema offline should still be able to submit. Need a migration path for in-flight submissions.
+
+## Notes
+Not started. Complex problem — need to decide whether to version submissions with the schema they were captured on, or block submission until schema is updated.
+
+## Activity
+- 2026-06-08T09:00:00Z — Flagged as risk during sprint planning; parked in inbox for now

--- a/examples/demo-workspace/fieldwork/.ghostties/tasks/gps-accuracy-threshold.md
+++ b/examples/demo-workspace/fieldwork/.ghostties/tasks/gps-accuracy-threshold.md
@@ -1,0 +1,20 @@
+---
+title: "Confirm GPS accuracy threshold for field capture"
+status: needs-you
+created: 2026-05-12T10:00:00Z
+project: fieldwork
+source: linear
+source-id: FWK-45
+priority: high
+needs: "What horizontal accuracy threshold should we require before accepting a GPS fix? Options: 5m (strict, slower), 20m (fast, good enough for most field use), or user-configurable. This gates the capture button UI state."
+---
+
+## Goal
+Set the minimum acceptable horizontal accuracy for a GPS fix before allowing a location-tagged form submission.
+
+## Notes
+High-accuracy mode burns battery but is critical for surveying workflows. Lower threshold makes the app faster in urban canyons. Some customers do rough-proximity tagging, others need sub-10m. Might need per-form-type config.
+
+## Activity
+- 2026-05-12T10:00:00Z — Surfaced to product lead; blocked
+- 2026-05-13T09:00:00Z — Added fallback to manual coordinate entry as stop-gap

--- a/examples/demo-workspace/fieldwork/.ghostties/tasks/offline-form-queue.md
+++ b/examples/demo-workspace/fieldwork/.ghostties/tasks/offline-form-queue.md
@@ -1,0 +1,23 @@
+---
+title: "Offline form submission queue"
+status: running
+created: 2026-05-05T08:00:00Z
+project: fieldwork
+source: linear
+source-id: FWK-39
+priority: high
+branch: feat/offline-queue
+worktree: ~/Code/fieldwork
+files-staged: 6
+---
+
+## Goal
+Queue form submissions locally when the device has no connectivity and sync them to the server when a connection is restored.
+
+## Notes
+Using SQLite as the local queue store. NetworkMonitor watches reachability via NWPathMonitor. On reconnect, submissions drain in FIFO order with retry on 5xx. Conflict detection needed for forms that reference server-side IDs.
+
+## Activity
+- 2026-05-05T08:00:00Z — Local queue store scaffolded with SQLite
+- 2026-05-07T11:00:00Z — NWPathMonitor integration done, queue drains on reconnect
+- 2026-05-09T15:00:00Z — Testing conflict edge case: form references deleted resource on server

--- a/examples/demo-workspace/fieldwork/.ghostties/tasks/photo-compression-pipeline.md
+++ b/examples/demo-workspace/fieldwork/.ghostties/tasks/photo-compression-pipeline.md
@@ -1,0 +1,24 @@
+---
+title: "Photo compression pipeline for field uploads"
+status: review
+created: 2026-05-25T09:00:00Z
+project: fieldwork
+source: github
+source-id: GH-73
+priority: medium
+pr: 73
+pr-state: open
+pr-url: https://github.com/example-org/fieldwork/pull/73
+branch: feat/photo-compress
+---
+
+## Goal
+Compress and resize photos captured in the field before upload to reduce data usage on LTE connections and speed up sync.
+
+## Notes
+Targeting 1200px max dimension at 0.82 JPEG quality. Using `ImageIO` framework for lossless metadata (EXIF, GPS tags) preservation. Thumbnails generated at 256px for the form preview.
+
+## Activity
+- 2026-05-25T09:00:00Z — Implemented compression pipeline using ImageIO
+- 2026-05-27T11:00:00Z — PR opened, 87% reduction in average upload size
+- 2026-05-29T10:00:00Z — Reviewer asked about HEIC support — added HEIC input path

--- a/examples/demo-workspace/fieldwork/src/offlineQueue.ts
+++ b/examples/demo-workspace/fieldwork/src/offlineQueue.ts
@@ -1,0 +1,227 @@
+/**
+ * Fieldwork — Offline Form Submission Queue
+ *
+ * Buffers form submissions locally when the device has no connectivity
+ * and drains them to the server in FIFO order once a connection is restored.
+ */
+
+export interface FormSubmission {
+  formId: string;
+  schemaVersion: number;
+  respondentId: string;
+  fields: Record<string, unknown>;
+  gpsCoordinates?: { lat: number; lng: number; accuracyMeters: number };
+  capturedAt: string; // ISO-8601
+}
+
+export interface QueuedSubmission {
+  id: string;
+  submission: FormSubmission;
+  enqueuedAt: string; // ISO-8601
+  attempts: number;
+  lastError?: string;
+}
+
+/** A submission that exhausted its retries (or was rejected outright). */
+export interface DeadLetteredSubmission extends QueuedSubmission {
+  deadLetteredAt: string; // ISO-8601
+  reason: string;
+}
+
+/** Minimal persistence contract — swap in SQLite, AsyncStorage, etc. */
+export interface QueueStore {
+  load(): Promise<QueuedSubmission[]>;
+  save(items: QueuedSubmission[]): Promise<void>;
+  /** Optional: persist the dead-letter bucket. In-memory only if omitted. */
+  loadDeadLetters?(): Promise<DeadLetteredSubmission[]>;
+  saveDeadLetters?(items: DeadLetteredSubmission[]): Promise<void>;
+}
+
+export interface RetryOptions {
+  /** Max delivery attempts per item before it is dead-lettered. */
+  maxAttempts: number;
+  /** First retry delay; doubles on each subsequent retry (1s, 2s, 4s, 8s…). */
+  baseDelayMs: number;
+  /** Ceiling on any single retry delay. */
+  maxDelayMs: number;
+}
+
+const defaultRetryOptions: RetryOptions = {
+  maxAttempts: 5,
+  baseDelayMs: 1_000,
+  maxDelayMs: 30_000,
+};
+
+/** No-op store used in tests and until a real store is injected. */
+const noopStore: QueueStore = {
+  async load() {
+    return [];
+  },
+  async save(_items) {
+    /* noop */
+  },
+};
+
+const sleep = (ms: number) =>
+  ms > 0
+    ? new Promise<void>((resolve) => setTimeout(resolve, ms))
+    : Promise.resolve();
+
+/** Outcome of trying to deliver one item, including retries. */
+type DeliveryOutcome = "delivered" | "dead" | "offline";
+
+export class OfflineQueue {
+  private items: QueuedSubmission[] = [];
+  private deadLetters: DeadLetteredSubmission[] = [];
+  private store: QueueStore;
+  private endpoint: string;
+  private retry: RetryOptions;
+
+  constructor(
+    endpoint: string,
+    store: QueueStore = noopStore,
+    retry: Partial<RetryOptions> = {},
+  ) {
+    this.endpoint = endpoint;
+    this.store = store;
+    this.retry = { ...defaultRetryOptions, ...retry };
+  }
+
+  /** Restore persisted queue from the store (call on app launch). */
+  async hydrate(): Promise<void> {
+    this.items = await this.store.load();
+    this.deadLetters = (await this.store.loadDeadLetters?.()) ?? [];
+  }
+
+  /** Add a new submission to the tail of the queue and persist immediately. */
+  async enqueue(submission: FormSubmission): Promise<void> {
+    const queued: QueuedSubmission = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      submission,
+      enqueuedAt: new Date().toISOString(),
+      attempts: 0,
+    };
+    this.items.push(queued);
+    await this.store.save(this.items);
+  }
+
+  /** How many submissions are waiting to be flushed. */
+  get size(): number {
+    return this.items.length;
+  }
+
+  /** Submissions that exhausted retries or were rejected by the server. */
+  get deadLettered(): readonly DeadLetteredSubmission[] {
+    return this.deadLetters;
+  }
+
+  /**
+   * Drain the queue. Posts each queued submission to the server in FIFO order.
+   *
+   * Failed POSTs are retried with exponential backoff (baseDelayMs doubling
+   * per attempt, capped at maxDelayMs) up to maxAttempts:
+   * - 2xx           → delivered, removed from the queue.
+   * - 4xx           → dead-lettered immediately (the payload is bad; retrying
+   *                   cannot fix it).
+   * - 5xx           → retried; dead-lettered once attempts are exhausted.
+   * - network error → retried; if attempts are exhausted the device is
+   *                   presumed offline, so the item stays queued and the
+   *                   flush stops. Nothing is dead-lettered for lost
+   *                   connectivity — the next reconnect flushes it again.
+   *
+   * The queue is persisted after every item so a crash mid-flush cannot
+   * lose state.
+   */
+  async flush(): Promise<{
+    delivered: number;
+    failed: number;
+    deadLettered: number;
+  }> {
+    let delivered = 0;
+    let deadLettered = 0;
+
+    while (this.items.length > 0) {
+      const item = this.items[0];
+      const outcome = await this.deliverWithRetry(item);
+
+      if (outcome === "offline") {
+        // Connectivity is gone — keep this item and everything behind it.
+        await this.store.save(this.items);
+        break;
+      }
+
+      this.items.shift();
+      if (outcome === "delivered") {
+        delivered++;
+      } else {
+        deadLettered++;
+        this.deadLetters.push({
+          ...item,
+          deadLetteredAt: new Date().toISOString(),
+          reason: item.lastError ?? "unknown",
+        });
+        await this.store.saveDeadLetters?.(this.deadLetters);
+      }
+      await this.store.save(this.items);
+    }
+
+    return { delivered, failed: this.items.length, deadLettered };
+  }
+
+  /**
+   * Attempt to POST one item, retrying with exponential backoff until it
+   * succeeds, is deemed undeliverable, or the device appears to be offline.
+   */
+  private async deliverWithRetry(
+    item: QueuedSubmission,
+  ): Promise<DeliveryOutcome> {
+    while (true) {
+      item.attempts++;
+      let response: Response;
+
+      try {
+        response = await fetch(this.endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(item.submission),
+        });
+      } catch (err) {
+        // Network error — likely offline rather than a bad submission.
+        item.lastError = err instanceof Error ? err.message : String(err);
+        if (item.attempts >= this.retry.maxAttempts) {
+          // Reset so the next reconnect gets a full retry budget.
+          item.attempts = 0;
+          return "offline";
+        }
+        await sleep(this.backoffDelay(item.attempts));
+        continue;
+      }
+
+      if (response.ok) {
+        return "delivered";
+      }
+
+      item.lastError = `HTTP ${response.status}`;
+
+      if (response.status >= 500) {
+        // Server error — transient, worth retrying.
+        if (item.attempts >= this.retry.maxAttempts) {
+          return "dead";
+        }
+        await sleep(this.backoffDelay(item.attempts));
+        continue;
+      }
+
+      // 4xx — the server understood and rejected it; retrying cannot help.
+      return "dead";
+    }
+  }
+
+  /** Delay before retry N (1-based): base × 2^(N−1), capped at maxDelayMs. */
+  private backoffDelay(attempt: number): number {
+    return Math.min(
+      this.retry.baseDelayMs * 2 ** (attempt - 1),
+      this.retry.maxDelayMs,
+    );
+  }
+}

--- a/examples/demo-workspace/ghostties/.ghostties/tasks/menu-bar-status-item.md
+++ b/examples/demo-workspace/ghostties/.ghostties/tasks/menu-bar-status-item.md
@@ -1,0 +1,25 @@
+---
+title: "Add live agent-count badge to the menu bar status item"
+status: running
+created: 2026-08-10T09:00:00Z
+project: ghostties
+source: linear
+source-id: GHT-41
+priority: medium
+branch: feat/menubar-status-badge
+worktree: ~/Code/ghostties
+files-staged: 3
+---
+
+## Goal
+Show a small count badge on the menu bar status item for sessions currently
+in a "needs you" state, so the signal is visible without opening the window.
+
+## Notes
+Badge should clear itself the moment the underlying session's indicator
+state changes away from `.waiting`. Avoid polling — hook into the existing
+`@Published` session state instead.
+
+## Activity
+- 2026-08-10T09:00:00Z — Scaffolded MenuBarController
+- 2026-08-14T15:00:00Z — Badge renders, count updates on state change

--- a/examples/demo-workspace/ghostties/.ghostties/tasks/preset-picker-search.md
+++ b/examples/demo-workspace/ghostties/.ghostties/tasks/preset-picker-search.md
@@ -1,0 +1,25 @@
+---
+title: "Add fuzzy search to the session template picker"
+status: needs-you
+created: 2026-08-20T12:00:00Z
+project: ghostties
+source: github
+source-id: GH-152
+priority: medium
+pr: 152
+pr-state: open
+pr-url: https://github.com/example-org/ghostties/pull/152
+---
+
+## Goal
+Template picker popover lists presets alphabetically; needs a search field
+for users with more than ~10 saved templates.
+
+## Blocking question
+Should search match only the template name, or also the first line of the
+prompt body? Second option is more useful but needs an index built at load
+time rather than a simple substring filter.
+
+## Activity
+- 2026-08-20T12:00:00Z — Opened PR with name-only search
+- 2026-08-22T10:00:00Z — Review requested a decision on prompt-body matching

--- a/examples/demo-workspace/ghostties/README.md
+++ b/examples/demo-workspace/ghostties/README.md
@@ -1,0 +1,15 @@
+# ghostties
+
+Multi-agent workspace sidebar on top of a GPU terminal. One window, many
+long-running agent sessions grouped by project, with a status rail that
+shows what finished overnight and what's waiting on you.
+
+## Layout
+
+- `Sources/` — sidebar view models and session store
+- `.ghostties/tasks/` — this project's own task tracking, dogfooded
+
+## Status
+
+Sidebar core is stable; menu bar status item and preset picker are active
+work. See tasks below for what's in flight.

--- a/examples/demo-workspace/ghostties/Sources/SessionStore.swift
+++ b/examples/demo-workspace/ghostties/Sources/SessionStore.swift
@@ -1,0 +1,15 @@
+// SessionStore.swift
+// Central @Published state for the workspace sidebar: projects, sessions,
+// and per-session indicator status. Persists to disk on a debounced timer.
+
+import Foundation
+
+@MainActor
+final class SessionStore: ObservableObject {
+    @Published var projects: [Project] = []
+    @Published var sessions: [AgentSession] = []
+
+    func persist() {
+        // Debounced write to workspace.json — see PersistenceGotchas.md
+    }
+}

--- a/examples/demo-workspace/ghostties/Sources/StatusIndicator.swift
+++ b/examples/demo-workspace/ghostties/Sources/StatusIndicator.swift
@@ -1,0 +1,18 @@
+// StatusIndicator.swift
+// Six-state indicator (inactive/idle/processing/longRunning/waiting/error)
+// rendered as a small ghost glyph next to each session row.
+
+import SwiftUI
+
+enum IndicatorState {
+    case inactive, idle, processing, longRunning, waiting, error
+}
+
+struct StatusIndicator: View {
+    let state: IndicatorState
+
+    var body: some View {
+        // Pixel-glyph rendering lives in GhostCharacterView
+        EmptyView()
+    }
+}

--- a/examples/demo-workspace/pendulum/.ghostties/tasks/confirm-rounding-rules.md
+++ b/examples/demo-workspace/pendulum/.ghostties/tasks/confirm-rounding-rules.md
@@ -1,0 +1,19 @@
+---
+title: "Confirm billing rounding rules for export"
+status: needs-you
+created: 2026-05-27T10:00:00Z
+project: pendulum
+source: linear
+source-id: PND-51
+priority: high
+needs: "Should time entries round to the nearest 6 minutes (0.1h) or 15 minutes on export? This affects the invoice totals and I need to lock it before writing the export formatter."
+---
+
+## Goal
+Lock the rounding increment used when exporting time entries to CSV/invoice format.
+
+## Notes
+Different accounting tools expect different granularities. Quickbooks wants 0.1h increments, some legal billing software wants 15-min blocks. Need a product decision before the export formatter branches.
+
+## Activity
+- 2026-05-27T10:00:00Z — Surfaced to product; blocked on decision

--- a/examples/demo-workspace/pendulum/.ghostties/tasks/timer-background-sync.md
+++ b/examples/demo-workspace/pendulum/.ghostties/tasks/timer-background-sync.md
@@ -1,0 +1,23 @@
+---
+title: "Background sync for running timers"
+status: running
+created: 2026-05-22T13:00:00Z
+project: pendulum
+source: linear
+source-id: PND-44
+priority: high
+branch: feat/background-sync
+worktree: ~/Code/pendulum
+files-staged: 5
+---
+
+## Goal
+Keep timers ticking accurately when the app is backgrounded on iOS. Currently the elapsed time jumps forward on foreground if the device was locked.
+
+## Notes
+Using `UIApplication.backgroundTask` + storing a start timestamp in UserDefaults. Need to reconcile with the local SQLite state on foreground. BGAppRefreshTask probably overkill here.
+
+## Activity
+- 2026-05-22T13:00:00Z — Identified delta-time bug in foreground observer
+- 2026-05-23T09:00:00Z — Implemented timestamp-based elapsed calculation
+- 2026-05-24T16:30:00Z — Works for lock/unlock, still testing airplane mode edge case

--- a/examples/demo-workspace/pendulum/.ghostties/tasks/widget-live-activity.md
+++ b/examples/demo-workspace/pendulum/.ghostties/tasks/widget-live-activity.md
@@ -1,0 +1,18 @@
+---
+title: "Add Live Activity for active timer"
+status: inbox
+created: 2026-06-02T08:30:00Z
+project: pendulum
+source: linear
+source-id: PND-58
+priority: medium
+---
+
+## Goal
+Show the running timer duration on the Dynamic Island and Lock Screen via ActivityKit Live Activities.
+
+## Notes
+Requires ActivityAttributes conformance and a new widget extension target. Timing UI needs to update at 1s intervals without draining battery. Not started.
+
+## Activity
+- 2026-06-02T08:30:00Z — Added to inbox after user request in App Store review

--- a/examples/demo-workspace/silo/.ghostties/tasks/conflict-resolution-ui.md
+++ b/examples/demo-workspace/silo/.ghostties/tasks/conflict-resolution-ui.md
@@ -1,0 +1,20 @@
+---
+title: "Design conflict resolution modal"
+status: needs-you
+created: 2026-05-20T09:00:00Z
+project: silo
+source: linear
+source-id: SLO-67
+priority: medium
+needs: "When two devices edit the same file offline, should we auto-merge (last-write-wins), show a diff UI, or keep both versions as fork copies? This is a product call that blocks the sync engine's conflict handler."
+---
+
+## Goal
+Define the conflict resolution strategy so the sync engine knows what to do when it detects a diverged file.
+
+## Notes
+Last-write-wins is simplest but loses data silently. Diff UI is best UX but complex to build. Fork copies (both kept with a suffix) is a safe middle ground. Dropbox and iCloud use different strategies.
+
+## Activity
+- 2026-05-20T09:00:00Z — Conflict scenario documented, three options sketched
+- 2026-05-21T11:00:00Z — Awaiting product direction before implementing handler

--- a/examples/demo-workspace/silo/.ghostties/tasks/delta-sync-engine.md
+++ b/examples/demo-workspace/silo/.ghostties/tasks/delta-sync-engine.md
@@ -1,0 +1,24 @@
+---
+title: "Implement delta sync for large file trees"
+status: running
+created: 2026-05-10T09:00:00Z
+project: silo
+source: github
+source-id: GH-112
+priority: high
+branch: feat/delta-sync
+worktree: ~/Code/silo
+files-staged: 8
+---
+
+## Goal
+Replace full-tree hash comparison on sync with a delta approach that only transfers changed blocks, reducing sync time on large vaults by ~80%.
+
+## Notes
+Using rolling hash (Rabin fingerprint) for block deduplication. The tricky part is handling renames vs new file + delete. Content-addressed storage means renames are nearly free if the hash matches.
+
+## Activity
+- 2026-05-10T09:00:00Z — Designed block chunking strategy, target 4MB average chunk
+- 2026-05-12T14:00:00Z — Implemented rolling hash chunker, passing unit tests
+- 2026-05-14T11:30:00Z — Working on rename detection heuristic (same hash, different path)
+- 2026-05-16T16:00:00Z — Integration tests running, ~73% reduction in bytes transferred on benchmark vault

--- a/examples/demo-workspace/silo/.ghostties/tasks/s3-multipart-upload.md
+++ b/examples/demo-workspace/silo/.ghostties/tasks/s3-multipart-upload.md
@@ -1,0 +1,27 @@
+---
+title: "Switch large file uploads to S3 multipart"
+status: done
+created: 2026-04-22T10:00:00Z
+project: silo
+source: github
+source-id: GH-89
+priority: high
+pr: 89
+pr-state: merged
+pr-url: https://github.com/example-org/silo/pull/89
+completed: 2026-05-02T15:00:00Z
+updated: 2026-05-02T15:00:00Z
+---
+
+## Goal
+Replace single-part PUT uploads with S3 multipart for files over 100MB. Improves reliability on flaky connections by allowing resume on failure.
+
+## Notes
+Implemented chunked upload with 10MB parts. Added exponential backoff per part. Upload manager tracks part ETags and assembles on completion.
+
+## Activity
+- 2026-04-22T10:00:00Z — Designed chunked upload manager
+- 2026-04-25T14:00:00Z — Implemented multipart initiation and part upload loop
+- 2026-04-28T11:00:00Z — Added resume-from-checkpoint logic using part ETags stored in SQLite
+- 2026-05-01T09:00:00Z — PR open, passing CI
+- 2026-05-02T15:00:00Z — Merged after QA sign-off

--- a/examples/demo-workspace/switchboard/.ghostties/tasks/endpoint-health-checks.md
+++ b/examples/demo-workspace/switchboard/.ghostties/tasks/endpoint-health-checks.md
@@ -1,0 +1,18 @@
+---
+title: "Add webhook endpoint health check probing"
+status: backlog
+created: 2026-05-12T10:00:00Z
+project: switchboard
+source: linear
+source-id: SWB-90
+priority: medium
+---
+
+## Goal
+Periodically probe registered webhook endpoints with a lightweight ping request so the dashboard can surface unreachable destinations before live deliveries fail.
+
+## Notes
+Probe cadence: every 5 minutes per endpoint. Expected response: any 2xx within 5 seconds. Three consecutive failures flip status to "unhealthy" and trigger a dashboard alert. Avoid probing endpoints that have been manually paused. Probe requests should include a distinguishing header (X-Switchboard-Probe: true) so customers can handle them separately in their own logic.
+
+## Activity
+- 2026-05-12T10:00:00Z — Added to backlog after support tickets for silent delivery failures to stale endpoints

--- a/examples/demo-workspace/switchboard/.ghostties/tasks/event-schema-registry.md
+++ b/examples/demo-workspace/switchboard/.ghostties/tasks/event-schema-registry.md
@@ -1,0 +1,17 @@
+---
+title: "Build event schema registry"
+status: inbox
+created: 2026-06-10T10:00:00Z
+project: switchboard
+source: shell
+priority: low
+---
+
+## Goal
+Allow teams to register JSON Schema definitions for their webhook event types so the dashboard can validate and pretty-print payloads.
+
+## Notes
+Not started. Would integrate with the existing event log view. Stretch goal: auto-generate TypeScript types from registered schemas.
+
+## Activity
+- 2026-06-10T10:00:00Z — Sketched idea during team retro, added to inbox

--- a/examples/demo-workspace/switchboard/.ghostties/tasks/payload-log-retention.md
+++ b/examples/demo-workspace/switchboard/.ghostties/tasks/payload-log-retention.md
@@ -1,0 +1,26 @@
+---
+title: "Enforce payload log retention policy"
+status: done
+created: 2026-04-25T09:00:00Z
+project: switchboard
+source: linear
+source-id: SWB-61
+priority: medium
+pr: 61
+pr-state: merged
+pr-url: https://github.com/example-org/switchboard/pull/61
+completed: 2026-05-08T13:00:00Z
+updated: 2026-05-08T13:00:00Z
+---
+
+## Goal
+Automatically delete webhook payload logs older than 90 days (or per-workspace retention setting) to comply with data minimization requirements.
+
+## Notes
+Implemented as a nightly cron job using a soft-delete pattern. Workspace admins can configure 30/60/90-day windows. Hard delete runs 7 days after soft delete to allow accidental recovery.
+
+## Activity
+- 2026-04-25T09:00:00Z — Retention policy spec written
+- 2026-04-28T14:00:00Z — Cron job implemented and tested on staging
+- 2026-05-05T10:00:00Z — Admin UI for workspace retention setting shipped
+- 2026-05-08T13:00:00Z — Merged and verified in production

--- a/examples/demo-workspace/switchboard/.ghostties/tasks/per-endpoint-delivery-metrics.md
+++ b/examples/demo-workspace/switchboard/.ghostties/tasks/per-endpoint-delivery-metrics.md
@@ -1,0 +1,24 @@
+---
+title: "Expose per-endpoint delivery success metrics"
+status: review
+created: 2026-06-08T09:00:00Z
+project: switchboard
+source: github
+source-id: GH-74
+priority: medium
+pr: 74
+pr-state: open
+pr-url: https://github.com/example-org/switchboard/pull/74
+branch: feat/endpoint-delivery-metrics
+---
+
+## Goal
+Surface per-endpoint delivery success rate, p95 latency, and error breakdown in the dashboard so teams can identify degraded destinations without digging through raw logs.
+
+## Notes
+Metrics are computed from the existing delivery_attempts table using a 24h rolling window. Added a materialized view (endpoint_delivery_stats) that refreshes every 60 seconds. Dashboard panel uses a bar chart for success vs. failure count and a sparkline for latency trend. No new data collection required.
+
+## Activity
+- 2026-06-08T09:00:00Z — Materialized view created, query plan confirmed index-only scan on delivery_attempts(endpoint_id, attempted_at)
+- 2026-06-10T14:00:00Z — Dashboard panel built, connected to stats view, screenshots shared in PR
+- 2026-06-11T10:30:00Z — Addressed review comment on refresh interval: switched from 30s to 60s after load testing showed contention at 30s under high write volume

--- a/examples/demo-workspace/switchboard/.ghostties/tasks/replay-dead-letter.md
+++ b/examples/demo-workspace/switchboard/.ghostties/tasks/replay-dead-letter.md
@@ -1,0 +1,20 @@
+---
+title: "Add replay UI for dead-letter queue"
+status: needs-you
+created: 2026-06-06T09:00:00Z
+project: switchboard
+source: linear
+source-id: SWB-88
+priority: medium
+needs: "Should replay be automatic (retry on schedule) or manual (user clicks replay per event)? The queue drain strategy changes the UI significantly and affects how we store retry metadata."
+---
+
+## Goal
+Let users inspect and replay failed webhook deliveries from the dead-letter queue without needing to re-trigger the source event.
+
+## Notes
+Failed events are already stored with payload + failure reason. Need to decide: automatic scheduled retry with exponential backoff, or a manual replay button in the dashboard. Both are reasonable but the data model differs.
+
+## Activity
+- 2026-06-06T09:00:00Z — DLQ storage in place, UI strategy unclear
+- 2026-06-06T14:00:00Z — Blocked on product decision for retry strategy

--- a/examples/demo-workspace/switchboard/.ghostties/tasks/webhook-signature-verify.md
+++ b/examples/demo-workspace/switchboard/.ghostties/tasks/webhook-signature-verify.md
@@ -1,0 +1,24 @@
+---
+title: "Implement HMAC signature verification for inbound webhooks"
+status: running
+created: 2026-06-01T08:00:00Z
+project: switchboard
+source: linear
+source-id: SWB-82
+priority: high
+branch: feat/webhook-hmac
+worktree: ~/Code/switchboard
+files-staged: 2
+---
+
+## Goal
+Verify HMAC-SHA256 signatures on inbound webhook payloads to reject spoofed requests before they hit handler logic.
+
+## Notes
+Each integration (Stripe, GitHub, Shopify) uses a slightly different signing scheme. Building a pluggable verifier interface with per-integration adapters. Timing-safe comparison is mandatory to prevent timing attacks.
+
+## Activity
+- 2026-06-01T08:00:00Z — Scaffolded verifier interface
+- 2026-06-03T11:00:00Z — Implemented Stripe and GitHub adapters
+- 2026-06-05T14:30:00Z — Added constant-time comparison, unit tests passing
+- 2026-07-06T00:00:00Z — Wired timingSafeEqual into verifySignature + added replay-window check (default 300s); 16-case verification script passing

--- a/examples/demo-workspace/switchboard/src/signature.ts
+++ b/examples/demo-workspace/switchboard/src/signature.ts
@@ -1,0 +1,118 @@
+/**
+ * Switchboard — Webhook HMAC Signature Verification
+ *
+ * Verifies inbound webhook payloads using HMAC-SHA256.
+ * Signing scheme: `t=<timestamp>,v1=<hex-hmac>` (compatible with Stripe-style headers).
+ */
+
+import * as crypto from "crypto";
+
+export interface VerificationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export interface SignatureHeader {
+  timestamp: number;
+  signatures: string[];
+}
+
+/**
+ * Parse a Switchboard signature header of the form:
+ *   `t=1717200000,v1=abc123...,v1=def456...`
+ *
+ * Returns the Unix timestamp and all v1 signature values.
+ */
+export function parseSignatureHeader(header: string): SignatureHeader | null {
+  const parts = header.split(",");
+  let timestamp: number | null = null;
+  const signatures: string[] = [];
+
+  for (const part of parts) {
+    const [key, value] = part.trim().split("=");
+    if (key === "t") {
+      const parsed = parseInt(value, 10);
+      if (isNaN(parsed)) return null;
+      timestamp = parsed;
+    } else if (key === "v1") {
+      signatures.push(value);
+    }
+  }
+
+  if (timestamp === null || signatures.length === 0) return null;
+  return { timestamp, signatures };
+}
+
+/**
+ * Compute the expected HMAC-SHA256 signature for a given payload + timestamp.
+ * Signed payload format: `<timestamp>.<raw-body>`
+ */
+function computeExpectedSignature(
+  rawBody: string,
+  timestamp: number,
+  secret: string,
+): string {
+  const signedPayload = `${timestamp}.${rawBody}`;
+  return crypto
+    .createHmac("sha256", secret)
+    .update(signedPayload, "utf8")
+    .digest("hex");
+}
+
+/**
+ * Compare a candidate signature against the expected one in constant time.
+ *
+ * `crypto.timingSafeEqual` throws on length mismatch, so length is checked
+ * first. The length of the candidate is attacker-supplied and the expected
+ * length (64 hex chars) is public, so the early return leaks nothing useful.
+ */
+function signaturesMatch(candidate: string, expected: string): boolean {
+  const candidateBuf = Buffer.from(candidate, "utf8");
+  const expectedBuf = Buffer.from(expected, "utf8");
+  if (candidateBuf.length !== expectedBuf.length) return false;
+  return crypto.timingSafeEqual(candidateBuf, expectedBuf);
+}
+
+/** Default replay tolerance: 5 minutes, matching Stripe's recommendation. */
+export const DEFAULT_TOLERANCE_SECONDS = 300;
+
+/**
+ * Verify an inbound webhook request from Switchboard.
+ *
+ * @param rawBody    - The raw, unparsed request body string.
+ * @param header     - The value of the `Switchboard-Signature` header.
+ * @param secret     - The endpoint's signing secret (from Switchboard dashboard).
+ * @param toleranceSeconds - Max allowed age (and future clock skew) of the
+ *                     signed timestamp; defaults to 300s.
+ * @returns VerificationResult — `valid: true` if the signature checks out.
+ */
+export function verifySignature(
+  rawBody: string,
+  header: string,
+  secret: string,
+  toleranceSeconds: number = DEFAULT_TOLERANCE_SECONDS,
+): VerificationResult {
+  const parsed = parseSignatureHeader(header);
+  if (!parsed) {
+    return { valid: false, reason: "malformed_signature_header" };
+  }
+
+  const expected = computeExpectedSignature(rawBody, parsed.timestamp, secret);
+
+  const matched = parsed.signatures.some((sig) =>
+    signaturesMatch(sig, expected),
+  );
+  if (!matched) {
+    return { valid: false, reason: "signature_mismatch" };
+  }
+
+  // Replay-window check: a captured request must not be replayable outside
+  // the tolerance window. Also rejects timestamps too far in the future,
+  // which only occur with forged headers or severe clock skew.
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - parsed.timestamp) > toleranceSeconds) {
+    return { valid: false, reason: "timestamp_out_of_tolerance" };
+  }
+
+  return { valid: true };
+}

--- a/examples/demo-workspace/terminal-flow.sh
+++ b/examples/demo-workspace/terminal-flow.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# =============================================================================
+# terminal-flow.sh — Ghostties Demo Terminal Flow Choreography
+# =============================================================================
+#
+# Drives demo task fixtures through a lifecycle sequence so the terminal
+# renders `gt list` lane re-renders as a task moves through status lanes.
+# Designed for screen recording via an EXTERNAL recorder (ffmpeg / Cmd-Shift-5).
+#
+# HARD RULE: This script NEVER captures the screen. Recording is external —
+# use Cmd-Shift-5 in macOS (or ffmpeg) to record before running this script.
+# This script only mutates fixture Markdown files and drives `gt list` output.
+#
+# USAGE:
+#   ./terminal-flow.sh              — Live mode. Real hold times. Runs to
+#                                     completion automatically; EXIT trap
+#                                     restores the fixture. Stop your recorder
+#                                     after the final `gt list` clears.
+#   ./terminal-flow.sh --dry-run    — Verification mode. Short holds (0.3s).
+#                                     Prints a labeled lane snapshot after each
+#                                     beat. Fixture is restored at exit.
+#
+# RUN FROM: anywhere — paths are hardcoded.
+#
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# PATHS
+# =============================================================================
+
+REPO_ROOT="/Users/seansmith/Code/ghostties"
+TASKS_DIR="${REPO_ROOT}/examples/demo-workspace/switchboard/.ghostties/tasks"
+GT_BIN="${REPO_ROOT}/cli/.build/release/gt"
+SWITCHBOARD_DIR="${REPO_ROOT}/examples/demo-workspace/switchboard"
+
+# =============================================================================
+# DRY-RUN HOLD OVERRIDE (seconds)
+# =============================================================================
+
+DRY_RUN_HOLD="0.3"
+
+# =============================================================================
+# SNAPSHOT / RESTORE HELPERS
+# =============================================================================
+
+SNAPSHOT_DIR=""
+
+snapshot_tasks() {
+  SNAPSHOT_DIR="$(mktemp -d)"
+  cp -R "${TASKS_DIR}/." "${SNAPSHOT_DIR}/"
+  echo "[terminal-flow] Snapshot saved to ${SNAPSHOT_DIR}"
+}
+
+restore_from_snapshot() {
+  if [[ -z "${SNAPSHOT_DIR}" || ! -d "${SNAPSHOT_DIR}" ]]; then
+    return
+  fi
+  echo ""
+  echo "[terminal-flow] Restoring fixture from snapshot…"
+  # Remove all current files in the tasks dir and copy the snapshot back
+  find "${TASKS_DIR}" -mindepth 1 -maxdepth 1 -delete
+  cp -R "${SNAPSHOT_DIR}/." "${TASKS_DIR}/"
+  echo "[terminal-flow] Fixture restored."
+}
+
+# =============================================================================
+# FILE MUTATION HELPERS
+# =============================================================================
+
+set_status() {
+  local filename="$1"   # without .md
+  local new_status="$2"
+  local filepath="${TASKS_DIR}/${filename}.md"
+
+  if [[ ! -f "${filepath}" ]]; then
+    echo "[terminal-flow] ERROR: File not found: ${filepath}" >&2
+    return 1
+  fi
+
+  # BSD sed (macOS): in-place replacement, no backup
+  sed -i '' -E "s/^status:.*/status: ${new_status}/" "${filepath}"
+}
+
+create_oauth_scope_validation() {
+  local filepath="${TASKS_DIR}/oauth-scope-validation.md"
+  cat > "${filepath}" <<'TASKEOF'
+---
+title: "Add OAuth scope validation to webhook registration API"
+status: inbox
+created: 2026-06-12T09:00:00Z
+project: switchboard
+source: github
+source-id: GH-79
+priority: medium
+branch: feat/oauth-scope-validation
+worktree: ~/Code/switchboard
+---
+
+## Goal
+Validate that the OAuth token used when registering a new webhook endpoint carries the required `webhooks:write` scope. Reject registrations with insufficient permissions before the endpoint is persisted, returning a 403 with a descriptive error body.
+
+## Notes
+Current registration handler checks token validity (expiry, signature) but skips scope inspection entirely. The scope claim lives in the JWT payload as `scope` (space-delimited string). Need a scope-parser utility and a middleware layer so the check is reusable by future permission-gated routes. Token refresh flow is out of scope — callers with expired tokens get a 401 via the existing auth middleware.
+
+## Activity
+- 2026-06-12T09:00:00Z — Discovered gap during security review of webhook registration endpoint
+TASKEOF
+}
+
+# =============================================================================
+# GT LANE SNAPSHOT (dry-run only)
+# =============================================================================
+
+print_lane_snapshot() {
+  local label="$1"
+
+  local gt_output
+  gt_output="$(cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list 2>/dev/null)" || true
+
+  echo ""
+  echo "  ┌─────────────────────────────────────────────────────────────────────┐"
+  printf  "  │ %-69s │\n" "${label}"
+  echo "  ├──────────────┬──────────────────────────────────────────────────────┤"
+
+  local lane_inbox lane_backlog lane_running lane_needs_you lane_review lane_graveyard
+  lane_inbox=""
+  lane_backlog=""
+  lane_running=""
+  lane_needs_you=""
+  lane_review=""
+  lane_graveyard=""
+
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    local id task_status
+    id="$(echo "${line}" | awk '{print $1}')"
+    task_status="$(echo "${line}" | awk '{print $2}')"
+
+    case "${task_status}" in
+      inbox)
+        lane_inbox="${lane_inbox:+${lane_inbox}, }${id}" ;;
+      backlog)
+        lane_backlog="${lane_backlog:+${lane_backlog}, }${id}" ;;
+      running)
+        lane_running="${lane_running:+${lane_running}, }${id}" ;;
+      needs-you)
+        lane_needs_you="${lane_needs_you:+${lane_needs_you}, }${id}" ;;
+      review)
+        lane_review="${lane_review:+${lane_review}, }${id}" ;;
+      graveyard)
+        lane_graveyard="${lane_graveyard:+${lane_graveyard}, }${id}" ;;
+    esac
+  done <<< "${gt_output}"
+
+  printf "  │ %-12s │ %-54s │\n" "inbox"     "${lane_inbox}"
+  printf "  │ %-12s │ %-54s │\n" "backlog"   "${lane_backlog}"
+  printf "  │ %-12s │ %-54s │\n" "running"   "${lane_running}"
+  printf "  │ %-12s │ %-54s │\n" "needs-you" "${lane_needs_you}"
+  printf "  │ %-12s │ %-54s │\n" "review"    "${lane_review}"
+  printf "  │ %-12s │ %-54s │\n" "graveyard" "${lane_graveyard}"
+
+  echo "  └──────────────┴──────────────────────────────────────────────────────┘"
+  echo ""
+}
+
+# =============================================================================
+# BEAT RUNNER
+# =============================================================================
+
+run_flow() {
+  local is_dry_run="$1"  # "true" or "false"
+
+  # ── Beat 1: Initial state — all six lanes ─────────────────────────────────
+  clear
+  cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list
+
+  if [[ "${is_dry_run}" == "true" ]]; then
+    print_lane_snapshot "Beat 1 — Initial state (six lanes)"
+    sleep "${DRY_RUN_HOLD}"
+  else
+    sleep 3
+  fi
+
+  # ── Beat 2: New task lands in Inbox ───────────────────────────────────────
+  create_oauth_scope_validation
+  clear
+  cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list
+
+  if [[ "${is_dry_run}" == "true" ]]; then
+    print_lane_snapshot "Beat 2 — oauth-scope-validation created (inbox)"
+    sleep "${DRY_RUN_HOLD}"
+  else
+    sleep 3
+  fi
+
+  # ── Beat 3: Agent starts work (Inbox → Running) ───────────────────────────
+  set_status "oauth-scope-validation" "running"
+  clear
+  cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list
+
+  if [[ "${is_dry_run}" == "true" ]]; then
+    print_lane_snapshot "Beat 3 — oauth-scope-validation running"
+    sleep "${DRY_RUN_HOLD}"
+  else
+    sleep 3
+  fi
+
+  # ── Beat 4: Agent is blocked — needs you (terracotta) ─────────────────────
+  set_status "oauth-scope-validation" "needs-you"
+  clear
+  cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list
+
+  if [[ "${is_dry_run}" == "true" ]]; then
+    print_lane_snapshot "Beat 4 — oauth-scope-validation needs-you (terracotta)"
+    sleep "${DRY_RUN_HOLD}"
+  else
+    sleep 3.5
+  fi
+
+  # ── Final: Settle on needs-you lane ───────────────────────────────────────
+  clear
+  cd "${SWITCHBOARD_DIR}" && "${GT_BIN}" list
+
+  if [[ "${is_dry_run}" == "true" ]]; then
+    print_lane_snapshot "Final — settle on needs-you"
+    sleep "${DRY_RUN_HOLD}"
+  else
+    sleep 2
+  fi
+}
+
+# =============================================================================
+# MODES
+# =============================================================================
+
+mode_dry_run() {
+  if [[ ! -d "${TASKS_DIR}" ]]; then
+    echo "[terminal-flow] ERROR: Tasks dir not found: ${TASKS_DIR}" >&2
+    exit 1
+  fi
+  if [[ ! -x "${GT_BIN}" ]]; then
+    echo "[terminal-flow] ERROR: gt binary not found or not executable: ${GT_BIN}" >&2
+    exit 1
+  fi
+
+  echo "[terminal-flow] DRY-RUN mode — holds are ${DRY_RUN_HOLD}s, fixture will be restored at exit."
+  snapshot_tasks
+
+  trap restore_from_snapshot EXIT
+
+  run_flow "true"
+
+  echo ""
+  echo "========================================================================="
+  echo "  PASS — All beats completed. Fixture will be restored on exit."
+  echo "========================================================================="
+}
+
+mode_live() {
+  if [[ ! -d "${TASKS_DIR}" ]]; then
+    echo "[terminal-flow] ERROR: Tasks dir not found: ${TASKS_DIR}" >&2
+    exit 1
+  fi
+  if [[ ! -x "${GT_BIN}" ]]; then
+    echo "[terminal-flow] ERROR: gt binary not found or not executable: ${GT_BIN}" >&2
+    exit 1
+  fi
+
+  echo "[terminal-flow] LIVE mode — real hold times, recording-ready."
+  echo ""
+  echo "         REMEMBER: This script does not capture the screen."
+  echo "         Start your recorder (Cmd-Shift-5 or ffmpeg) BEFORE running."
+  echo "         The script runs to completion automatically."
+  echo ""
+  sleep 1
+
+  snapshot_tasks
+
+  trap restore_from_snapshot EXIT
+
+  run_flow "false"
+
+  echo ""
+  echo "========================================================================="
+  echo "  Flow complete. Stop your screen recording now."
+  echo "  Fixture will be restored on exit."
+  echo "========================================================================="
+}
+
+# =============================================================================
+# ENTRY POINT
+# =============================================================================
+
+MODE="${1:-}"
+
+case "${MODE}" in
+  --dry-run)
+    mode_dry_run
+    ;;
+  "")
+    mode_live
+    ;;
+  *)
+    echo "[terminal-flow] Unknown flag: ${MODE}" >&2
+    echo "Usage: $0 [--dry-run]" >&2
+    exit 1
+    ;;
+esac

--- a/examples/demo-workspace/trove/.ghostties/tasks/confirm-sharing-model.md
+++ b/examples/demo-workspace/trove/.ghostties/tasks/confirm-sharing-model.md
@@ -1,0 +1,19 @@
+---
+title: "Confirm public sharing model before implementing"
+status: needs-you
+created: 2026-06-10T11:00:00Z
+project: trove
+source: linear
+source-id: TRV-85
+priority: high
+needs: "Should shared notes be published as static pages (no auth, public URL) or require the viewer to have a Trove account? This affects the rendering path, auth middleware, and how we handle embedded media."
+---
+
+## Goal
+Define whether note sharing is public-URL (static publish) or account-gated (authenticated viewer) before building the share flow.
+
+## Notes
+Public sharing is simpler for the sharer and has higher virality. Account-gated lets us track views and restrict sensitive notes. A hybrid (default public, optional account-gate) is possible but doubles the implementation surface.
+
+## Activity
+- 2026-06-10T11:00:00Z — Sharing modal design is ready; blocked on model decision

--- a/examples/demo-workspace/trove/.ghostties/tasks/daily-note-template.md
+++ b/examples/demo-workspace/trove/.ghostties/tasks/daily-note-template.md
@@ -1,0 +1,22 @@
+---
+title: "Daily note auto-creation with template"
+status: done
+created: 2026-04-20T09:00:00Z
+project: trove
+source: shell
+priority: medium
+completed: 2026-04-30T14:00:00Z
+updated: 2026-04-30T14:00:00Z
+---
+
+## Goal
+Automatically create a new note for today's date when the user opens the app, pre-filled with their selected daily note template.
+
+## Notes
+Template uses Handlebars-style tokens: `{{date}}`, `{{day}}`, `{{week_number}}`. Notes are created idempotently — opening the app twice on the same day doesn't create duplicates. Default template ships with three sections: Goals, Log, Reflection.
+
+## Activity
+- 2026-04-20T09:00:00Z — Designed template token system
+- 2026-04-22T11:00:00Z — Implemented idempotent daily note creation on app launch
+- 2026-04-25T14:00:00Z — Template editor UI shipped
+- 2026-04-30T14:00:00Z — Shipped to production, well received in beta

--- a/examples/demo-workspace/trove/.ghostties/tasks/import-from-notion.md
+++ b/examples/demo-workspace/trove/.ghostties/tasks/import-from-notion.md
@@ -1,0 +1,24 @@
+---
+title: "Notion import parser"
+status: review
+created: 2026-06-05T10:00:00Z
+project: trove
+source: github
+source-id: GH-134
+priority: medium
+pr: 134
+pr-state: open
+pr-url: https://github.com/example-org/trove/pull/134
+branch: feat/notion-import
+---
+
+## Goal
+Parse Notion's HTML export format and convert it to Trove's internal note schema, preserving headings, callouts, tables, and inline code.
+
+## Notes
+Notion export is messy HTML — lots of non-semantic wrappers and proprietary data attributes. Using a two-pass parser: clean the HTML, then map to the ProseMirror document model. Callout block mapping is the hairiest part.
+
+## Activity
+- 2026-06-05T10:00:00Z — Parser scaffolded, handling headings/paragraphs/lists
+- 2026-06-07T14:00:00Z — Table and code block support added
+- 2026-06-09T10:00:00Z — PR open; callout mapping flagged for follow-up

--- a/examples/demo-workspace/trove/.ghostties/tasks/semantic-search-index.md
+++ b/examples/demo-workspace/trove/.ghostties/tasks/semantic-search-index.md
@@ -1,0 +1,23 @@
+---
+title: "Build semantic search index with embeddings"
+status: running
+created: 2026-05-30T09:00:00Z
+project: trove
+source: linear
+source-id: TRV-71
+priority: high
+branch: feat/semantic-search
+worktree: ~/Code/trove
+files-staged: 4
+---
+
+## Goal
+Generate embeddings for all notes and enable vector-similarity search so users can find conceptually related content, not just keyword matches.
+
+## Notes
+Using OpenAI `text-embedding-3-small` for cost efficiency. Vectors stored in pgvector. Re-indexing on note save via a background queue to avoid blocking the write path. Chunking long notes into 512-token segments.
+
+## Activity
+- 2026-05-30T09:00:00Z — pgvector extension enabled, embeddings table created
+- 2026-06-01T11:00:00Z — Background indexer implemented, processing backfill job
+- 2026-06-03T15:00:00Z — Search endpoint working, tuning similarity threshold (currently 0.78)

--- a/examples/demo-workspace/wren/.ghostties/tasks/editor-collab-crdt.md
+++ b/examples/demo-workspace/wren/.ghostties/tasks/editor-collab-crdt.md
@@ -1,0 +1,18 @@
+---
+title: "Evaluate CRDT library for collaborative editing"
+status: backlog
+created: 2026-04-28T11:00:00Z
+project: wren
+source: linear
+source-id: WRN-33
+priority: low
+---
+
+## Goal
+Pick a CRDT implementation for real-time co-authoring. Shortlist: Yjs, Automerge 2.0, or Diamond Types.
+
+## Notes
+Yjs has best ecosystem (ProseMirror + Tiptap bindings). Automerge 2.0 has cleaner API but larger binary. Diamond Types is fast but immature JS bindings. Performance matters more than ecosystem for our use case.
+
+## Activity
+- 2026-04-28T11:00:00Z — Opened evaluation ticket; spike needed before committing

--- a/examples/demo-workspace/wren/.ghostties/tasks/export-pdf-fonts.md
+++ b/examples/demo-workspace/wren/.ghostties/tasks/export-pdf-fonts.md
@@ -1,0 +1,26 @@
+---
+title: "Fix font embedding in PDF export"
+status: done
+created: 2026-04-18T10:00:00Z
+project: wren
+source: github
+source-id: GH-178
+priority: high
+pr: 178
+pr-state: merged
+pr-url: https://github.com/example-org/wren/pull/178
+completed: 2026-04-26T11:00:00Z
+updated: 2026-04-26T11:00:00Z
+---
+
+## Goal
+Exported PDFs were rendering fallback system fonts instead of the document's selected typeface. Embed fonts correctly in the PDF output.
+
+## Notes
+Root cause: Puppeteer's PDF renderer wasn't waiting for @font-face resources to load before capturing. Fixed by waiting for `document.fonts.ready` before triggering print.
+
+## Activity
+- 2026-04-18T10:00:00Z — Bug reported by multiple users
+- 2026-04-20T14:00:00Z — Root cause identified (race condition on font load)
+- 2026-04-22T09:00:00Z — Fix implemented with `fonts.ready` await
+- 2026-04-26T11:00:00Z — PR merged, deployed to production

--- a/examples/demo-workspace/wren/.ghostties/tasks/slash-command-menu.md
+++ b/examples/demo-workspace/wren/.ghostties/tasks/slash-command-menu.md
@@ -1,0 +1,25 @@
+---
+title: "Build slash-command insertion menu"
+status: review
+created: 2026-05-28T09:00:00Z
+project: wren
+source: github
+source-id: GH-201
+priority: medium
+pr: 201
+pr-state: open
+pr-url: https://github.com/example-org/wren/pull/201
+branch: feat/slash-commands
+---
+
+## Goal
+Trigger a floating command palette when the user types `/` at the start of a line, allowing insertion of headings, callouts, code blocks, and embeds.
+
+## Notes
+Built on top of the ProseMirror plugin system. Filtering is fuzzy-matched client-side. Arrow-key navigation and Escape to dismiss are wired. Accessibility review still pending.
+
+## Activity
+- 2026-05-28T09:00:00Z — Core plugin scaffolded
+- 2026-05-30T14:00:00Z — Fuzzy filter and keyboard nav implemented
+- 2026-06-02T10:00:00Z — PR opened for review
+- 2026-06-04T09:30:00Z — Addressed reviewer feedback on focus trap handling

--- a/macos/Sources/Features/Update/UpdateDelegate.swift
+++ b/macos/Sources/Features/Update/UpdateDelegate.swift
@@ -2,7 +2,21 @@ import Sparkle
 import Cocoa
 
 extension UpdateDriver: SPUUpdaterDelegate {
+    /// Test-only override for the resolved Info.plist `SUFeedURL` — `Bundle.main`'s
+    /// Info.plist can't be mutated at runtime inside `xcodebuild test`, so tests set
+    /// this instead. `nil` (the default) means "read from `Bundle.main` as normal."
+    static var testOverrideInfoPlistFeedURL: String?
+
     func feedURLString(for updater: SPUUpdater) -> String? {
+        // Honour an explicit Info.plist SUFeedURL when present (e.g. the demo
+        // build's deliberately-unreachable feed). The shipping app carries no
+        // SUFeedURL, so this is inert for it.
+        let plistFeedURL = UpdateDriver.testOverrideInfoPlistFeedURL
+            ?? (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String)
+        if let plistFeedURL, !plistFeedURL.isEmpty {
+            return plistFeedURL
+        }
+
         guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else {
             return nil
         }

--- a/macos/Tests/Ghostties/UpdateDelegateFeedURLTests.swift
+++ b/macos/Tests/Ghostties/UpdateDelegateFeedURLTests.swift
@@ -1,0 +1,63 @@
+import Cocoa
+import Sparkle
+import Testing
+@testable import Ghostty
+
+/// Regression coverage for the demo-app Sparkle exposure: a re-bundled copy
+/// of the shipping app (same `SUPublicEDKey`, different bundle id) had no
+/// `SUFeedURL` in its own Info.plist, so `UpdateDriver.feedURLString(for:)`
+/// fell through to the delegate's real channel feeds — a manual "Check for
+/// Updates…" in the demo would install the real Ghostties over it.
+/// `feedURLString(for:)` now honours an explicit Info.plist `SUFeedURL`
+/// first (see `UpdateDelegate.swift`), so the demo build can carry a
+/// deliberately-unreachable feed of its own.
+///
+/// `feedURLString(for:)` reads `Bundle.main`, which can't be mutated at
+/// runtime inside `xcodebuild test`, so these tests drive it through
+/// `UpdateDriver.testOverrideInfoPlistFeedURL` — a test-only seam on the
+/// real production type, not a re-declared constant (see
+/// `feedback_vacuous-tests-pass-green.md`).
+@MainActor
+struct UpdateDelegateFeedURLTests {
+    private func makeDriver() -> UpdateDriver {
+        UpdateDriver(viewModel: UpdateViewModel(), hostBundle: Bundle.main)
+    }
+
+    @Test func feedURLStringReturnsPlistValueWhenSUFeedURLIsPresent() {
+        let previous = UpdateDriver.testOverrideInfoPlistFeedURL
+        defer { UpdateDriver.testOverrideInfoPlistFeedURL = previous }
+
+        let demoFeed = "https://ghostties.org/appcast-demo.xml"
+        UpdateDriver.testOverrideInfoPlistFeedURL = demoFeed
+
+        let driver = makeDriver()
+        // `updater` argument is unused by the production implementation; Sparkle
+        // gives us no lightweight way to construct a real `SPUUpdater` in a unit
+        // test, so this only needs to be a value of the right type.
+        let result = driver.feedURLString(for: SPUUpdater(
+            hostBundle: Bundle.main,
+            applicationBundle: Bundle.main,
+            userDriver: driver,
+            delegate: driver
+        ))
+
+        #expect(result == demoFeed)
+    }
+
+    @Test func shippingInfoPlistHasNoSUFeedURLKey() throws {
+        // #filePath: .../macos/Tests/Ghostties/UpdateDelegateFeedURLTests.swift
+        // Three `deletingLastPathComponent()` calls reach `macos/`.
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<3 { url.deleteLastPathComponent() }
+        let plistPath = url.appendingPathComponent("Ghostties-Info.plist").path
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: plistPath))
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let dict = try #require(plist as? [String: Any])
+
+        // If this ever fails, someone added SUFeedURL to the shipping app's
+        // Info.plist — which would let it silently reroute the real update
+        // feed. That needs a deliberate decision, not a silent pass.
+        #expect(dict["SUFeedURL"] == nil)
+    }
+}

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -3,6 +3,39 @@
 Produces an isolated `Ghostties Demo.app` for screen recording and marketing
 capture — never touches the real daily-driver app or its data.
 
+## Entrypoint: `demo-ready.sh`
+
+Before capturing anything, run:
+
+```bash
+./scripts/demo/demo-ready.sh
+```
+
+This is the one command an agent or Sean should run as preflight. It resolves
+the newest release tag on `SeanSmithWorks/ghostties`, compares it against the
+installed demo app's version, calls `refresh-demo.sh` only if they differ,
+always reseeds the fixture workspace via `seed-demo-workspace.sh`, and writes
+a manifest recording exactly what's on disk. `refresh-demo.sh` and
+`seed-demo-workspace.sh` are the pieces it calls — call them directly only
+when working on the rig itself.
+
+```bash
+./scripts/demo/demo-ready.sh --check     # assert freshness; exits non-zero if stale/missing, changes nothing
+./scripts/demo/demo-ready.sh --source    # demo the current checkout instead of the newest release
+./scripts/demo/demo-ready.sh --dest <path>  # non-default app location
+```
+
+### Manifest
+
+Every non-`--check` run writes
+`~/Library/Application Support/Ghostties Demo/demo-manifest.json`, recording
+the demo app version (or, in `--source` mode, the built commit sha), the
+source tag or ref+sha, the app bundle's mtime, an ISO-8601 refreshed-at
+timestamp, the fixture project count, and the seeded repos path. **A capture
+run should copy this manifest next to whatever assets it produces** — it's
+what lets anyone later trace a screenshot or clip back to the exact build
+that produced it.
+
 ## How isolation works
 
 `refresh-demo.sh` re-bundles the app under bundle ID

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -31,11 +31,19 @@ directory from `Bundle.main.bundleIdentifier`, so the demo app reads/writes
 Release downloads are cached under `~/Library/Caches/ghostties-demo/<tag>/` so
 re-running the same tag doesn't re-download the ~147MB asset.
 
-**Sparkle is disabled in the demo build.** Ad-hoc re-signing (required to
-rewrite the bundle ID) invalidates the Developer ID signature Sparkle needs
-to trust an update, so the script strips `SUFeedURL` and disables automatic
-checks. **This script is the demo's update mechanism — re-run it to refresh
-to a new release.**
+**Sparkle updates are disabled in the demo build.** Ad-hoc re-signing
+(required to rewrite the bundle ID) invalidates the Developer ID signature
+Sparkle needs to trust an update, and `UpdateDelegate.feedURLString(for:)`
+honours an explicit Info.plist `SUFeedURL` before falling back to the real
+release channels — so a manual "Check for Updates…" in the demo could
+otherwise resolve the real Ghostties feed and overwrite the demo app with
+the real one (they share the same `SUPublicEDKey`). The script instead sets
+`SUFeedURL` to `https://ghostties.org/appcast-demo.xml`, a URL that
+deliberately does not exist, so a manual check fails benignly with a 404
+rather than installing anything. It also unconditionally sets
+`SUEnableAutomaticChecks` to `false` (adding the key if absent) — a missing
+key makes Sparkle prompt the user, so it's never left out. **This script is
+the demo's update mechanism — re-run it to refresh to a new release.**
 
 ## Seed the workspace
 

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -20,21 +20,24 @@ a manifest recording exactly what's on disk. `refresh-demo.sh` and
 when working on the rig itself.
 
 ```bash
-./scripts/demo/demo-ready.sh --check     # assert freshness; exits non-zero if stale/missing, changes nothing
+./scripts/demo/demo-ready.sh --check     # assert freshness; exits non-zero if stale/missing, never changes the app
 ./scripts/demo/demo-ready.sh --source    # demo the current checkout instead of the newest release
 ./scripts/demo/demo-ready.sh --dest <path>  # non-default app location
 ```
 
 ### Manifest
 
-Every non-`--check` run writes
+Every successful run — including a passing `--check` — writes
 `~/Library/Application Support/Ghostties Demo/demo-manifest.json`, recording
 the demo app version (or, in `--source` mode, the built commit sha), the
-source tag or ref+sha, the app bundle's mtime, an ISO-8601 refreshed-at
-timestamp, the fixture project count, and the seeded repos path. **A capture
-run should copy this manifest next to whatever assets it produces** — it's
-what lets anyone later trace a screenshot or clip back to the exact build
-that produced it.
+source tag or ref+sha, the resolved absolute path of the app bundle that was
+just inspected or refreshed, the app bundle's mtime, an ISO-8601
+refreshed-at timestamp, the fixture project count, and the seeded repos
+path. `--check` never touches the app or the fixture workspace — it only
+records what it just verified, so a stale manifest can't survive a clean
+preflight. **A capture run should copy this manifest next to whatever assets
+it produces** — it's what lets anyone later trace a screenshot or clip back
+to the exact build that produced it.
 
 ## How isolation works
 

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,59 @@
+# Ghostties Demo Rig
+
+Produces an isolated `Ghostties Demo.app` for screen recording and marketing
+capture — never touches the real daily-driver app or its data.
+
+## How isolation works
+
+`refresh-demo.sh` re-bundles the app under bundle ID
+`com.seansmithdesign.ghostties.demo`. `WorkspacePersistence` derives its state
+directory from `Bundle.main.bundleIdentifier`, so the demo app reads/writes
+`~/Library/Application Support/Ghostties Demo/` — completely separate from
+`~/Library/Application Support/Ghostties/` (release) and `Ghostties Dev/`.
+
+## Refresh modes
+
+```bash
+# Default: download the latest published release and re-bundle it (recommended)
+./scripts/demo/refresh-demo.sh
+
+# Pin to a specific tag
+./scripts/demo/refresh-demo.sh --from-release v0.1.0-beta.24
+
+# Build the local checkout instead (Debug, arm64)
+./scripts/demo/refresh-demo.sh --from-source
+./scripts/demo/refresh-demo.sh --from-source --pull-main   # fetch+checkout main first
+
+# Verification / CI use
+./scripts/demo/refresh-demo.sh --dest /tmp/x.app --no-launch
+```
+
+Release downloads are cached under `~/Library/Caches/ghostties-demo/<tag>/` so
+re-running the same tag doesn't re-download the ~147MB asset.
+
+**Sparkle is disabled in the demo build.** Ad-hoc re-signing (required to
+rewrite the bundle ID) invalidates the Developer ID signature Sparkle needs
+to trust an update, so the script strips `SUFeedURL` and disables automatic
+checks. **This script is the demo's update mechanism — re-run it to refresh
+to a new release.**
+
+## Seed the workspace
+
+```bash
+./scripts/demo/seed-demo-workspace.sh
+```
+
+Copies the 10 fixtures in `examples/demo-workspace/` into
+`~/Library/Application Support/Ghostties Demo/repos/<name>/`, turns each into
+a real git repo (init + one commit; a few get an extra branch), and points
+`workspace.json` at those copies — not at this checkout, so the demo doesn't
+break when this repo changes branch. Idempotent; backs up any existing
+`workspace.json` before overwriting.
+
+## Quitting
+
+Never `killall`. Quit cleanly:
+
+```bash
+osascript -e 'tell application "Ghostties Demo" to quit'
+```

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -94,6 +94,46 @@ a real git repo (init + one commit; a few get an extra branch), and points
 break when this repo changes branch. Idempotent; backs up any existing
 `workspace.json` before overwriting.
 
+## Stage real agent sessions: `demo-drive.sh`
+
+```bash
+./scripts/demo/demo-drive.sh              # stage 4 sessions across seeded repos
+./scripts/demo/demo-drive.sh --count 6    # stage 6 sessions
+./scripts/demo/demo-drive.sh --reset      # clear staged sessions
+```
+
+**The demo app must be quit before running this.** `WorkspacePersistence`
+rewrites `workspace.json` from memory while the app runs, so any edit made
+while it's open is silently reverted. If it's running, the script refuses to
+proceed and prints:
+
+```bash
+osascript -e 'tell application "Ghostties Demo" to quit'
+```
+
+It detects a running instance via `osascript`/System Events by bundle ID —
+querying only, never used to quit or drive the app.
+
+Each staged session is bound to its own per-repo `AgentTemplate` whose
+command is `claude` with a short, harmless, read-only prompt (summarize the
+README, list TODOs, describe the structure, explain the last commit — cycled
+across sessions). Nothing about the resulting activity is faked: no GUI
+automation is used anywhere, and the script never launches the app or runs
+`claude` itself. It only writes the staged records to `workspace.json`
+(backed up first, validated as JSON, written atomically); re-running replaces
+the previously staged set rather than appending duplicates.
+
+**Important:** Ghostties only spawns a process from a user-triggered UI
+action (a sidebar "Relaunch" click, a row click, or the composer) — there is
+no launch-time code path that replays persisted sessions automatically. A
+staged session appears in the sidebar as "Exited" with a Relaunch action;
+producing genuinely live ghost states for capture still requires clicking
+"Relaunch" once per session after opening the app:
+
+```bash
+open "/Applications/Ghostties Demo.app"
+```
+
 ## Quitting
 
 Never `killall`. Quit cleanly:

--- a/scripts/demo/demo-drive.sh
+++ b/scripts/demo/demo-drive.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# =============================================================================
+# demo-drive.sh — Stage real agent sessions into the Ghostties Demo workspace
+#
+# PURPOSE
+#   Writes N AgentSession entries (bound to per-repo AgentTemplates whose
+#   command is `claude`) directly into
+#   "~/Library/Application Support/Ghostties Demo/workspace.json", spread
+#   across the fixture repos seeded by seed-demo-workspace.sh. Nothing about
+#   the resulting agent activity is faked: this script never launches the
+#   app and never runs `claude` itself. When the operator opens the demo app
+#   and clicks "Relaunch" on a staged session, the app spawns a REAL `claude`
+#   process against a real fixture repo, running a short, harmless,
+#   read-only prompt — that is what produces genuinely live ghost states for
+#   capture.
+#
+#   IMPORTANT — what this script does NOT do:
+#     Ghostties only calls SessionCoordinator.createSession() (the thing that
+#     actually spawns a process) from user-triggered UI actions — the
+#     sidebar "Relaunch" button, a row click, or the composer. There is no
+#     app-launch-time code path that iterates persisted sessions and
+#     relaunches them automatically. A session staged by this script will
+#     appear in the sidebar as "Exited" (per AgentSession's own doc comment)
+#     with a Relaunch action available — it will NOT start running on its
+#     own just because the app launched. Producing live activity for a shot
+#     still requires one manual click per session; this script cannot and
+#     does not attempt to script that click (no GUI automation, ever).
+#
+# PRECONDITIONS
+#   1. `demo-ready.sh --check` must pass (current app + fixtures). Stale?
+#      Run `./scripts/demo/demo-ready.sh` first.
+#   2. Ghostties Demo.app MUST be quit before running this script.
+#      WorkspacePersistence rewrites workspace.json from memory while the
+#      app runs, so any edit made here would be silently discarded the
+#      moment the app is running. If it's open:
+#        osascript -e 'tell application "Ghostties Demo" to quit'
+#      This script detects a running instance via System Events (querying
+#      only — never used to quit or drive the app) and refuses to proceed.
+#
+# USAGE
+#   ./scripts/demo/demo-drive.sh                # stage 4 sessions (default)
+#   ./scripts/demo/demo-drive.sh --count 6       # stage 6 sessions
+#   ./scripts/demo/demo-drive.sh --reset         # clear staged sessions
+#
+# BEHAVIOR
+#   - Idempotent: re-running replaces the previously staged set (identified
+#     by a "Demo Agent — " name prefix) rather than appending duplicates.
+#   - Backs up workspace.json before writing (same convention as
+#     seed-demo-workspace.sh: workspace.json.bak-<timestamp>).
+#   - Writes to a temp file, validates it as JSON, then moves it into place
+#     — never leaves a partially-written workspace.json.
+#   - Does NOT launch the app. Prints the `open` command to run manually.
+#   - Never writes to ~/.ghostties/presets/ (shared with the real app) or
+#     to ~/Library/Application Support/Ghostties/ (the real workspace).
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEMO_READY_SCRIPT="$REPO_ROOT/scripts/demo/demo-ready.sh"
+
+DEMO_DIR="$HOME/Library/Application Support/Ghostties Demo"
+TARGET="$DEMO_DIR/workspace.json"
+REPOS_DIR="$DEMO_DIR/repos"
+APP_PATH="/Applications/Ghostties Demo.app"
+BUNDLE_ID="com.seansmithdesign.ghostties.demo"
+
+SESSION_MARKER="Demo Agent — "
+TEMPLATE_MARKER="Demo Drive: "
+
+COUNT=4
+RESET=0
+
+# ── Arg parsing ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --count)
+      COUNT="$2"
+      shift 2
+      ;;
+    --reset)
+      RESET=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unrecognized argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$COUNT" =~ ^[0-9]+$ ]] || [[ "$COUNT" -lt 1 ]]; then
+  echo "ERROR: --count must be a positive integer, got: $COUNT" >&2
+  exit 1
+fi
+
+echo "==> Ghostties demo-drive"
+echo "    Target: $TARGET"
+if [[ "$RESET" -eq 1 ]]; then
+  echo "    Mode:   reset (clear staged sessions)"
+else
+  echo "    Mode:   stage $COUNT session(s)"
+fi
+echo ""
+
+# ── Safety check: never touch the release workspace ─────────────────────────
+RELEASE_DIR="$HOME/Library/Application Support/Ghostties"
+if [[ "$DEMO_DIR" == "$RELEASE_DIR" ]]; then
+  echo "ERROR: Demo dir resolved to release dir. Aborting." >&2
+  exit 1
+fi
+
+# ── Precondition 1: fixtures must be current ────────────────────────────────
+echo "==> Checking demo-ready.sh --check..."
+if ! "$DEMO_READY_SCRIPT" --check; then
+  echo "" >&2
+  echo "ERROR: demo-ready.sh --check failed — app/fixtures are stale or missing." >&2
+  echo "       Run ./scripts/demo/demo-ready.sh first, then retry." >&2
+  exit 1
+fi
+echo ""
+
+# ── Precondition 2: app must be quit ────────────────────────────────────────
+echo "==> Checking whether Ghostties Demo is running..."
+IS_RUNNING="false"
+if command -v osascript >/dev/null 2>&1; then
+  IS_RUNNING=$(osascript -e "tell application \"System Events\" to exists (first process whose bundle identifier is \"$BUNDLE_ID\")" 2>/dev/null || echo "false")
+fi
+
+if [[ "$IS_RUNNING" == "true" ]]; then
+  echo "ERROR: Ghostties Demo is currently running." >&2
+  echo "       workspace.json edits are silently reverted while the app runs" >&2
+  echo "       (WorkspacePersistence rewrites it from memory). Quit it first:" >&2
+  echo "" >&2
+  echo "         osascript -e 'tell application \"Ghostties Demo\" to quit'" >&2
+  echo "" >&2
+  echo "       Then re-run this script." >&2
+  exit 1
+fi
+echo "    Not running. Proceeding."
+echo ""
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "ERROR: $TARGET does not exist. Run seed-demo-workspace.sh (or demo-ready.sh) first." >&2
+  exit 1
+fi
+
+# ── Back up existing workspace.json ─────────────────────────────────────────
+BACKUP="$DEMO_DIR/workspace.json.bak-$(date +%Y%m%dT%H%M%S)"
+echo "==> Backing up existing workspace.json -> $(basename "$BACKUP")"
+cp "$TARGET" "$BACKUP"
+echo ""
+
+# ── Write staged sessions via python3 (atomic temp-file swap) ───────────────
+TMP_FILE="$(mktemp "${TMPDIR:-/tmp}/workspace.XXXXXX.json")"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+echo "==> Rewriting workspace.json..."
+python3 - "$TARGET" "$TMP_FILE" "$REPOS_DIR" "$COUNT" "$RESET" "$SESSION_MARKER" "$TEMPLATE_MARKER" <<'PYEOF'
+import sys
+import json
+import subprocess
+import os
+
+target_path, tmp_path, repos_dir, count_str, reset_str, session_marker, template_marker = sys.argv[1:8]
+count = int(count_str)
+reset = reset_str == "1"
+
+with open(target_path) as f:
+    state = json.load(f)
+
+projects = state.get("projects", [])
+if not projects:
+    print("ERROR: workspace.json has no projects to bind sessions to.", file=sys.stderr)
+    sys.exit(1)
+
+# Only bind to projects whose rootPath actually lives under the seeded repos
+# dir — never point a session at an arbitrary project.
+eligible_projects = [p for p in projects if p.get("rootPath", "").startswith(repos_dir)]
+if not eligible_projects:
+    print(f"ERROR: no projects with rootPath under {repos_dir}.", file=sys.stderr)
+    sys.exit(1)
+
+# Strip any previously staged sessions/templates (identified by name prefix)
+# so re-running replaces rather than appends.
+prior_sessions = state.get("sessions", [])
+prior_templates = state.get("templates", [])
+
+kept_sessions = [s for s in prior_sessions if not s.get("name", "").startswith(session_marker)]
+kept_templates = [t for t in prior_templates if not t.get("name", "").startswith(template_marker)]
+
+removed_sessions = len(prior_sessions) - len(kept_sessions)
+removed_templates = len(prior_templates) - len(kept_templates)
+print(f"    Removed {removed_sessions} previously staged session(s), {removed_templates} template(s).")
+
+if reset:
+    state["sessions"] = kept_sessions
+    state["templates"] = kept_templates
+    with open(tmp_path, "w") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+    print("    Reset complete — staged sessions cleared.")
+    sys.exit(0)
+
+def new_uuid():
+    return subprocess.run(["uuidgen"], capture_output=True, text=True, check=True).stdout.strip().upper()
+
+# Short, harmless, read-only prompts — cycled across staged sessions. Each
+# is a plain positional argument to `claude`, never a flag that could touch
+# the filesystem.
+PROMPTS = [
+    "Summarize this repository's README in 3 bullet points. Read-only — do not modify any files.",
+    "List any TODO or FIXME comments you can find in this repository. Read-only — do not modify any files.",
+    "Describe this repository's directory structure in a few sentences. Read-only — do not modify any files.",
+    "Explain what the most recent git commit in this repository changed. Read-only — do not modify any files.",
+]
+
+new_sessions = []
+new_templates = []
+
+for i in range(count):
+    project = eligible_projects[i % len(eligible_projects)]
+    prompt = PROMPTS[i % len(PROMPTS)]
+    project_name = project["name"]
+    root_path = project["rootPath"]
+
+    template_id = new_uuid()
+    session_id = new_uuid()
+
+    template = {
+        "id": template_id,
+        "name": f"{template_marker}{project_name}",
+        "kind": "claudeCode",
+        "isDefault": False,
+        "isGlobal": False,
+        "projectId": project["id"],
+        "command": "claude",
+        "environmentVariables": {},
+        "workingDirectory": root_path,
+        "agent": {
+            "additionalFlags": [prompt],
+        },
+        "templateDescription": "Demo-drive staged agent (read-only)",
+    }
+
+    session = {
+        "id": session_id,
+        "name": f"{session_marker}{project_name}",
+        "templateId": template_id,
+        "projectId": project["id"],
+        "isNamePinned": True,
+    }
+
+    new_templates.append(template)
+    new_sessions.append(session)
+
+state["sessions"] = kept_sessions + new_sessions
+state["templates"] = kept_templates + new_templates
+
+with open(tmp_path, "w") as f:
+    json.dump(state, f, indent=2, sort_keys=True)
+
+print(f"    Staged {len(new_sessions)} session(s) across {len(eligible_projects)} eligible project(s):")
+for s, t in zip(new_sessions, new_templates):
+    print(f"      - {s['name']}  (template: {t['workingDirectory']})")
+PYEOF
+
+# ── Validate before moving into place ───────────────────────────────────────
+echo ""
+echo "==> Validating JSON..."
+python3 -m json.tool "$TMP_FILE" > /dev/null
+echo "    Valid."
+
+mv "$TMP_FILE" "$TARGET"
+chmod 600 "$TARGET"
+trap - EXIT
+
+echo ""
+echo "==> Verifying staged state..."
+python3 - "$TARGET" "$SESSION_MARKER" <<'PYEOF'
+import sys, json
+target_path, marker = sys.argv[1:3]
+with open(target_path) as f:
+    data = json.load(f)
+staged = [s for s in data.get("sessions", []) if s.get("name", "").startswith(marker)]
+print(f"    Total sessions   : {len(data.get('sessions', []))}")
+print(f"    Staged sessions  : {len(staged)}")
+print(f"    Total templates  : {len(data.get('templates', []))}")
+PYEOF
+
+echo ""
+if [[ "$RESET" -eq 1 ]]; then
+  echo "Done. Staged sessions cleared."
+else
+  echo "Done. $COUNT session(s) staged."
+fi
+echo ""
+echo "Next: open the demo app to materialize the staged sessions, then click"
+echo "\"Relaunch\" on each one to spawn its real claude process for capture:"
+echo ""
+echo "  open \"$APP_PATH\""

--- a/scripts/demo/demo-ready.sh
+++ b/scripts/demo/demo-ready.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# =============================================================================
+# demo-ready.sh — Single preflight entrypoint for capturing Ghostties Demo assets
+#
+# PURPOSE
+#   The one command an agent (or Sean) runs before capturing anything. It makes
+#   it structurally impossible to shoot from a stale demo build: it checks the
+#   installed demo app's version/commit against the intended source of truth,
+#   refreshes only if needed, always reseeds the fixture workspace, and writes
+#   a manifest recording exactly what produced the app now on disk.
+#
+# MODES
+#   --release (default)  Compare the installed app's CFBundleShortVersionString
+#                         against the newest tag on SeanSmithWorks/ghostties
+#                         (gh release list, pre-releases included).
+#   --source              Compare the installed app's GhosttyCommit (an
+#                         Info.plist key this script sets on --from-source
+#                         builds) against this checkout's HEAD sha. Never
+#                         compares against a release tag.
+#
+# USAGE
+#   ./scripts/demo/demo-ready.sh                       # ensure release-current, reseed
+#   ./scripts/demo/demo-ready.sh --check                # assert freshness, exit non-zero if stale
+#   ./scripts/demo/demo-ready.sh --source                # demo the current checkout instead
+#   ./scripts/demo/demo-ready.sh --dest /path/x.app      # non-default app location (testing)
+#
+# FLAGS
+#   --check         Report status and exit non-zero if stale or missing. Never
+#                   refreshes, never reseeds, never writes the manifest.
+#   --dest <path>   Demo app path. Default: /Applications/Ghostties Demo.app
+#   --source        Use this checkout (refresh-demo.sh --from-source) instead
+#                   of the newest release. "Current" means the app's recorded
+#                   git sha equals this checkout's HEAD sha.
+#
+# MANIFEST
+#   Always written (on a non---check run) to:
+#     ~/Library/Application Support/Ghostties Demo/demo-manifest.json
+#   regardless of --dest, because seed-demo-workspace.sh is likewise pinned to
+#   that fixed state directory (it is keyed off the demo bundle ID, not the
+#   app's install location). A capture run should copy this file next to
+#   whatever assets it produces — see scripts/demo/README.md.
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REFRESH_SCRIPT="$REPO_ROOT/scripts/demo/refresh-demo.sh"
+SEED_SCRIPT="$REPO_ROOT/scripts/demo/seed-demo-workspace.sh"
+FIXTURES_DIR="$REPO_ROOT/examples/demo-workspace"
+RELEASE_REPO="SeanSmithWorks/ghostties"
+ASSET_NAME="ghostties-macos-arm64.zip"
+
+DEMO_STATE_DIR="$HOME/Library/Application Support/Ghostties Demo"
+MANIFEST_PATH="$DEMO_STATE_DIR/demo-manifest.json"
+REPOS_DIR="$DEMO_STATE_DIR/repos"
+
+MODE="release"
+DEST_APP="/Applications/Ghostties Demo.app"
+CHECK_ONLY=0
+
+# ── Arg parsing ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK_ONLY=1
+      shift
+      ;;
+    --dest)
+      DEST_APP="$2"
+      shift 2
+      ;;
+    --source)
+      MODE="source"
+      shift
+      ;;
+    *)
+      echo "ERROR: Unrecognized argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+fail() {
+  echo "ERROR: $1" >&2
+  exit 1
+}
+
+plist_get() {
+  # plist_get <plist-path> <key>  -> prints value, or "" if unreadable/missing
+  local plist="$1" key="$2"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null || true
+}
+
+echo "==> Ghostties demo-ready preflight"
+echo "    Mode: $MODE"
+echo "    Dest: $DEST_APP"
+echo "    Check-only: $([[ "$CHECK_ONLY" -eq 1 ]] && echo yes || echo no)"
+echo ""
+
+PLIST="$DEST_APP/Contents/Info.plist"
+APP_EXISTS=0
+[[ -d "$DEST_APP" && -f "$PLIST" ]] && APP_EXISTS=1
+
+SOURCE_LABEL=""
+CURRENT=0
+REFRESH_ARGS=()
+SUMMARY_VERSION=""
+
+if [[ "$MODE" == "release" ]]; then
+  echo "==> Resolving newest release (including pre-releases) on $RELEASE_REPO..."
+  if ! RELEASE_JSON=$(gh release list --repo "$RELEASE_REPO" --limit 1 --json tagName 2>&1); then
+    fail "Could not reach GitHub to list releases for $RELEASE_REPO (gh failed: ${RELEASE_JSON}). Check 'gh auth status' and network connectivity."
+  fi
+  TAG=$(echo "$RELEASE_JSON" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d[0]["tagName"] if d else "")')
+  if [[ -z "$TAG" ]]; then
+    fail "No releases found on $RELEASE_REPO. Cannot determine the newest tag."
+  fi
+  echo "    Resolved tag: $TAG"
+
+  echo "==> Verifying release asset '$ASSET_NAME' exists on $TAG..."
+  if ! ASSET_JSON=$(gh release view "$TAG" --repo "$RELEASE_REPO" --json assets 2>&1); then
+    fail "Could not read release '$TAG' on $RELEASE_REPO (gh failed: ${ASSET_JSON})."
+  fi
+  HAS_ASSET=$(echo "$ASSET_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if any(a['name']=='$ASSET_NAME' for a in d.get('assets', [])) else 'no')")
+  if [[ "$HAS_ASSET" != "yes" ]]; then
+    fail "Release '$TAG' on $RELEASE_REPO has no '$ASSET_NAME' asset. Refusing to fall back to whatever demo app happens to be installed."
+  fi
+  echo "    Asset present."
+  echo ""
+
+  WANT_VERSION="${TAG#v}"
+  SOURCE_LABEL="$TAG"
+
+  if [[ "$APP_EXISTS" -eq 1 ]]; then
+    INSTALLED_VERSION=$(plist_get "$PLIST" CFBundleShortVersionString)
+  else
+    INSTALLED_VERSION=""
+  fi
+  SUMMARY_VERSION="$WANT_VERSION"
+
+  if [[ "$APP_EXISTS" -eq 0 ]]; then
+    echo "==> No demo app at '$DEST_APP'."
+  elif [[ -z "$INSTALLED_VERSION" ]]; then
+    echo "==> Demo app at '$DEST_APP' has no readable CFBundleShortVersionString — treating as stale."
+  elif [[ "$INSTALLED_VERSION" == "$WANT_VERSION" ]]; then
+    CURRENT=1
+    echo "==> Demo app is already at $INSTALLED_VERSION (matches newest tag $TAG)."
+  else
+    echo "==> Demo app is at $INSTALLED_VERSION, newest tag is $TAG ($WANT_VERSION) — stale."
+  fi
+  REFRESH_ARGS=(--from-release "$TAG" --dest "$DEST_APP" --no-launch)
+
+else
+  # ── --source ──────────────────────────────────────────────────────────────
+  HEAD_REF=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+  HEAD_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+  HEAD_SHORT=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+  SOURCE_LABEL="$HEAD_REF @ $HEAD_SHORT"
+  SUMMARY_VERSION="$HEAD_SHORT"
+  echo "==> Source checkout: $REPO_ROOT"
+  echo "    Ref: $HEAD_REF  SHA: $HEAD_SHA"
+  echo ""
+
+  if [[ "$APP_EXISTS" -eq 1 ]]; then
+    INSTALLED_SHA=$(plist_get "$PLIST" GhosttyCommit)
+  else
+    INSTALLED_SHA=""
+  fi
+
+  if [[ "$APP_EXISTS" -eq 0 ]]; then
+    echo "==> No demo app at '$DEST_APP'."
+  elif [[ -z "$INSTALLED_SHA" ]]; then
+    echo "==> Demo app at '$DEST_APP' has no recorded GhosttyCommit — treating as stale."
+  elif [[ "$INSTALLED_SHA" == "$HEAD_SHA" ]]; then
+    CURRENT=1
+    echo "==> Demo app already built from $HEAD_REF @ $HEAD_SHORT."
+  else
+    INSTALLED_SHORT="${INSTALLED_SHA:0:7}"
+    echo "==> Demo app was built from $INSTALLED_SHORT, checkout HEAD is $HEAD_SHORT — stale."
+  fi
+  REFRESH_ARGS=(--from-source --dest "$DEST_APP" --no-launch)
+fi
+
+echo ""
+
+# ── --check: report only, never mutate ──────────────────────────────────────
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  if [[ "$CURRENT" -eq 1 ]]; then
+    echo "OK: Ghostties Demo is current (source: $SOURCE_LABEL, dest: $DEST_APP)."
+    exit 0
+  else
+    echo "STALE: Ghostties Demo at '$DEST_APP' does not match $SOURCE_LABEL. Run demo-ready.sh (without --check) to refresh." >&2
+    exit 1
+  fi
+fi
+
+# ── Refresh if needed ────────────────────────────────────────────────────────
+DID_REFRESH=0
+if [[ "$CURRENT" -eq 1 ]]; then
+  echo "==> App already current — skipping refresh."
+else
+  echo "==> Refreshing: $REFRESH_SCRIPT ${REFRESH_ARGS[*]}"
+  "$REFRESH_SCRIPT" "${REFRESH_ARGS[@]}"
+  DID_REFRESH=1
+
+  if [[ "$MODE" == "source" ]]; then
+    echo "==> Recording built commit sha into Info.plist (GhosttyCommit)..."
+    /usr/libexec/PlistBuddy -c "Set :GhosttyCommit $HEAD_SHA" "$PLIST"
+  fi
+fi
+echo ""
+
+# ── Always reseed the fixture workspace ─────────────────────────────────────
+echo "==> Seeding fixture workspace..."
+"$SEED_SCRIPT"
+echo ""
+
+# ── Write manifest ───────────────────────────────────────────────────────────
+FIXTURE_COUNT=$(find "$FIXTURES_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+APP_MTIME_EPOCH=$(stat -f%m "$DEST_APP")
+APP_MTIME_ISO=$(date -u -r "$APP_MTIME_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+REFRESHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+if [[ "$MODE" == "release" ]]; then
+  INSTALLED_VERSION_NOW=$(plist_get "$PLIST" CFBundleShortVersionString)
+else
+  INSTALLED_VERSION_NOW=$(plist_get "$PLIST" GhosttyCommit)
+fi
+
+mkdir -p "$DEMO_STATE_DIR"
+chmod 700 "$DEMO_STATE_DIR"
+
+python3 - "$MANIFEST_PATH" <<PYEOF
+import json
+
+manifest = {
+    "demoAppVersion": "$INSTALLED_VERSION_NOW",
+    "mode": "$MODE",
+    "source": "$SOURCE_LABEL",
+    "destPath": "$DEST_APP",
+    "appBundleMtime": "$APP_MTIME_ISO",
+    "refreshedAt": "$REFRESHED_AT",
+    "fixtureProjectCount": $FIXTURE_COUNT,
+    "seededReposPath": "$REPOS_DIR",
+}
+
+with open("$MANIFEST_PATH", "w") as f:
+    json.dump(manifest, f, indent=2, sort_keys=True)
+PYEOF
+chmod 600 "$MANIFEST_PATH"
+
+echo "==> Wrote manifest: $MANIFEST_PATH"
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+if [[ "$DID_REFRESH" -eq 1 ]]; then
+  ACTION="refreshed"
+else
+  ACTION="already current"
+fi
+if [[ "$MODE" == "release" ]]; then
+  echo "Demo ready: Ghostties Demo v$SUMMARY_VERSION (source: $SOURCE_LABEL) — $ACTION"
+else
+  echo "Demo ready: Ghostties Demo @ $SUMMARY_VERSION (source: $SOURCE_LABEL) — $ACTION"
+fi

--- a/scripts/demo/demo-ready.sh
+++ b/scripts/demo/demo-ready.sh
@@ -26,19 +26,24 @@
 #
 # FLAGS
 #   --check         Report status and exit non-zero if stale or missing. Never
-#                   refreshes, never reseeds, never writes the manifest.
+#                   refreshes, never reseeds, never touches the app or fixture
+#                   workspace — but a PASSING check still writes the manifest,
+#                   since that's the record of which bundle it just verified.
 #   --dest <path>   Demo app path. Default: /Applications/Ghostties Demo.app
 #   --source        Use this checkout (refresh-demo.sh --from-source) instead
 #                   of the newest release. "Current" means the app's recorded
 #                   git sha equals this checkout's HEAD sha.
 #
 # MANIFEST
-#   Always written (on a non---check run) to:
+#   Written on every successful run (including a passing --check) to:
 #     ~/Library/Application Support/Ghostties Demo/demo-manifest.json
 #   regardless of --dest, because seed-demo-workspace.sh is likewise pinned to
 #   that fixed state directory (it is keyed off the demo bundle ID, not the
-#   app's install location). A capture run should copy this file next to
-#   whatever assets it produces — see scripts/demo/README.md.
+#   app's install location). destPath always records the resolved, absolute
+#   path of the app that was actually inspected — the manifest describes
+#   whatever bundle the run just checked or refreshed, not a fixed default.
+#   A capture run should copy this file next to whatever assets it produces —
+#   see scripts/demo/README.md.
 # =============================================================================
 set -euo pipefail
 
@@ -182,10 +187,54 @@ fi
 
 echo ""
 
-# ── --check: report only, never mutate ──────────────────────────────────────
+# ── Manifest writer: records exactly which bundle was just inspected/refreshed ─
+write_manifest() {
+  local dest_app_resolved
+  dest_app_resolved="$(cd "$(dirname "$DEST_APP")" && pwd)/$(basename "$DEST_APP")"
+
+  local fixture_count app_mtime_epoch app_mtime_iso refreshed_at installed_version_now
+  fixture_count=$(find "$FIXTURES_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  app_mtime_epoch=$(stat -f%m "$dest_app_resolved")
+  app_mtime_iso=$(date -u -r "$app_mtime_epoch" +"%Y-%m-%dT%H:%M:%SZ")
+  refreshed_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  if [[ "$MODE" == "release" ]]; then
+    installed_version_now=$(plist_get "$PLIST" CFBundleShortVersionString)
+  else
+    installed_version_now=$(plist_get "$PLIST" GhosttyCommit)
+  fi
+
+  mkdir -p "$DEMO_STATE_DIR"
+  chmod 700 "$DEMO_STATE_DIR"
+
+  python3 - "$MANIFEST_PATH" <<PYEOF
+import json
+
+manifest = {
+    "demoAppVersion": "$installed_version_now",
+    "mode": "$MODE",
+    "source": "$SOURCE_LABEL",
+    "destPath": "$dest_app_resolved",
+    "appBundleMtime": "$app_mtime_iso",
+    "refreshedAt": "$refreshed_at",
+    "fixtureProjectCount": $fixture_count,
+    "seededReposPath": "$REPOS_DIR",
+}
+
+with open("$MANIFEST_PATH", "w") as f:
+    json.dump(manifest, f, indent=2, sort_keys=True)
+PYEOF
+  chmod 600 "$MANIFEST_PATH"
+
+  echo "==> Wrote manifest: $MANIFEST_PATH"
+}
+
+# ── --check: report only, never touch the app/fixtures — but do record what
+#             was just verified, so a passing check can't leave a stale manifest
 if [[ "$CHECK_ONLY" -eq 1 ]]; then
   if [[ "$CURRENT" -eq 1 ]]; then
     echo "OK: Ghostties Demo is current (source: $SOURCE_LABEL, dest: $DEST_APP)."
+    write_manifest
     exit 0
   else
     echo "STALE: Ghostties Demo at '$DEST_APP' does not match $SOURCE_LABEL. Run demo-ready.sh (without --check) to refresh." >&2
@@ -215,40 +264,7 @@ echo "==> Seeding fixture workspace..."
 echo ""
 
 # ── Write manifest ───────────────────────────────────────────────────────────
-FIXTURE_COUNT=$(find "$FIXTURES_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-APP_MTIME_EPOCH=$(stat -f%m "$DEST_APP")
-APP_MTIME_ISO=$(date -u -r "$APP_MTIME_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
-REFRESHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-if [[ "$MODE" == "release" ]]; then
-  INSTALLED_VERSION_NOW=$(plist_get "$PLIST" CFBundleShortVersionString)
-else
-  INSTALLED_VERSION_NOW=$(plist_get "$PLIST" GhosttyCommit)
-fi
-
-mkdir -p "$DEMO_STATE_DIR"
-chmod 700 "$DEMO_STATE_DIR"
-
-python3 - "$MANIFEST_PATH" <<PYEOF
-import json
-
-manifest = {
-    "demoAppVersion": "$INSTALLED_VERSION_NOW",
-    "mode": "$MODE",
-    "source": "$SOURCE_LABEL",
-    "destPath": "$DEST_APP",
-    "appBundleMtime": "$APP_MTIME_ISO",
-    "refreshedAt": "$REFRESHED_AT",
-    "fixtureProjectCount": $FIXTURE_COUNT,
-    "seededReposPath": "$REPOS_DIR",
-}
-
-with open("$MANIFEST_PATH", "w") as f:
-    json.dump(manifest, f, indent=2, sort_keys=True)
-PYEOF
-chmod 600 "$MANIFEST_PATH"
-
-echo "==> Wrote manifest: $MANIFEST_PATH"
+write_manifest
 echo ""
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/demo/refresh-demo.sh
+++ b/scripts/demo/refresh-demo.sh
@@ -35,8 +35,10 @@
 #   - Never modifies ~/Library/Application Support/Ghostties/ (release workspace).
 #   - Never runs killall. Quit any existing instance before running.
 #   - arm64 only (GhosttyKit.xcframework is arm64-only).
-#   - Sparkle auto-update is DISABLED in the demo build (ad-hoc re-signing
-#     invalidates the Developer ID signature Sparkle needs). This script IS
+#   - Sparkle auto-checks are DISABLED and the feed is pointed at a
+#     deliberately-nonexistent URL (ad-hoc re-signing invalidates the
+#     Developer ID signature Sparkle needs, and a manual "Check for
+#     Updates…" must never resolve the real Ghostties feed). This script IS
 #     the demo's update mechanism — re-run it to refresh.
 # =============================================================================
 set -euo pipefail
@@ -201,18 +203,30 @@ PLIST="$DEST_APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Ghostties Demo"    "$PLIST"
 
 # Neutralise Sparkle — ad-hoc re-signing invalidates the Developer ID signature
-# Sparkle needs to trust an update, so leaving the feed URL in place would just
-# produce silent update failures. This script is the demo's update mechanism.
+# Sparkle needs to trust an update, so a manual "Check for Updates…" must
+# never resolve the real Ghostties feed. UpdateDelegate.feedURLString(for:)
+# honours an explicit Info.plist SUFeedURL first, so point it at a feed that
+# deliberately does not exist — a manual check 404s harmlessly instead of
+# installing the real app over this one. (SUFeedURL used to be deleted here,
+# which relied on the delegate falling through to the real channel feeds —
+# that was the bug: Sparkle trusts this byte-copy's signature.)
+DEMO_FEED_URL="https://ghostties.org/appcast-demo.xml"
 if /usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$PLIST" >/dev/null 2>&1; then
-  /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$PLIST"
-  echo "    Removed SUFeedURL."
+  /usr/libexec/PlistBuddy -c "Set :SUFeedURL $DEMO_FEED_URL" "$PLIST"
+else
+  /usr/libexec/PlistBuddy -c "Add :SUFeedURL string $DEMO_FEED_URL" "$PLIST"
 fi
+echo "    Set SUFeedURL to a deliberately-nonexistent demo feed."
+
+# Always set SUEnableAutomaticChecks, never delete it — Sparkle treats a
+# missing key as "prompt the user", while an explicit false means no
+# background checks. Add if absent, Set if present.
 if /usr/libexec/PlistBuddy -c "Print :SUEnableAutomaticChecks" "$PLIST" >/dev/null 2>&1; then
   /usr/libexec/PlistBuddy -c "Set :SUEnableAutomaticChecks false" "$PLIST"
 else
   /usr/libexec/PlistBuddy -c "Add :SUEnableAutomaticChecks bool false" "$PLIST"
 fi
-echo "    Sparkle disabled. This script is the demo's update mechanism — re-run it to refresh."
+echo "    Background auto-checks disabled. A manual check fails benignly (404) against the demo feed."
 
 echo "    Plist updated:"
 echo "      CFBundleIdentifier  = $(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$PLIST")"

--- a/scripts/demo/refresh-demo.sh
+++ b/scripts/demo/refresh-demo.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# =============================================================================
+# refresh-demo.sh — Produce/refresh Ghostties Demo.app for marketing capture
+#
+# PURPOSE
+#   Produces "Ghostties Demo.app" with bundle ID com.seansmithdesign.ghostties.demo,
+#   which causes WorkspacePersistence to resolve its state directory to
+#   "~/Library/Application Support/Ghostties Demo/" — completely isolated from
+#   the release ("Ghostties") and dev ("Ghostties Dev") workspaces.
+#
+# DEFAULT MODE: --from-release
+#   Downloads a published GitHub release artifact (the same binary Sean ships)
+#   and re-bundles it as the demo app. This is the correct source for a
+#   marketing demo — it matches what's actually shipping.
+#
+# USAGE
+#   ./scripts/demo/refresh-demo.sh                       # latest release (incl. pre-releases)
+#   ./scripts/demo/refresh-demo.sh --from-release v0.1.0-beta.24
+#   ./scripts/demo/refresh-demo.sh --from-source          # build local checkout (Debug)
+#   ./scripts/demo/refresh-demo.sh --from-source --pull-main
+#   ./scripts/demo/refresh-demo.sh --dest /tmp/x.app --no-launch
+#
+# FLAGS
+#   --from-release [TAG]  Download the published release asset and re-bundle it.
+#                          DEFAULT if no source flag is given. With no TAG, resolves
+#                          to the newest release (including pre-releases) on
+#                          SeanSmithWorks/ghostties. With TAG, uses that exact tag.
+#   --from-source          Build the current local checkout instead (Debug, arm64).
+#   --pull-main            Only valid with --from-source. Fetch origin + checkout
+#                          main + pull --ff-only BEFORE building.
+#   --dest <path>          Destination .app path. Default: /Applications/Ghostties Demo.app
+#   --no-launch            Skip the final `open` step.
+#
+# SAFETY
+#   - Never modifies ~/Library/Application Support/Ghostties/ (release workspace).
+#   - Never runs killall. Quit any existing instance before running.
+#   - arm64 only (GhosttyKit.xcframework is arm64-only).
+#   - Sparkle auto-update is DISABLED in the demo build (ad-hoc re-signing
+#     invalidates the Developer ID signature Sparkle needs). This script IS
+#     the demo's update mechanism — re-run it to refresh.
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCHEME="Ghostties"
+PROJECT="$REPO_ROOT/macos/Ghostties.xcodeproj"
+BUILD_DIR="$REPO_ROOT/.build-demo"
+BUNDLE_ID="com.seansmithdesign.ghostties.demo"
+RELEASE_REPO="SeanSmithWorks/ghostties"
+ASSET_NAME="ghostties-macos-arm64.zip"
+CACHE_DIR="$HOME/Library/Caches/ghostties-demo"
+
+MODE="from-release"
+RELEASE_TAG=""
+DEST_APP="/Applications/Ghostties Demo.app"
+DO_LAUNCH=1
+PULL_MAIN=0
+
+# ── Arg parsing ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from-release)
+      MODE="from-release"
+      shift
+      # Optional positional tag: only consume it if it doesn't look like another flag.
+      if [[ $# -gt 0 && "$1" != --* ]]; then
+        RELEASE_TAG="$1"
+        shift
+      fi
+      ;;
+    --from-source)
+      MODE="from-source"
+      shift
+      ;;
+    --pull-main)
+      PULL_MAIN=1
+      shift
+      ;;
+    --dest)
+      DEST_APP="$2"
+      shift 2
+      ;;
+    --no-launch)
+      DO_LAUNCH=0
+      shift
+      ;;
+    *)
+      echo "ERROR: Unrecognized argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$PULL_MAIN" -eq 1 && "$MODE" != "from-source" ]]; then
+  echo "ERROR: --pull-main is only valid with --from-source." >&2
+  exit 1
+fi
+
+echo "==> Ghostties Demo refresh"
+echo "    Mode: $MODE"
+echo "    Dest: $DEST_APP"
+echo ""
+
+BUILT_APP=""
+
+if [[ "$MODE" == "from-source" ]]; then
+  echo "    Repo: $REPO_ROOT"
+  echo "    Branch: $(git -C "$REPO_ROOT" branch --show-current)"
+  echo ""
+
+  if [[ "$PULL_MAIN" -eq 1 ]]; then
+    echo "==> [--pull-main] Fetching origin and switching to main..."
+    git -C "$REPO_ROOT" fetch origin
+    git -C "$REPO_ROOT" checkout main
+    git -C "$REPO_ROOT" pull --ff-only
+    echo "    Done. Now on: $(git -C "$REPO_ROOT" branch --show-current)"
+    echo ""
+  fi
+
+  echo "==> Phase 1: Building from source (Debug, arm64)..."
+  xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration Debug \
+    -derivedDataPath "$BUILD_DIR" \
+    ONLY_ACTIVE_ARCH=YES \
+    ARCHS=arm64 \
+    CODE_SIGN_IDENTITY="-" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    build \
+    | grep -E "^(Build|CompileSwift|error:|warning: build input|PhaseScriptExecution|== BUILD)" \
+    | head -200 || true
+
+  BUILT_APP=$(find "$BUILD_DIR/Build/Products/Debug" -maxdepth 1 -name "Ghostties Dev.app" -type d | head -1)
+  if [[ -z "$BUILT_APP" ]]; then
+    echo ""
+    echo "ERROR: Build output not found at $BUILD_DIR/Build/Products/Debug/Ghostties Dev.app"
+    echo "       Run xcodebuild without grep to see full error output."
+    exit 1
+  fi
+  echo "    Built: $BUILT_APP"
+  echo ""
+else
+  # ── from-release ────────────────────────────────────────────────────────────
+  if [[ -z "$RELEASE_TAG" ]]; then
+    echo "==> Resolving newest release (including pre-releases) on $RELEASE_REPO..."
+    RELEASE_TAG=$(gh release list --repo "$RELEASE_REPO" --limit 1 --json tagName -q '.[0].tagName')
+    if [[ -z "$RELEASE_TAG" ]]; then
+      echo "ERROR: Could not resolve a release tag from $RELEASE_REPO." >&2
+      exit 1
+    fi
+  fi
+  echo "    Resolved tag: $RELEASE_TAG"
+  echo ""
+
+  CACHED_ZIP="$CACHE_DIR/$RELEASE_TAG/$ASSET_NAME"
+  if [[ -f "$CACHED_ZIP" ]]; then
+    echo "==> Using cached asset: $CACHED_ZIP"
+  else
+    echo "==> Downloading $ASSET_NAME for $RELEASE_TAG (~147MB)..."
+    mkdir -p "$CACHE_DIR/$RELEASE_TAG"
+    TMP_DL_DIR="$(mktemp -d)"
+    gh release download "$RELEASE_TAG" \
+      --repo "$RELEASE_REPO" \
+      --pattern "$ASSET_NAME" \
+      --dir "$TMP_DL_DIR"
+    mv "$TMP_DL_DIR/$ASSET_NAME" "$CACHED_ZIP"
+    rm -rf "$TMP_DL_DIR"
+    echo "    Cached: $CACHED_ZIP"
+  fi
+  echo ""
+
+  echo "==> Unzipping release artifact..."
+  UNZIP_DIR="$(mktemp -d)"
+  ditto -x -k "$CACHED_ZIP" "$UNZIP_DIR"
+  BUILT_APP=$(find "$UNZIP_DIR" -maxdepth 2 -name "*.app" -type d | head -1)
+  if [[ -z "$BUILT_APP" ]]; then
+    echo "ERROR: No .app found inside $ASSET_NAME." >&2
+    exit 1
+  fi
+  echo "    Found: $BUILT_APP"
+  echo ""
+fi
+
+# ── Phase 2: Re-bundle ───────────────────────────────────────────────────────
+echo "==> Re-bundling to '$DEST_APP'..."
+
+mkdir -p "$(dirname "$DEST_APP")"
+if [[ -d "$DEST_APP" ]]; then
+  echo "    Removing previous $DEST_APP..."
+  rm -rf "$DEST_APP"
+fi
+
+cp -R "$BUILT_APP" "$DEST_APP"
+echo "    Copied."
+
+PLIST="$DEST_APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID"         "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName Ghostties Demo"           "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Ghostties Demo"    "$PLIST"
+
+# Neutralise Sparkle — ad-hoc re-signing invalidates the Developer ID signature
+# Sparkle needs to trust an update, so leaving the feed URL in place would just
+# produce silent update failures. This script is the demo's update mechanism.
+if /usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$PLIST" >/dev/null 2>&1; then
+  /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$PLIST"
+  echo "    Removed SUFeedURL."
+fi
+if /usr/libexec/PlistBuddy -c "Print :SUEnableAutomaticChecks" "$PLIST" >/dev/null 2>&1; then
+  /usr/libexec/PlistBuddy -c "Set :SUEnableAutomaticChecks false" "$PLIST"
+else
+  /usr/libexec/PlistBuddy -c "Add :SUEnableAutomaticChecks bool false" "$PLIST"
+fi
+echo "    Sparkle disabled. This script is the demo's update mechanism — re-run it to refresh."
+
+echo "    Plist updated:"
+echo "      CFBundleIdentifier  = $(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$PLIST")"
+echo "      CFBundleName        = $(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$PLIST")"
+echo "      CFBundleDisplayName = $(/usr/libexec/PlistBuddy -c 'Print :CFBundleDisplayName' "$PLIST")"
+echo "      CFBundleExecutable  = $(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$PLIST") (unchanged)"
+echo ""
+
+# ── Phase 3: Re-sign ad-hoc ──────────────────────────────────────────────────
+echo "==> Ad-hoc re-signing..."
+if [[ "$MODE" == "from-release" ]]; then
+  echo "    Clearing quarantine attribute (downloaded artifact)..."
+  xattr -dr com.apple.quarantine "$DEST_APP" || true
+fi
+codesign --force --deep --sign - "$DEST_APP"
+echo "    Signed. Verifying..."
+codesign --verify --deep "$DEST_APP"
+echo "    Verification passed."
+echo ""
+
+# ── Phase 4: Launch ──────────────────────────────────────────────────────────
+if [[ "$DO_LAUNCH" -eq 1 ]]; then
+  echo "==> Launching Ghostties Demo..."
+  open "$DEST_APP"
+  echo "    Launched."
+  echo ""
+else
+  echo "==> Skipping launch (--no-launch)."
+  echo ""
+fi
+
+echo "==> Done. Ghostties Demo is at:"
+echo "    $DEST_APP"
+echo "    State: ~/Library/Application Support/Ghostties Demo/workspace.json"
+echo ""
+echo "    To quit cleanly (never use killall):"
+echo "    osascript -e 'tell application \"Ghostties Demo\" to quit'"

--- a/scripts/demo/seed-demo-workspace.sh
+++ b/scripts/demo/seed-demo-workspace.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# =============================================================================
+# seed-demo-workspace.sh — Write isolated demo workspace.json for screen captures
+#
+# PURPOSE
+#   Seeds ~/Library/Application Support/Ghostties Demo/workspace.json with 10
+#   fictional projects that look realistic on camera. This directory is used
+#   exclusively by Ghostties Demo.app (bundle ID com.seansmithdesign.ghostties.demo).
+#   It NEVER touches ~/Library/Application Support/Ghostties/ (release workspace).
+#
+#   Each fixture in examples/demo-workspace/ is copied into
+#   "~/Library/Application Support/Ghostties Demo/repos/<name>/" and turned into
+#   a real git repo (git init, one commit; a few get an extra branch), so the
+#   demo has real repo state and doesn't depend on this checkout's branch.
+#
+# USAGE
+#   ./scripts/demo/seed-demo-workspace.sh
+#
+#   Idempotent / re-runnable. Any existing workspace.json is backed up to
+#   workspace.json.bak-<timestamp> before overwriting. Repo copies under
+#   repos/<name>/ are removed and recreated fresh on every run.
+#
+# NON-REPRODUCIBLE ITEMS (not handled here)
+#   - Branded shell prompt: `export PS1='ghostties ~/%1~ %% '`
+#     This is per-shell-session and must be set by hand at capture time.
+#     Making it persistent would require a demo-only ZDOTDIR override; that
+#     is out of scope for this script.
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURES_DIR="$REPO_ROOT/examples/demo-workspace"
+
+DEMO_DIR="$HOME/Library/Application Support/Ghostties Demo"
+TARGET="$DEMO_DIR/workspace.json"
+REPOS_DIR="$DEMO_DIR/repos"
+
+echo "==> Seeding Ghostties Demo workspace"
+echo "    Target: $TARGET"
+echo "    Repos:  $REPOS_DIR"
+echo ""
+
+# ── Safety check: never touch the release workspace ─────────────────────────
+RELEASE_DIR="$HOME/Library/Application Support/Ghostties"
+if [[ "$DEMO_DIR" == "$RELEASE_DIR" ]]; then
+  echo "ERROR: Demo dir resolved to release dir. Aborting."
+  exit 1
+fi
+
+# ── Create directories if needed ─────────────────────────────────────────────
+if [[ ! -d "$DEMO_DIR" ]]; then
+  echo "    Creating directory: $DEMO_DIR"
+  mkdir -p "$DEMO_DIR"
+  chmod 700 "$DEMO_DIR"
+fi
+mkdir -p "$REPOS_DIR"
+
+# ── Back up existing workspace.json ─────────────────────────────────────────
+if [[ -f "$TARGET" ]]; then
+  BACKUP="$DEMO_DIR/workspace.json.bak-$(date +%Y%m%dT%H%M%S)"
+  echo "    Backing up existing workspace.json -> $(basename "$BACKUP")"
+  cp "$TARGET" "$BACKUP"
+fi
+
+# ── Projects: (name, extra-branch-or-empty) ──────────────────────────────────
+declare -a PROJECT_SPECS=(
+  "atlas-api|"
+  "fieldwork|"
+  "pendulum|feat/live-activity-widget"
+  "silo|"
+  "switchboard|feat/webhook-hmac"
+  "trove|"
+  "wren|fix/export-pdf-fonts"
+  "brukas|"
+  "annotie|"
+  "ghostties|"
+)
+
+echo "==> Rebuilding fixture repos under $REPOS_DIR ..."
+for spec in "${PROJECT_SPECS[@]}"; do
+  IFS='|' read -r name extra_branch <<< "$spec"
+  src="$FIXTURES_DIR/$name"
+  dest="$REPOS_DIR/$name"
+
+  if [[ ! -d "$src" ]]; then
+    echo "ERROR: Fixture not found: $src" >&2
+    exit 1
+  fi
+
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -R "$src/." "$dest/"
+
+  git -C "$dest" init -q -b main
+  git -C "$dest" config user.name "Demo User"
+  git -C "$dest" config user.email "demo@example.com"
+  git -C "$dest" add -A
+  git -C "$dest" commit -q -m "Initial commit"
+
+  if [[ -n "$extra_branch" ]]; then
+    git -C "$dest" checkout -q -b "$extra_branch"
+    git -C "$dest" checkout -q main
+  fi
+
+  echo "    $name -> $dest ($(git -C "$dest" branch --show-current))"
+done
+echo ""
+
+# ── Generate JSON via python3 ────────────────────────────────────────────────
+echo "    Generating workspace.json with ${#PROJECT_SPECS[@]} projects..."
+
+python3 - "$TARGET" "$REPOS_DIR" <<'PYEOF'
+import sys
+import json
+import subprocess
+import datetime
+
+target_path = sys.argv[1]
+repos_dir = sys.argv[2]
+
+projects_spec = [
+    ("atlas-api",    "banshee"),
+    ("fieldwork",    "clyde"),
+    ("pendulum",     "ember"),
+    ("silo",         "haunt"),
+    ("switchboard",  "pinky"),
+    ("trove",        "specter"),
+    ("wren",         "wisp"),
+    ("brukas",       "jinx"),
+    ("annotie",      "mist"),
+    ("ghostties",    "wraith"),
+]
+
+def new_uuid():
+    result = subprocess.run(["uuidgen"], capture_output=True, text=True, check=True)
+    return result.stdout.strip().upper()
+
+now_base = datetime.datetime.utcnow()
+projects = []
+switchboard_id = None
+
+CLAUDE_CODE_TEMPLATE_ID = "00000000-0000-0000-0000-000000000002"
+
+for i, (name, ghost) in enumerate(projects_spec):
+    uid = new_uuid()
+    ts = (now_base - datetime.timedelta(hours=i * 3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    proj = {
+        "ghostCharacter": ghost,
+        "id": uid,
+        "isPinned": True,  # All projects pinned — renders control-tower disclosure rows
+        "lastActiveAt": ts,
+        "name": name,
+        "rootPath": f"{repos_dir}/{name}",
+    }
+    if name == "switchboard":
+        proj["defaultTemplateId"] = CLAUDE_CODE_TEMPLATE_ID
+        switchboard_id = uid
+    projects.append(proj)
+
+state = {
+    "hasDismissedPinMigrationNotice": True,
+    "hasShownPinMigrationNotice": True,
+    "lastSelectedProjectId": switchboard_id,
+    "projects": projects,
+    "sessions": [],
+    "sidebarMode": 0,
+    "templates": [],
+}
+
+with open(target_path, "w") as f:
+    json.dump(state, f, indent=2, sort_keys=True)
+
+print(f"    Written {len(projects)} projects.")
+print(f"    switchboard UUID: {switchboard_id}")
+print(f"    lastSelectedProjectId: {state['lastSelectedProjectId']}")
+PYEOF
+
+chmod 600 "$TARGET"
+
+echo ""
+echo "==> Verifying output..."
+python3 - "$TARGET" <<'PYEOF'
+import sys, json
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+projects = data['projects']
+print(f"    Project count : {len(projects)}")
+print(f"    sidebarMode   : {data['sidebarMode']}")
+print(f"    lastSelected  : {data['lastSelectedProjectId']}")
+
+all_pinned = all(p.get('isPinned') is True for p in projects)
+print(f"    All isPinned  : {all_pinned}")
+if not all_pinned:
+    not_pinned = [p['name'] for p in projects if not p.get('isPinned')]
+    print(f"    ERROR: unpinned projects: {not_pinned}")
+    sys.exit(1)
+
+switchboard = next((p for p in projects if p['name'] == 'switchboard'), None)
+if switchboard:
+    id_match = switchboard['id'] == data['lastSelectedProjectId']
+    default_tmpl = switchboard.get('defaultTemplateId', '<missing>')
+    print(f"    switchboard id: {switchboard['id']}")
+    print(f"    lastSelected == switchboard: {id_match}")
+    print(f"    defaultTemplateId : {default_tmpl}")
+    if default_tmpl != "00000000-0000-0000-0000-000000000002":
+        print("    ERROR: defaultTemplateId does not match AgentTemplate.claudeCode.id!")
+        sys.exit(1)
+else:
+    print("    ERROR: switchboard project not found!")
+    sys.exit(1)
+PYEOF
+
+# ── UI feature flags (NSUserDefaults — NOT in workspace.json) ────────────────
+# These must be set via `defaults write` against the demo bundle ID.
+# They are NOT stored in workspace.json; the app reads them from NSUserDefaults.
+#
+# NOTE: sidebarViewMode is intentionally set to "projectFirst", NOT "taskFirst".
+# taskFirst mode routes through TaskStore which leaks real global sessions from
+# the release app — not safe for demo captures.
+echo ""
+echo "==> Writing UI feature flags for com.seansmithdesign.ghostties.demo..."
+defaults write com.seansmithdesign.ghostties.demo ghostties.hasSeenOnboarding -bool true
+defaults write com.seansmithdesign.ghostties.demo ghostties.sidebarViewMode -string projectFirst
+defaults write com.seansmithdesign.ghostties.demo ghostties.sidebarTab -string projects
+echo "    ghostties.hasSeenOnboarding  = true"
+echo "    ghostties.sidebarViewMode    = projectFirst"
+echo "    ghostties.sidebarTab         = projects"
+
+echo ""
+echo "==> Done. Seed complete:"
+echo "    $TARGET"


### PR DESCRIPTION
The demo app used for marketing/social capture was a local Debug build from 2026-07-20, six weeks behind the shipped beta, and the entire rig was untracked — one `rm` from gone. This brings it under version control and makes staleness structurally unreachable.

## What changed

**`scripts/demo/demo-ready.sh` (new) — the single entrypoint.**
Refuses to proceed on a stale or missing demo app, refreshes it from the newest published release, seeds the fixtures, and stamps a manifest. `--check` asserts freshness and exits non-zero, so an agent sent to gather assets cannot silently capture from an old build.

**`refresh-demo.sh` now defaults to `--from-release`** — downloads the published `ghostties-macos-arm64.zip` and re-bundles it as `com.seansmithdesign.ghostties.demo` (cached per tag). `--from-source` keeps the old local-build path. No Xcode required to get a current demo.

**Fixtures are real git repos, seeded outside the checkout.** `workspace.json` used to point at `examples/demo-workspace/` inside the repo, which broke the moment the checkout changed branch. The seeder now copies fixtures to `~/Library/Application Support/Ghostties Demo/repos/`, `git init`s each, and gives several a second branch. Added a 10th fixture, `ghostties`.

**Closed a live Sparkle exposure.** The demo carries no `SUFeedURL`, but `UpdateDelegate.feedURLString(for:)` supplies the real beta feed and Sparkle gives the delegate priority over the plist — so "Check for Updates…" in the demo would have installed real Ghostties over `/Applications/Ghostties Demo.app`, destroying its isolation. Sparkle would not have blocked it: its validator accepts an install when *either* the EdDSA signature *or* the code signature is good, and the demo is a byte-copy carrying the same `SUPublicEDKey`. The delegate now honours an explicit plist `SUFeedURL` first (inert for the shipping app, which has none), and the rebundle sets a deliberately-unreachable demo feed plus `SUEnableAutomaticChecks=false`.

## Verification

- Full suite: 1099 passed, 1 failed, 1 skipped. The failure is a pre-existing timing flake in `GitWorktreeCreationTests`, untouched here.
- Both new tests mutation-proved: each was made to fail against a deliberate production edit, then restored.
- `shellcheck` clean on all three scripts.
- End-to-end against the real app: `demo-ready.sh --check` → `OK: Ghostties Demo is current (source: v0.1.0-beta.24)`, exit 0.

## Not covered

`--source` mode's build path has never been executed — it needs a real Xcode build. The comparison logic is implemented but untested end-to-end.

No changes to `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Z9rKHtTP8WQADnfgHogtL