### PR TITLE
docs: zero-chrome canvas sources + backlog through 2026-09-10

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2325,3 +2325,28 @@ Branch `feat/composer-variant-g`, 10 commits pushed to origin, UNMERGED.
 ## 2026-09-01 — PR #155 review round 2
 
 - [ ] **The macOS test target is never executed in CI.** `.github/workflows/test-ghostties.yml:151-155` runs `xcodebuild build-for-testing` only — compiled, never run. The `swift test` job covers `cli/` alone. Every macOS test in this repo rests on a local run by whoever last touched it. This is why fail-open assertions and unpinned globals matter more here than they would elsewhere. | quality | new
+
+## 2026-09-09 — Zero-chrome composer exploration (carried)
+
+Sean narrowed the ten directions to **zero-chrome (variant 09)** and asked for flow, hints and
+transition choreography, then for prior-art sourcing. Canvas:
+https://claude.ai/code/artifact/fbd31813-d56e-4a55-8f7a-3a9dea7239f9 · sources committed at
+`docs/design/composer/zero-chrome/`. **No direction is picked yet.**
+
+**Blocking on Sean (either can sink the direction):**
+- [ ] **Placement — centre-float vs docked band.** Every other open detail changes with the answer; the docked band deletes items 3–5 outright. Prior art is unanimous: vim's cmdline, fzf, Emacs' minibuffer and Fig all refuse to float over live content. See the `Placement` artboard. | experience | new
+- [ ] **Reduce Motion has no floor.** The direction rests on motion carrying the mode signal because nothing else is left. With Reduce Motion on there is no ramp, no lift, no stagger and no card — text simply exists. Every other direction in the set degrades gracefully; this one does not. If the static fallback needs a surface, the direction has a surface. | craft | new
+
+**Cheapest next move:**
+- [ ] Capture ~10s of the composer open with a build running, to see live output scrolling *under* stationary text. The card hid this completely; nobody has seen it. Static mockups cannot answer it. | craft | new
+
+**Remaining seven open details** — blur depth (6px proposed vs Raycast v2's 48px), user terminal
+themes breaking every contrast assumption, hover with no row background, nothing bounding width or
+row count, VoiceOver's lost container, and the armed-segment tint that
+[[reference_composer-field-cannot-tint-subranges]] says may not be buildable at the macOS 13 floor.
+All ten are written up worst-first on the canvas's **Unsolved** page; not duplicated here.
+
+**Also open (carried from 2026-09-06):**
+- [ ] PR #165 `fix/composer-return-to-shell` @ `d32fb32b6` — OPEN, MERGEABLE, CI green, but CI is
+  `build-for-testing` only and **its tests have never been executed anywhere**. Needs a build in the
+  main tree and Sean running the ⌘T flow. | build | carried 1×

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,28 @@
 # Ghostties — Backlog
 
+## 2026-09-05 — Composer-launched sessions die on exit instead of dropping to a shell
+
+Sean: after `wrap-continue` + exiting a Claude session launched from the composer, the
+surface shows "Process exited. Press any key to close the terminal." instead of returning
+to a live prompt — so the terminal has to be closed and reopened.
+
+**Diagnosed, not a regression from the composer stack.** `SessionCoordinator` writes a
+wrapper script per session and sets it as Ghostty's `command`, which *replaces* the shell.
+The script ends in `exec <cmd>` (`SessionCoordinator.swift:255`), so nothing survives the
+agent's exit. `exec` has been there since `dffde628d` (2026-03-24) and was deliberately
+restored in `e8dbf6ed7` (2026-04-27). What changed is Sean's habit: the old flow was a blank
+shell he typed `cco` into (child process, shell survives), the new flow is composer-launched.
+
+No `cco` template or preset exists — `workspace.json` holds 3 empty "New Template" rows and
+`~/.ghostties/presets/` has only `disk-cleanup.md` and `linear-sync`. `cco` is ad-hoc text.
+
+- [ ] **Decide:** land back on an interactive shell after the agent exits (replace
+  `exec \(cmd)` with `\(cmd)` + `exec zsh -i`), or leave as-is.
+  **Risk if changed:** the surface staying alive after the agent exits decouples "process
+  running" from "session running" — `setStatus(.running,)` and `subscribeToOutput` both
+  assume the surface dies with the agent, and indicator state lives in two caches. Not a
+  one-liner; needs the status engine checked.
+
 ## 2026-09-02 — CEF crash root-caused (Chromium 150→144 profile downgrade); overnight fix dispatched
 
 **Verdict (Fable 5.1):** Sean's Release CEF profile was written by Chromium 150; the Aug 1

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,40 @@
 # Ghostties — Backlog
 
+## 2026-09-10 — PR #165 + changelog merged; zero-chrome composer spike in review; beta.25 tag on hold
+
+- [x] **PR #165 exit-to-shell MERGED** `9d1c8710d` — 6/6 launcher-script tests executed
+  locally; full suite 1073, the 6 documented load flakes clean in isolation (35/35).
+- [x] **PR #168 beta.25 CHANGELOG section MERGED** `57b086d87`; `extract-release-notes.py
+  0.1.0-beta.25` passes on `main`.
+- [ ] **beta.25 tag ON HOLD** — Sean wants to see zero-chrome first, then decide whether
+  beta.25 ships today's composer or waits. Before tagging: full suite on `main` @
+  `57b086d87` (needs no `Ghostties Dev` instance running — the test host shares the `.dev`
+  bundle id), then `git tag -a v0.1.0-beta.25` from the orchestrator thread on his nod.
+- [ ] **Zero-chrome composer spike — draft PR #169** `feat/composer-zero-chrome` @
+  `01d2b8c3b`, behind `ghostties.composerStyle` = `zeroChrome` | `singleLine` (unset =
+  classic) and `ghostties.composerZeroChromeMaterial`. Sean's decisions 2026-09-10: centre
+  float, left-aligned text, wash takes over the full window, type larger/bolder (32pt
+  semibold field, 20pt rows, 75% measure 480–960pt); standard fallback = single line, no
+  list; descriptors cycle at rest with the chevron path never first. Three review rounds;
+  fourth (rounds 2–3) in progress. Dev app for Sean lives in the builder's agent worktree
+  `.claude/worktrees/agent-abdc9d9bfba62cfd5` — keep until he has reacted.
+- [ ] **DESIGN.md follow-ups if zero-chrome sticks:** semibold weight and 32pt on a floating
+  surface deviate from §3; a new "zero-chrome" surface class needs an entry; `ghostPlaceholder`
+  opacity 65% in new styles vs 50% classic.
+- [ ] **Stranded copy, pre-existing:** `SessionComposerCommandParser.swift:26` "Use the
+  create-branch suggestion above" was already wrong after PR #155 hid the pickers; PR #169
+  adds a second constant for the new styles, classic string still says "above".
+- [ ] **Test isolation:** app-hosted composer tests read the live
+  `com.seansmithdesign.ghostties.dev` defaults; PR #169 pins `styleOverrideForTesting:
+  .classic` at 24 call sites. Any future style flag needs the same seam. Subagents must
+  never `defaults write`/`delete` a real bundle id (one did, and wiped Sean's flag mid-review).
+- [ ] **Worktree cleanup after the tag:** `session-7` has a `macos/build` (GBs) plus
+  symlinked build inputs; the builder worktree above has its own `macos/build`. Disk was
+  15G → 13G free across the day.
+- [ ] **This docs branch (`worktree-session-7`) is not on `main`** — carries the zero-chrome
+  canvas sources (`docs/design/composer/zero-chrome/`) and three backlog entries. Merge via
+  this PR.
+
 ## 2026-09-06 — Composer Tab flow shipped; exit-to-shell fixed; ten redesign directions
 
 - [x] **PR #164 MERGED** — Tab accepts a segment + space, never a chevron. `main` @ `a0297a9d9`.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,26 @@
 # Ghostties — Backlog
 
+## 2026-09-06 — Composer Tab flow shipped; exit-to-shell fixed; ten redesign directions
+
+- [x] **PR #164 MERGED** — Tab accepts a segment + space, never a chevron. `main` @ `a0297a9d9`.
+  Verified by Sean in a real build: `ghostt` Tab `cco -n "testing"` Return runs clean.
+- [ ] **PR #165 open, UNVERIFIED — carried.** `fix/composer-return-to-shell` @ `d32fb32b6`.
+  Diff reviewed by hand, but no test run exists anywhere: agent worktrees lack
+  `GhosttyKit.xcframework`, `zig-out/`, `vendor/cef`. Build it and run the ⌘T flow before merge.
+- [ ] **Ten composer directions published — Sean to pick.** Artifact:
+  `https://claude.ai/code/artifact/b9f2eb46-8d4e-41f6-a061-6533f63f89b3`.
+  Mild 01-04, middle 05-07, wild 08-10. Claude's read: 01/03/06 strongest against the
+  minimal constraint, all three subtractive; 02 is the best idea with the worst fit;
+  08 is build-to-learn, not pick-from-a-page. Sources in the session scratchpad
+  (`shotfun/variant-NN.html` + `.swift`) — **scratch, not committed anywhere.**
+- [ ] **PARKED — `design-shotfun` skill is broken.** It calls `mcp__paper__*`; the server on
+  this machine is `pencil`, which refuses every call without a `.pen` file open in the GUI.
+  Skill also caps at 6 variants. Routed around by hand this session.
+- [ ] **PARKED — three fragments were authored broken** (05/06/07): section is `display:flex`
+  with no `flex-direction`, and both boards sit in an unclassed wrapper with no CSS, so
+  `.board{flex:1}` is inert and the boards collapse to ~0 width. Corrected in the page
+  wrapper, not in the fragments.
+
 ## 2026-09-05 — Composer-launched sessions die on exit instead of dropping to a shell
 
 Sean: after `wrap-continue` + exiting a Claude session launched from the composer, the
@@ -16,7 +37,11 @@ shell he typed `cco` into (child process, shell survives), the new flow is compo
 No `cco` template or preset exists — `workspace.json` holds 3 empty "New Template" rows and
 `~/.ghostties/presets/` has only `disk-cleanup.md` and `linear-sync`. `cco` is ad-hoc text.
 
-- [ ] **Decide:** land back on an interactive shell after the agent exits (replace
+- [x] **Decided 2026-09-06 (Sean): yes, default to a shell.** "If I want to go to orchestrator
+  template I would specify that." Implemented in PR #165 — the launcher script now runs the
+  agent in the foreground and ends `exec /bin/zsh -l`. **Tests never executed** (no build
+  inputs in any agent worktree) — needs a real lab build before merge.
+- [ ] ~~Decide~~ (superseded): land back on an interactive shell after the agent exits (replace
   `exec \(cmd)` with `\(cmd)` + `exec zsh -i`), or leave as-is.
   **Risk if changed:** the surface staying alive after the agent exits decouples "process
   running" from "session running" — `setStatus(.running,)` and `subscribeToOutput` both

--- a/docs/design/composer/zero-chrome/Branch.dc.html
+++ b/docs/design/composer/zero-chrome/Branch.dc.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 620px; line-height: 1.5; }
+    .term { position: relative; width: 672px; height: 336px; border-radius: 12px; overflow: hidden; background: #2D2D2D; }
+    .backdrop { position: absolute; inset: 0; padding: 16px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 17px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .wash { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .stack { position: absolute; top: 88px; left: 50%; transform: translateX(-50%); width: 360px; display: flex; flex-direction: column; gap: 16px; align-items: center; }
+    .query { font-size: 15px; font-weight: 400; color: #f0efed; display: flex; align-items: center; }
+    .ghost { color: #f0efed; opacity: 0.50; }
+    .caret { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+    .rows { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+    .row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; font-size: 13px; font-weight: 500; color: #f0efed; opacity: 0.55; }
+    .row.on { opacity: 1; color: #5B8DEF; }
+    .meta { font-size: 11px; font-weight: 400; color: #9a9a9a; }
+    .note { display: flex; gap: 8px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.5; max-width: 672px; }
+    .pin { width: 4px; height: 4px; border-radius: 50%; background: #5B8DEF; margin-top: 6px; flex: none; }
+    .warn { background: #C97350; }
+    .seg { color: #5B8DEF; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">03 · Branch armed — a typed &gt; only</div>
+    <div class="ttl">The accent is the only thing that says "this is structure now"</div>
+    <div class="sub">On a card, a chip or a tinted field background could mark the armed segment. With no surface to tint, the tint has to land on the glyphs themselves — #5B8DEF on the branch segment, no layout shift, 100ms crossfade.</div>
+  </div>
+  <div class="term">
+    <div class="backdrop">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment and a space
+d32fb32  fix(session): drop back to a shell instead of closing
+ef1267e  Merge pull request #163 from seansmithworks/docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+    <div class="wash"></div>
+    <div class="stack">
+      <div class="query">ghostties <span class="seg">&gt; mai</span><span class="ghost">n</span><span class="caret"></span></div>
+      <div class="rows">
+        <div class="row on"><span>main</span><span class="meta">default</span></div>
+        <div class="row"><span>fix/composer-return-to-shell</span><span class="meta">recent</span></div>
+        <div class="row"><span>docs/backlog-2026-09-06</span><span class="meta"></span></div>
+      </div>
+    </div>
+  </div>
+  <div class="note"><div class="pin"></div><div>Tinting live glyphs is the one place this direction fights the codebase: <code>reference_composer-field-cannot-tint-subranges</code> says the field cannot colour sub-ranges at the macOS 13 floor. This needs the ghost-subview trick the remainder ghost already uses, or it needs to degrade to no tint on 13.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Commit.dc.html
+++ b/docs/design/composer/zero-chrome/Commit.dc.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 620px; line-height: 1.5; }
+    .term { position: relative; width: 672px; height: 336px; border-radius: 12px; overflow: hidden; background: #2D2D2D; }
+    .backdrop { position: absolute; inset: 0; padding: 16px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 17px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .wash { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .stack { position: absolute; top: 88px; left: 50%; transform: translateX(-50%); width: 360px; display: flex; flex-direction: column; gap: 16px; align-items: center; }
+    .query { font-size: 15px; font-weight: 400; color: #f0efed; display: flex; align-items: center; }
+    .ghost { color: #f0efed; opacity: 0.50; }
+    .caret { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+    .rows { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+    .row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; font-size: 13px; font-weight: 500; color: #f0efed; opacity: 0.55; }
+    .row.on { opacity: 1; color: #5B8DEF; }
+    .meta { font-size: 11px; font-weight: 400; color: #9a9a9a; }
+    .note { display: flex; gap: 8px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.5; max-width: 672px; }
+    .pin { width: 4px; height: 4px; border-radius: 50%; background: #5B8DEF; margin-top: 6px; flex: none; }
+    .warn { background: #C97350; }
+    .wash.half { backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px); }
+    .stack.going { opacity: 0.28; transform: translateX(-50%) translateY(-6px); }
+    .seg { color: #5B8DEF; }
+    .arrow { font-size: 11px; color: #5B8DEF; letter-spacing: 0.04em; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">04 · Commit — Return pressed, mid-flight</div>
+    <div class="ttl">The terminal coming back into focus is the confirmation</div>
+    <div class="sub">Captured ~60ms after Return. Text has lifted 6px and dropped to 28%; the blur is unwinding 6px&nbsp;→&nbsp;0 behind it. There is no card to slide away, so the sharpening backdrop is what tells you the session took the command.</div>
+  </div>
+  <div class="term">
+    <div class="backdrop">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment and a space
+d32fb32  fix(session): drop back to a shell instead of closing
+ef1267e  Merge pull request #163 from seansmithworks/docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+    <div class="wash half"></div>
+    <div class="stack going">
+      <div class="query">ghostties <span class="seg">&gt; main</span> claude</div>
+    </div>
+  </div>
+  <div class="note"><div class="pin"></div><div><strong style="color:#f0efed">Blur must lag the text.</strong> Text leaves first (100ms), blur unwinds behind it (160ms). Reverse that ordering and it reads as a popup closing; in this order it reads as a mode releasing. That single timing relationship is what makes zero-chrome feel deliberate rather than missing.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Contrast.dc.html
+++ b/docs/design/composer/zero-chrome/Contrast.dc.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 720px; line-height: 1.5; }
+    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+    .colhd { font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: #636363; }
+    .cell { display: flex; flex-direction: column; gap: 6px; }
+    .stage { position: relative; height: 128px; border-radius: 6px; overflow: hidden; }
+    .stage.dk { background: #2D2D2D; }
+    .stage.lt { background: #FAF7F3; }
+    .bd { position: absolute; inset: 0; padding: 10px 12px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; line-height: 16px; white-space: pre; opacity: 0.85; }
+    .stage.dk .bd { color: #f0efed; }
+    .stage.lt .bd { color: #1a1a1a; }
+    .hot { color: #6fcf97; }
+    .stage.lt .hot { color: #2d7d46; }
+    .bl { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .floor { position: absolute; left: 0; right: 0; top: 42px; height: 44px; }
+    .stage.dk .floor { background: radial-gradient(ellipse 70% 100% at 50% 50%, rgba(45,45,45,0.92) 0%, rgba(45,45,45,0.55) 55%, rgba(45,45,45,0) 100%); }
+    .stage.lt .floor { background: radial-gradient(ellipse 70% 100% at 50% 50%, rgba(250,247,243,0.94) 0%, rgba(250,247,243,0.6) 55%, rgba(250,247,243,0) 100%); }
+    .txt { position: absolute; left: 0; right: 0; top: 54px; text-align: center; font-size: 15px; }
+    .stage.dk .txt { color: #f0efed; }
+    .stage.lt .txt { color: #1a1a1a; }
+    .o50 { opacity: 0.50; }
+    .o65 { opacity: 0.65; }
+    .cap { font-size: 10px; color: #636363; line-height: 1.45; }
+    .cap b { color: #9a9a9a; font-weight: 500; }
+    .pass { color: #6fcf97; }
+    .fail { color: #FF6B6B; }
+    .verdict { display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; background: #2a2a2a; border-radius: 6px; padding: 14px 16px; }
+    .verdict strong { color: #f0efed; }
+    .bar { width: 2px; align-self: stretch; background: #5B8DEF; border-radius: 1px; flex: none; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Hints — the legibility cost, measured</div>
+    <div class="ttl">Zero-chrome forces the contrast fix that has been deferred twice</div>
+    <div class="sub">The 50% ghost grey is a knowingly-accepted WCAG failure — DESIGN.md records ≈3.0:1 in light mode against the 4.5:1 floor, and notes 65% clears it at 4.74:1. On a card that was a defensible tradeoff. Over live terminal output it stops being defensible, because the background is no longer under our control.</div>
+  </div>
+
+  <div class="grid">
+    <div class="cell"><div class="colhd">50% — as shipped</div>
+      <div class="stage dk">
+        <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+  ready in 1.2s
+$ git push origin HEAD
+  everything up-to-date</div>
+        <div class="bl"></div>
+        <div class="txt o50">ghostties &gt; main &gt; claude</div>
+      </div>
+      <div class="cap"><b class="fail">Loses.</b> Bright build output punches straight through 6px of blur and competes glyph-for-glyph.</div>
+    </div>
+
+    <div class="cell"><div class="colhd">65% — AA-clearing</div>
+      <div class="stage dk">
+        <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+  ready in 1.2s
+$ git push origin HEAD
+  everything up-to-date</div>
+        <div class="bl"></div>
+        <div class="txt o65">ghostties &gt; main &gt; claude</div>
+      </div>
+      <div class="cap"><b>Better, not solved.</b> Readable against dim rows; still contends with the green line.</div>
+    </div>
+
+    <div class="cell"><div class="colhd">65% + local floor</div>
+      <div class="stage dk">
+        <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+  ready in 1.2s
+$ git push origin HEAD
+  everything up-to-date</div>
+        <div class="bl"></div>
+        <div class="floor"></div>
+        <div class="txt o65">ghostties &gt; main &gt; claude</div>
+      </div>
+      <div class="cap"><b class="pass">Holds.</b> A soft radial wash of the canvas colour, following the text block — no edge, no rectangle, no scrim.</div>
+    </div>
+
+    <div class="cell">
+      <div class="stage lt">
+        <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+  ready in 1.2s
+$ git push origin HEAD
+  everything up-to-date</div>
+        <div class="bl"></div>
+        <div class="txt o50">ghostties &gt; main &gt; claude</div>
+      </div>
+      <div class="cap"><b class="fail">Worst case.</b> Light mode at 50% is the measured ≈3.0:1 failure, now with live text under it.</div>
+    </div>
+
+    <div class="cell">
+      <div class="stage lt">
+        <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+  ready in 1.2s
+$ git push origin HEAD
+  everything up-to-date</div>
+        <div class="bl"></div>
+        <div class="txt o65">ghostties &gt; main &gt; claude</div>
+      </div>
+      <div class="cap"><b>4.74:1</b> against a flat canvas — but the canvas is not flat here.</div>
+    </div>
+
+    <div class="cell">
+      <div class="stage lt">
+        <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+  ready in 1.2s
+$ git push origin HEAD
+  everything up-to-date</div>
+        <div class="bl"></div>
+        <div class="floor"></div>
+        <div class="txt o65">ghostties &gt; main &gt; claude</div>
+      </div>
+      <div class="cap"><b class="pass">Holds.</b> Same wash, canvas colour swapped. This is the recommended pair.</div>
+    </div>
+  </div>
+
+  <div class="verdict"><div class="bar"></div><div><strong>Is the local floor still "zero-chrome"?</strong> That is the question this direction turns on, and it is yours. It has no edge, no radius, no shadow and no fixed bounds — it is a gradient that follows text. But it is a surface, and if the answer is that any surface disqualifies the direction, then zero-chrome ships with a known contrast failure over uncontrolled backgrounds. Both answers are legitimate; only one of them is currently written down.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Error.dc.html
+++ b/docs/design/composer/zero-chrome/Error.dc.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 620px; line-height: 1.5; }
+    .term { position: relative; width: 672px; height: 336px; border-radius: 12px; overflow: hidden; background: #2D2D2D; }
+    .backdrop { position: absolute; inset: 0; padding: 16px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 17px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .wash { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .stack { position: absolute; top: 88px; left: 50%; transform: translateX(-50%); width: 360px; display: flex; flex-direction: column; gap: 16px; align-items: center; }
+    .query { font-size: 15px; font-weight: 400; color: #f0efed; display: flex; align-items: center; }
+    .ghost { color: #f0efed; opacity: 0.50; }
+    .caret { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+    .rows { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+    .row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; font-size: 13px; font-weight: 500; color: #f0efed; opacity: 0.55; }
+    .row.on { opacity: 1; color: #5B8DEF; }
+    .meta { font-size: 11px; font-weight: 400; color: #9a9a9a; }
+    .note { display: flex; gap: 8px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.5; max-width: 672px; }
+    .pin { width: 4px; height: 4px; border-radius: 50%; background: #5B8DEF; margin-top: 6px; flex: none; }
+    .warn { background: #C97350; }
+    .seg { color: #5B8DEF; }
+    .err { font-size: 11px; color: #FF6B6B; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">05 · Typed branch not found</div>
+    <div class="ttl">The status strip is the one element that must stay loud</div>
+    <div class="sub">Everything else in this direction gets quieter. The failure message goes the other way — it is the only text here allowed to break the tonal range, because a silent failure over a live terminal is indistinguishable from nothing happening.</div>
+  </div>
+  <div class="term">
+    <div class="backdrop">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment and a space
+d32fb32  fix(session): drop back to a shell instead of closing
+ef1267e  Merge pull request #163 from seansmithworks/docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+    <div class="wash"></div>
+    <div class="stack">
+      <div class="query">ghostties <span class="seg">&gt; mian</span><span class="caret"></span></div>
+      <div class="err">branch "mian" not found</div>
+    </div>
+  </div>
+  <div class="note"><div class="pin warn"></div><div><strong style="color:#C97350">Watch this one in review.</strong> Deleting a control stranded its copy once already (<code>feedback_deleting-a-control-strands-its-copy</code>) — two live strings still told users to "pick one from the branch picker" after the picker was removed. Removing chrome means grepping user-visible strings in the same commit, not just code.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Exit.dc.html
+++ b/docs/design/composer/zero-chrome/Exit.dc.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 720px; line-height: 1.5; }
+    .pair { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
+    .cell { display: flex; flex-direction: column; gap: 8px; }
+    .lbl { display: flex; align-items: baseline; gap: 8px; }
+    .k { font-size: 11px; font-weight: 600; color: #f0efed; }
+    .kk { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; color: #5B8DEF; }
+
+    .term { position: relative; width: 100%; height: 200px; border-radius: 8px; overflow: hidden; background: #2D2D2D; }
+    .bd { position: absolute; inset: 0; padding: 12px 14px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; line-height: 16px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .st { position: absolute; top: 76px; left: 0; right: 0; text-align: center; font-size: 15px; color: #f0efed; }
+    .seg { color: #5B8DEF; }
+
+    .bl-c { position: absolute; inset: 0; animation: blurC 2800ms ease-out infinite; }
+    .st-c { animation: textC 2800ms ease-out infinite; }
+    .bl-d { position: absolute; inset: 0; animation: blurD 2800ms ease-out infinite; }
+    .st-d { animation: textD 2800ms ease-out infinite; }
+
+    @keyframes blurC {
+      0%, 28.6%   { backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+      35.7%, 78.6%{ backdrop-filter: blur(0px); -webkit-backdrop-filter: blur(0px); }
+      82.1%, 100% { backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    }
+    @keyframes textC {
+      0%, 28.6%   { opacity: 1; transform: translateY(0); }
+      32.1%, 82.0%{ opacity: 0; transform: translateY(-6px); }
+      82.1%       { opacity: 0; transform: translateY(0); }
+      85.7%, 100% { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes blurD {
+      0%, 28.6%   { backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+      35.0%, 78.6%{ backdrop-filter: blur(0px); -webkit-backdrop-filter: blur(0px); }
+      82.1%, 100% { backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    }
+    @keyframes textD {
+      0%, 28.6%   { opacity: 1; transform: translateY(0); }
+      32.9%, 82.1%{ opacity: 0; transform: translateY(0); }
+      85.7%, 100% { opacity: 1; transform: translateY(0); }
+    }
+
+    .rail { position: relative; height: 14px; background: #2a2a2a; border-radius: 3px; }
+    .sg { position: absolute; top: 0; height: 14px; border-radius: 3px; font-size: 9px; display: flex; align-items: center; justify-content: center; }
+    .b1 { background: #6fcf97; color: #0e2416; }
+    .b2 { background: #5B8DEF; color: #0e1a2e; }
+    .trk { display: flex; flex-direction: column; gap: 4px; }
+    .tn { font-size: 10px; color: #9a9a9a; }
+    .cap { font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .cap strong { color: #f0efed; }
+    .verdict { display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; background: #2a2a2a; border-radius: 6px; padding: 12px 14px; }
+    .bar { width: 2px; align-self: stretch; background: #5B8DEF; border-radius: 1px; flex: none; }
+    .verdict strong { color: #f0efed; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Motion — the two exits</div>
+    <div class="ttl">Commit lifts. Dismiss does not. That 6px is the whole distinction.</div>
+    <div class="sub">With a card, Return and Escape could look identical — the card sliding away was the event, and what happened next was somebody else's problem. With nothing on screen but text, the exit is the only chance to say whether anything was launched.</div>
+  </div>
+
+  <div class="pair">
+    <div class="cell">
+      <div class="lbl"><span class="k">Commit</span><span class="kk">⏎</span></div>
+      <div class="term">
+        <div class="bd">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment
+d32fb32  fix(session): drop back to a shell
+ef1267e  Merge pull request #163 from docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s</span>
+$ </div>
+        <div class="bl-c"></div>
+        <div class="st st-c">ghostties <span class="seg">&gt; main</span> claude</div>
+      </div>
+      <div class="trk"><div class="tn">Text · lift 6px + fade</div><div class="rail"><div class="sg b1" style="left:0;width:35%">100ms</div></div></div>
+      <div class="trk"><div class="tn">Blur · 6 → 0</div><div class="rail"><div class="sg b2" style="left:14%;width:56%">160ms</div></div></div>
+      <div class="cap"><strong>Reads as departure.</strong> The text leaves upward and the terminal sharpens behind it — the session took the command.</div>
+    </div>
+
+    <div class="cell">
+      <div class="lbl"><span class="k">Dismiss</span><span class="kk">esc</span></div>
+      <div class="term">
+        <div class="bd">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment
+d32fb32  fix(session): drop back to a shell
+ef1267e  Merge pull request #163 from docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s</span>
+$ </div>
+        <div class="bl-d"></div>
+        <div class="st st-d">ghostties <span class="seg">&gt; main</span> claude</div>
+      </div>
+      <div class="trk"><div class="tn">Text · fade only, no lift</div><div class="rail"><div class="sg b1" style="left:0;width:42%">120ms</div></div></div>
+      <div class="trk"><div class="tn">Blur · 6 → 0</div><div class="rail"><div class="sg b2" style="left:7%;width:49%">140ms</div></div></div>
+      <div class="cap"><strong>Reads as cancellation.</strong> Nothing travels anywhere; the mode simply releases and the terminal returns.</div>
+    </div>
+  </div>
+
+  <div class="verdict"><div class="bar"></div><div><strong>Both exits keep blur trailing text.</strong> The text is gone before the backdrop finishes resolving, in both cases — that ordering is what makes the terminal feel like it was underneath the whole time rather than replacing something. It is also the cheapest part of this whole direction to build: two <code>withAnimation</code> blocks where there are currently none.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/HintLadder.dc.html
+++ b/docs/design/composer/zero-chrome/HintLadder.dc.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 700px; line-height: 1.5; }
+    .ladder { display: flex; flex-direction: column; gap: 12px; }
+    .rung { display: grid; grid-template-columns: 84px 300px minmax(0, 1fr); gap: 16px; align-items: start; padding: 12px 0; border-top: 1px solid #2a2a2a; }
+    .when { font-size: 11px; font-weight: 500; color: #5B8DEF; line-height: 1.4; }
+    .when em { display: block; font-style: normal; color: #9a9a9a; font-weight: 400; margin-top: 2px; }
+    .demo { background: #2D2D2D; border-radius: 6px; padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; min-height: 34px; justify-content: center; }
+    .q { font-size: 15px; color: #f0efed; display: flex; align-items: center; }
+    .g50 { color: #f0efed; opacity: 0.50; }
+    .g65 { color: #f0efed; opacity: 0.65; }
+    .caret { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+    .r { font-size: 13px; font-weight: 500; color: #f0efed; opacity: 0.55; }
+    .r.on { opacity: 1; color: #5B8DEF; }
+    .keys { display: flex; gap: 14px; font-size: 11px; color: #f0efed; opacity: 0.35; }
+    .err { font-size: 11px; color: #FF6B6B; }
+    .exp { font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .exp strong { color: #f0efed; font-weight: 500; }
+    .tag { display: inline-block; font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 6px; border-radius: 3px; margin-bottom: 6px; }
+    .ships { background: #1f3a2a; color: #6fcf97; }
+    .new { background: #1f2f4a; color: #5B8DEF; }
+    .risk { background: #3a2a1f; color: #C97350; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Hints — the affordance ladder</div>
+    <div class="ttl">Four moments teach the whole grammar. Three of them already ship.</div>
+    <div class="sub">Zero-chrome does not need new teaching surfaces — it needs the existing ones to stop being decoration and start being load-bearing. Only rung 2 has a genuine hole, and it was opened by PR #155, not by this direction.</div>
+  </div>
+  <div class="ladder">
+
+    <div class="rung">
+      <div class="when">t = 0<em>empty, focused</em></div>
+      <div class="demo">
+        <div class="q"><span class="caret"></span><span class="g50">ghostties &gt; main &gt; claude</span></div>
+      </div>
+      <div class="exp"><span class="tag ships">Ships today</span><br><strong>The ghost placeholder is the best hint in the product.</strong> It renders the exact path Return would commit — sourced from the same computation a commit reads, so it can never name a destination Return would not launch. It teaches the grammar by demonstrating it, with zero instructional copy. Keep it untouched.</div>
+    </div>
+
+    <div class="rung">
+      <div class="when">first keystroke<em>— or ↓</em></div>
+      <div class="demo">
+        <div class="q">ghos<span class="g50">ties</span><span class="caret"></span></div>
+        <div class="r on">ghostties</div>
+        <div class="r">ghostties-web</div>
+      </div>
+      <div class="exp"><span class="tag risk">Real hole</span><br><strong>Type-to-reveal removes the last browse path.</strong> PR #155 deleted the project and branch picker controls; the results list is now the only mouse entry point into browsing. If rows appear only while typing, a user who does not know what to type has nothing to look at.<br><br>Fix, and it is small: <strong>↓ reveals the list too.</strong> Arrow-down on an empty field shows the lanes without committing to a query. Keeps rest state clean, keeps discovery alive.</div>
+    </div>
+
+    <div class="rung">
+      <div class="when">first runs<em>decays away</em></div>
+      <div class="demo">
+        <div class="q"><span class="caret"></span><span class="g50">ghostties &gt; main &gt; claude</span></div>
+        <div class="keys"><span>⏎ launch</span><span>⇥ complete</span><span>&gt; branch</span><span>esc dismiss</span></div>
+      </div>
+      <div class="exp"><span class="tag new">Proposed</span><br><strong>A key line that expires.</strong> One 11pt row at 35%, shown on the first few summons and faded permanently after ~5 successful launches. It is not chrome because it does not persist — it is onboarding that removes itself. This is the only new element this direction adds, and it exists purely to cover the moment before the ghost placeholder has taught anything.</div>
+    </div>
+
+    <div class="rung">
+      <div class="when">on failure<em>any time</em></div>
+      <div class="demo">
+        <div class="q">ghostties &gt; mian<span class="caret"></span></div>
+        <div class="err">branch "mian" not found</div>
+      </div>
+      <div class="exp"><span class="tag ships">Ships today</span><br><strong>The status strip stays exactly as it is.</strong> One occupant, rendered only when non-nil, red. Everything else in this direction gets quieter; this does not. Over a live terminal a quiet failure is invisible.</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/JobsHandoff.dc.html
+++ b/docs/design/composer/zero-chrome/JobsHandoff.dc.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 700px; line-height: 1.5; }
+    .tbl { display: grid; grid-template-columns: 132px 1fr 1fr 64px; gap: 0; }
+    .th { font-size: 9px; letter-spacing: 0.07em; text-transform: uppercase; color: #636363; padding: 0 12px 8px 0; border-bottom: 1px solid #2a2a2a; }
+    .td { font-size: 11px; color: #9a9a9a; line-height: 1.5; padding: 12px 12px 12px 0; border-bottom: 1px solid #2a2a2a; }
+    .td.job { color: #f0efed; font-weight: 500; }
+    .td.own { color: #f0efed; }
+    .td.own em { font-style: normal; color: #5B8DEF; }
+    .lv { font-size: 9px; letter-spacing: 0.05em; text-transform: uppercase; padding: 3px 6px; border-radius: 3px; display: inline-block; }
+    .ok { background: #1f3a2a; color: #6fcf97; }
+    .mid { background: #3a2a1f; color: #C97350; }
+    .bad { background: #3a1f1f; color: #FF6B6B; }
+    .verdict { display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; background: #2a2a2a; border-radius: 6px; padding: 14px 16px; }
+    .verdict strong { color: #f0efed; }
+    .bar { width: 2px; align-self: stretch; background: #5B8DEF; border-radius: 1px; flex: none; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Hints — what the card was actually doing</div>
+    <div class="ttl">The card holds six jobs. Removing it reassigns all six.</div>
+    <div class="sub">"Zero-chrome" sounds subtractive, and mostly it is. But four of these jobs are invisible until they are gone, and two of them do not have a free replacement.</div>
+  </div>
+
+  <div class="tbl">
+    <div class="th">Job</div><div class="th">How the card did it</div><div class="th">Zero-chrome owner</div><div class="th">Risk</div>
+
+    <div class="td job">Boundary</div>
+    <div class="td">12pt radius + edge — says "surface, not terminal output"</div>
+    <div class="td own">Backdrop blur alone. Detail drops out behind the text; luminance does not change.</div>
+    <div class="td"><span class="lv mid">Medium</span></div>
+
+    <div class="td job">Legibility floor</div>
+    <div class="td"><code>.regularMaterial</code> + windowBackgroundColor at <code>.blendMode(.color)</code>. <code>.ultraThinMaterial</code> was already too weak once the scrim went.</div>
+    <div class="td own">Blur, plus <em>raising ghost opacity 50% → 65%</em>. Nothing else. There is no material without a surface to apply it to.</div>
+    <div class="td"><span class="lv bad">High</span></div>
+
+    <div class="td job">Mode signal</div>
+    <div class="td">The card appearing. It cuts in instantly — there is no present animation in 3,401 lines.</div>
+    <div class="td own"><em>Caret morph</em> block → 1.5px bar, plus the blur ramp. Lands where the eye already is.</div>
+    <div class="td"><span class="lv ok">Low</span></div>
+
+    <div class="td job">Grouping</div>
+    <div class="td">The card's bounds bind field and rows into one object.</div>
+    <div class="td own">Alignment and rhythm only — <em>left-align the stack to the caret</em>, 16pt gap. Centring forfeits this.</div>
+    <div class="td"><span class="lv mid">Medium</span></div>
+
+    <div class="td job">Elevation</div>
+    <div class="td">Shadow 0.30 / 24 / y8 — tuned up in PR #132 specifically because no scrim backs it.</div>
+    <div class="td own">Blur depth carries the whole "on top of" read. No shadow exists without an edge to cast one.</div>
+    <div class="td"><span class="lv mid">Medium</span></div>
+
+    <div class="td job">Dismiss target</div>
+    <div class="td">Click outside the card.</div>
+    <div class="td own"><em>Unchanged.</em> <code>SessionComposerOverlay</code>'s invisible dismiss layer already spans the whole terminal, minus the titlebar band.</div>
+    <div class="td"><span class="lv ok">None</span></div>
+  </div>
+
+  <div class="verdict"><div class="bar"></div><div><strong>The honest summary:</strong> five of six jobs find a real owner. Legibility does not — it degrades, by design, and variant 09's own note admits it. That is the price of this direction and it should be paid knowingly, not discovered in review. The mitigation on the next board is the only one available that is not a card and not a scrim.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Main.dc.html
+++ b/docs/design/composer/zero-chrome/Main.dc.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 620px; line-height: 1.5; }
+    .term { position: relative; width: 672px; height: 336px; border-radius: 12px; overflow: hidden; background: #2D2D2D; }
+    .backdrop { position: absolute; inset: 0; padding: 16px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 17px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .wash { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .stack { position: absolute; top: 104px; left: 50%; transform: translateX(-50%); width: 360px; display: flex; flex-direction: column; gap: 16px; align-items: center; }
+    .query { font-size: 15px; font-weight: 400; color: #f0efed; display: flex; align-items: center; gap: 0; }
+    .ghost { color: #f0efed; opacity: 0.50; }
+    .caret { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; margin-right: 1px; }
+    .note { display: flex; gap: 8px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.5; max-width: 672px; }
+    .pin { width: 4px; height: 4px; border-radius: 50%; background: #5B8DEF; margin-top: 6px; flex: none; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">01 · Summoned — ⌘T, nothing typed</div>
+    <div class="ttl">Rest state carries one hint, and it is the whole UI</div>
+    <div class="sub">No card, no shadow, no row backgrounds. The only thing on screen is the ghost placeholder already shipping today: the exact path Return would commit right now. With the card gone it stops being a hint and becomes the interface.</div>
+  </div>
+  <div class="term">
+    <div class="backdrop">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment and a space
+d32fb32  fix(session): drop back to a shell instead of closing
+ef1267e  Merge pull request #163 from seansmithworks/docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+    <div class="wash"></div>
+    <div class="stack">
+      <div class="query"><span class="caret"></span><span class="ghost">ghostties &gt; main &gt; claude</span></div>
+    </div>
+  </div>
+  <div class="note"><div class="pin"></div><div>The caret is the mode signal. The terminal draws a block caret; the composer draws a 1.5px bar. Swapping caret shape is the cheapest possible "you are typing at the app, not the shell" — and it happens exactly where the eye already is.</div></div>
+  <div class="note"><div class="pin"></div><div>Blur only, no dim. A scrim was ruled out in PR #132 and stays out. Blur removes competing detail without changing luminance — which is honest, and also why the contrast problem on the Hints page is real.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Placement.dc.html
+++ b/docs/design/composer/zero-chrome/Placement.dc.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 18px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 720px; line-height: 1.5; }
+    .three { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+    .cell { display: flex; flex-direction: column; gap: 8px; }
+    .ch { display: flex; flex-direction: column; gap: 2px; }
+    .cn { font-size: 12px; font-weight: 600; color: #f0efed; }
+    .cw { font-size: 10px; color: #636363; }
+    .stage { position: relative; height: 190px; border-radius: 8px; overflow: hidden; background: #2D2D2D; }
+    .bd { position: absolute; inset: 0; padding: 10px 12px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 9.5px; line-height: 15px; color: #f0efed; opacity: 0.72; white-space: pre; }
+    .hot { color: #6fcf97; }
+    .bl { position: absolute; inset: 0; backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); }
+    .q { position: absolute; font-size: 13px; color: #f0efed; }
+    .g { opacity: 0.65; }
+    .seg { color: #5B8DEF; }
+    .rows { font-size: 11px; line-height: 1.7; }
+    .on { color: #5B8DEF; }
+    .off { color: #f0efed; opacity: 0.55; }
+    /* A centre float */
+    .qA { left: 0; right: 0; top: 74px; text-align: center; }
+    /* B cursor adjacent */
+    .qB { left: 12px; top: 118px; }
+    /* C docked band */
+    .bandwrap { position: absolute; left: 0; right: 0; bottom: 0; height: 82px; background: #2D2D2D; border-top: 0; }
+    .qC { left: 12px; bottom: 54px; }
+    .rowsC { position: absolute; left: 12px; bottom: 10px; }
+    .verdict { display: flex; gap: 8px; align-items: flex-start; font-size: 10.5px; line-height: 1.5; }
+    .dot { width: 4px; height: 4px; border-radius: 50%; margin-top: 5px; flex: none; }
+    .bad { background: #FF6B6B; } .mid { background: #C97350; } .good { background: #6fcf97; }
+    .vt { color: #9a9a9a; }
+    .vt b { color: #f0efed; font-weight: 500; }
+    .box { background: #2a2a2a; border-radius: 6px; padding: 14px 16px; display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .bar { width: 2px; align-self: stretch; background: #6fcf97; border-radius: 1px; flex: none; }
+    .box strong { color: #f0efed; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Prior art — the placement question</div>
+    <div class="ttl">Where it sits decides whether legibility is a problem at all</div>
+    <div class="sub">This is the detail the first canvas did not question. Variant 09 inherits centre-float from the existing card, because that is where the card already is — but the card could afford to float. Text cannot.</div>
+  </div>
+
+  <div class="three">
+
+    <div class="cell">
+      <div class="ch"><div class="cn">A · Centre float</div><div class="cw">variant 09 as drawn</div></div>
+      <div class="stage">
+        <div class="bd">$ git log --oneline -4
+a0297a9  fix(composer): Tab
+d32fb32  fix(session): shell
+ef1267e  Merge PR #163
+$ npm run build
+<span class="hot">  ✓ 1284 modules</span>
+  ready in 1.2s
+$ git status
+  nothing to commit
+$ </div>
+        <div class="bl"></div>
+        <div class="q qA">ghostties <span class="g">&gt; main</span></div>
+      </div>
+      <div class="verdict"><div class="dot bad"></div><div class="vt"><b>Maximum overlap.</b> Sits over the densest part of the scrollback. Every legibility fix on the Hints page exists to service this one choice.</div></div>
+    </div>
+
+    <div class="cell">
+      <div class="ch"><div class="cn">B · At the prompt</div><div class="cw">Fig's answer</div></div>
+      <div class="stage">
+        <div class="bd">$ git log --oneline -4
+a0297a9  fix(composer): Tab
+d32fb32  fix(session): shell
+ef1267e  Merge PR #163
+$ npm run build
+<span class="hot">  ✓ 1284 modules</span>
+  ready in 1.2s
+$ git status
+  nothing to commit
+$ </div>
+        <div class="q qB">ghostties <span class="seg">&gt; main</span><br><span class="rows"><span class="on">main</span><br><span class="off">fix/composer…</span></span></div>
+      </div>
+      <div class="verdict"><div class="dot mid"></div><div class="vt"><b>Overlaps only what is below the cursor</b> — usually empty. No blur needed. But the composer is not a shell completion; it launches sessions, and anchoring it to a prompt implies otherwise.</div></div>
+    </div>
+
+    <div class="cell">
+      <div class="ch"><div class="cn">C · Docked band</div><div class="cw">vim · fzf · minibuffer</div></div>
+      <div class="stage">
+        <div class="bd">$ git log --oneline -4
+a0297a9  fix(composer): Tab
+d32fb32  fix(session): shell
+ef1267e  Merge PR #163
+$ npm run build
+<span class="hot">  ✓ 1284 modules</span>
+  ready in 1.2s</div>
+        <div class="bandwrap"></div>
+        <div class="q qC">ghostties <span class="seg">&gt; mai</span><span class="g">n</span></div>
+        <div class="rows rowsC"><span class="on">main</span> &nbsp; <span class="off">fix/composer-return-to-shell</span></div>
+      </div>
+      <div class="verdict"><div class="dot good"></div><div class="vt"><b>Nothing behind it.</b> Output is pushed up, the band is empty canvas. Truly zero chrome — no blur, no wash, no contrast tradeoff, because there is nothing to be legible against.</div></div>
+    </div>
+
+  </div>
+
+  <div class="box"><div class="bar"></div><div><strong>C is the version of this direction that actually works — and it is more minimal, not less.</strong> Every mitigation on the Hints page (raised ghost opacity, the local luminance wash, heavier blur) exists to defend text floating over content. Move the text somewhere nothing is, and all of it becomes unnecessary. The cost is that the terminal reflows when the composer opens, which is a real change and the thing to react to: vim, fzf and Emacs all decided that reflow was cheaper than the overlap it avoids. <em>The counter-argument is that Ghostties is a GUI app, not a TUI, and a reflowing terminal may read as broken rather than native — that judgement is yours.</em></div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/PriorArt.dc.html
+++ b/docs/design/composer/zero-chrome/PriorArt.dc.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 20px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 720px; line-height: 1.5; }
+    .finds { display: flex; flex-direction: column; gap: 0; }
+    .find { display: grid; grid-template-columns: 22px 1fr; gap: 12px; padding: 14px 0; border-top: 1px solid #2a2a2a; align-items: start; }
+    .n { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; color: #5B8DEF; padding-top: 1px; }
+    .body { display: flex; flex-direction: column; gap: 5px; }
+    .h { font-size: 12px; font-weight: 600; color: #f0efed; line-height: 1.4; }
+    .p { font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .p b { color: #f0efed; font-weight: 500; }
+    .src { font-size: 10px; color: #636363; }
+    .blurhd { font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: #636363; margin-bottom: 8px; }
+    .bcols { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+    .bcell { display: flex; flex-direction: column; gap: 6px; }
+    .bl { font-size: 10px; color: #9a9a9a; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+    .stage { position: relative; height: 120px; border-radius: 6px; overflow: hidden; background: #2D2D2D; }
+    .bd { position: absolute; inset: 0; padding: 10px 12px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; line-height: 16px; color: #f0efed; opacity: 0.8; white-space: pre; }
+    .hot { color: #6fcf97; }
+    .warn2 { color: #C97350; }
+    .b6  { position: absolute; inset: 0; backdrop-filter: blur(6px);  -webkit-backdrop-filter: blur(6px); }
+    .b24 { position: absolute; inset: 0; backdrop-filter: blur(24px); -webkit-backdrop-filter: blur(24px); }
+    .b48 { position: absolute; inset: 0; backdrop-filter: blur(48px); -webkit-backdrop-filter: blur(48px); }
+    .txt { position: absolute; left: 0; right: 0; top: 48px; text-align: center; font-size: 14px; color: #f0efed; opacity: 0.65; }
+    .cap { font-size: 10px; color: #636363; line-height: 1.45; }
+    .cap b { color: #9a9a9a; font-weight: 500; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Prior art — what the field actually does</div>
+    <div class="ttl">Nobody ships this. That is worth knowing before you commit, not after.</div>
+    <div class="sub">Four findings from Mobbin's pattern set, Raycast's 2026 rebuild, and the terminal-native tools that solved this problem first.</div>
+  </div>
+
+  <div class="finds">
+    <div class="find"><div class="n">01</div><div class="body">
+      <div class="h">Mobbin studied 120+ command-palette patterns. Not one is chromeless.</div>
+      <div class="p">Every variant they name — keyboard shortcuts, tabs, chips — assumes a card. There is no "borderless" or "minimal surface" variant in the taxonomy at all. That is not a reason to abandon the direction; it means there is no pattern to lean on and every detail is yours to invent. Worth noting too: <b>chips are one of their three named variants</b>, and you already built and rejected that in the Model A rebuild.</div>
+      <div class="src">mobbin.com/glossary/command-palette</div>
+    </div></div>
+
+    <div class="find"><div class="n">02</div><div class="body">
+      <div class="h">Raycast's 2026 rebuild went the other way — and their blur is 8× yours.</div>
+      <div class="p">Raycast v2 redesigned for Liquid Glass: <b>backdrop-filter blur(48px)</b>, 1px border, 8px radius. The nearest incumbent is <em>adding</em> chrome, not removing it. But the number is the useful part — variant 09 proposes 6px. If blur is going to carry the whole boundary job on its own, 6px is not in the right order of magnitude.</div>
+      <div class="src">manual.raycast.com/new-in-v2 · styles.refero.design</div>
+    </div></div>
+
+    <div class="find"><div class="n">03</div><div class="body">
+      <div class="h">Fig put its terminal overlay at the cursor, IDE-style. Not floating centre.</div>
+      <div class="p">The one product that solved "UI over a live terminal" at scale chose <b>adjacency</b> — the popup tracks the cursor position and context, the way an IDE completion does. It never floats over the middle of the scrollback.</div>
+      <div class="src">fig.io/user-manual/autocomplete</div>
+    </div></div>
+
+    <div class="find"><div class="n">04</div><div class="body">
+      <div class="h">The terminal-native tools dodge the problem entirely: they reserve space.</div>
+      <div class="p">vim's command line owns the last row. fzf takes a reserved region or the alternate screen. Emacs' minibuffer grows the bottom. <b>None of them overlap live output — so none of them have a legibility problem to solve.</b> Variant 09 floats over the centre of the scrollback, which is the one configuration none of the prior art picked. See the next board.</div>
+      <div class="src">structural, verified against fzf.vim and vim-floaterm docs</div>
+    </div></div>
+  </div>
+
+  <div>
+    <div class="blurhd">Finding 02, made literal — same terminal, same 65% text</div>
+    <div class="bcols">
+      <div class="bcell"><div class="bl">blur(6px) — variant 09</div>
+        <div class="stage">
+          <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+<span class="warn2">  warn  2 peer deps unmet</span>
+  ready in 1.2s
+$ git push origin HEAD</div>
+          <div class="b6"></div><div class="txt">ghostties &gt; main &gt; claude</div>
+        </div>
+        <div class="cap"><b>Scrollback still legible.</b> Which is the problem — it competes.</div>
+      </div>
+      <div class="bcell"><div class="bl">blur(24px)</div>
+        <div class="stage">
+          <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+<span class="warn2">  warn  2 peer deps unmet</span>
+  ready in 1.2s
+$ git push origin HEAD</div>
+          <div class="b24"></div><div class="txt">ghostties &gt; main &gt; claude</div>
+        </div>
+        <div class="cap"><b>Colour survives, glyphs don't.</b> Reads as atmosphere.</div>
+      </div>
+      <div class="bcell"><div class="bl">blur(48px) — Raycast v2</div>
+        <div class="stage">
+          <div class="bd">$ npm run build
+<span class="hot">  ✓ compiled 1284 modules</span>
+<span class="warn2">  warn  2 peer deps unmet</span>
+  ready in 1.2s
+$ git push origin HEAD</div>
+          <div class="b48"></div><div class="txt">ghostties &gt; main &gt; claude</div>
+        </div>
+        <div class="cap"><b>A surface, effectively.</b> Honest question: is this still zero-chrome?</div>
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/README.md
+++ b/docs/design/composer/zero-chrome/README.md
@@ -1,0 +1,23 @@
+# Zero-Chrome Composer — design canvas sources
+
+Design-Components artboards for the zero-chrome composer direction (variant 09
+of the ten mild→wild composer directions).
+
+Published canvas: https://claude.ai/code/artifact/fbd31813-d56e-4a55-8f7a-3a9dea7239f9
+
+Five pages, laid out by `canvas.json`:
+
+| Page | Artboards | What it answers |
+| --- | --- | --- |
+| Prior art | `PriorArt`, `Placement` | What the field actually ships, and where the composer should sit |
+| Unsolved | `Unsolved` | Ten open details, worst first |
+| Flow | `Main`, `Typing`, `Branch`, `Commit`, `Error` | The five states over live terminal output |
+| Hints | `HintLadder`, `JobsHandoff`, `Contrast` | What teaches the user, and the legibility cost |
+| Motion | `Summon`, `Reveal`, `Exit`, `Timing` | Transition choreography (three artboards animate) |
+
+To edit: change the `.dc.html` files here, re-seed with the `design` skill's
+`seed-canvas.mjs`, and republish to the same artifact URL.
+
+Values are lifted from `DESIGN.md` §3/§4 — composer selection `#5B8DEF`, canvas
+`#FAF7F3`/`#2D2D2D`, centered-modal 15/13/11pt scale, 12pt radius, 50% ghost grey.
+`DESIGN.md` remains the source of truth; these boards are a proposal against it.

--- a/docs/design/composer/zero-chrome/Reveal.dc.html
+++ b/docs/design/composer/zero-chrome/Reveal.dc.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 700px; line-height: 1.5; }
+    .cols { display: grid; grid-template-columns: 400px minmax(0, 1fr); gap: 24px; align-items: start; }
+
+    .term { position: relative; width: 400px; height: 240px; border-radius: 8px; overflow: hidden; background: #2D2D2D; }
+    .bd { position: absolute; inset: 0; padding: 12px 14px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; line-height: 16px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .bl { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .st { position: absolute; top: 62px; left: 50%; width: 300px; margin-left: -150px; display: flex; flex-direction: column; gap: 12px; }
+    .q { font-size: 15px; color: #f0efed; display: flex; align-items: center; }
+    .typed { animation: typed 3600ms steps(1) infinite; }
+    .g { color: #f0efed; opacity: 0.65; }
+    .car { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+    .rows { display: flex; flex-direction: column; gap: 8px; }
+    .row { font-size: 13px; font-weight: 500; color: #f0efed; opacity: 0; display: flex; justify-content: space-between; }
+    .row.on { color: #5B8DEF; }
+    .mt { font-size: 11px; font-weight: 400; color: #9a9a9a; }
+    .r1 { animation: r1 3600ms ease-out infinite; }
+    .r2 { animation: r2 3600ms ease-out infinite; }
+    .r3 { animation: r3 3600ms ease-out infinite; }
+
+    @keyframes typed {
+      0%, 11.0% { opacity: 0; } 11.1%, 72.2% { opacity: 1; } 72.3%, 100% { opacity: 0; }
+    }
+    @keyframes r1 {
+      0%, 13.9% { opacity: 0; transform: translateY(3px); }
+      16.4%, 72.2% { opacity: 1; transform: translateY(0); }
+      77.2%, 100% { opacity: 0; transform: translateY(0); }
+    }
+    @keyframes r2 {
+      0%, 14.4% { opacity: 0; transform: translateY(3px); }
+      16.9%, 72.2% { opacity: 0.55; transform: translateY(0); }
+      77.2%, 100% { opacity: 0; transform: translateY(0); }
+    }
+    @keyframes r3 {
+      0%, 15.0% { opacity: 0; transform: translateY(3px); }
+      17.5%, 72.2% { opacity: 0.55; transform: translateY(0); }
+      77.2%, 100% { opacity: 0; transform: translateY(0); }
+    }
+
+    .tl { display: flex; flex-direction: column; gap: 14px; }
+    .tlhd { font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: #636363; }
+    .track { position: relative; }
+    .tname { font-size: 11px; color: #f0efed; margin-bottom: 4px; }
+    .rail { position: relative; height: 14px; background: #2a2a2a; border-radius: 3px; }
+    .seg { position: absolute; top: 0; height: 14px; border-radius: 3px; font-size: 9px; display: flex; align-items: center; justify-content: center; }
+    .b-a { background: #5B8DEF; color: #0e1a2e; }
+    .b-b { background: #6fcf97; color: #0e2416; }
+    .scale { position: relative; height: 14px; margin-top: 2px; }
+    .tick { position: absolute; font-size: 9px; color: #636363; transform: translateX(-50%); }
+    .lede { font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .lede strong { color: #f0efed; }
+    .verdict { display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; background: #2a2a2a; border-radius: 6px; padding: 12px 14px; }
+    .bar { width: 2px; align-self: stretch; background: #C97350; border-radius: 1px; flex: none; }
+    .verdict strong { color: #C97350; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Motion — type-to-reveal</div>
+    <div class="ttl">A 20ms stagger is what makes rows read as arriving, not as popping</div>
+    <div class="sub">Rows have no background to fade, so the only things animating are opacity and 3px of rise. At zero stagger three rows appearing together read as a single block flashing on. Offset them and the eye tracks a sequence, which is what tells you the list is a response to your typing.</div>
+  </div>
+
+  <div class="cols">
+    <div class="term">
+      <div class="bd">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment
+d32fb32  fix(session): drop back to a shell
+ef1267e  Merge pull request #163 from docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+      <div class="bl"></div>
+      <div class="st">
+        <div class="q"><span class="typed">ghos<span class="g">ties</span></span><span class="car"></span></div>
+        <div class="rows">
+          <div class="row on r1"><span>ghostties</span><span class="mt" style="color:#5B8DEF;opacity:.7">pinned</span></div>
+          <div class="row r2"><span>ghostties-web</span><span class="mt">recent</span></div>
+          <div class="row r3"><span>ghost-physics</span><span class="mt">recent</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tl">
+      <div class="tlhd">Choreography · 0–200ms from keystroke</div>
+
+      <div class="track">
+        <div class="tname">Row 1 &nbsp;<span style="color:#636363">opacity 0→1, y 3→0</span></div>
+        <div class="rail"><div class="seg b-a" style="left: 0%; width: 45%;">90ms</div></div>
+      </div>
+      <div class="track">
+        <div class="tname">Row 2</div>
+        <div class="rail"><div class="seg b-a" style="left: 10%; width: 45%;">+20ms</div></div>
+      </div>
+      <div class="track">
+        <div class="tname">Row 3</div>
+        <div class="rail"><div class="seg b-a" style="left: 20%; width: 45%;">+40ms</div></div>
+      </div>
+      <div class="track">
+        <div class="tname">Dissolve at rest &nbsp;<span style="color:#636363">query emptied</span></div>
+        <div class="rail"><div class="seg b-b" style="left: 0%; width: 90%;">180ms · no stagger</div></div>
+      </div>
+
+      <div class="scale">
+        <span class="tick" style="left:0%">0</span>
+        <span class="tick" style="left:50%">100</span>
+        <span class="tick" style="left:100%">200ms</span>
+      </div>
+
+      <div class="lede"><strong>Out is slower than in, and unstaggered.</strong> Arrival wants to feel responsive; departure wants to feel unhurried, or it reads as the list being yanked away. Staggering the exit draws attention to something leaving, which is the opposite of what a rest state wants.</div>
+    </div>
+  </div>
+
+  <div class="verdict"><div class="bar"></div><div><strong>Open decision:</strong> what reveals the list. If it is typing alone, a user who does not know what to type never sees a list at all — and since PR #155 removed the picker controls, the list is the only browse path left. Recommend ↓ reveals it too, at the same 90/20 stagger.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Summon.dc.html
+++ b/docs/design/composer/zero-chrome/Summon.dc.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 700px; line-height: 1.5; }
+    .cols { display: grid; grid-template-columns: 400px minmax(0, 1fr); gap: 24px; align-items: start; }
+
+    .term { position: relative; width: 400px; height: 240px; border-radius: 8px; overflow: hidden; background: #2D2D2D; }
+    .bd { position: absolute; inset: 0; padding: 12px 14px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; line-height: 16px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .bl { position: absolute; inset: 0; animation: blurin 3600ms ease-out infinite; }
+    .st { position: absolute; top: 84px; left: 50%; width: 300px; margin-left: -150px; display: flex; flex-direction: column; gap: 12px; animation: textin 3600ms ease-out infinite; }
+    .q { font-size: 15px; color: #f0efed; display: flex; align-items: center; justify-content: center; }
+    .g { color: #f0efed; opacity: 0.65; }
+    .car { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+
+    @keyframes blurin {
+      0%     { backdrop-filter: blur(0px);  -webkit-backdrop-filter: blur(0px); }
+      3.9%   { backdrop-filter: blur(6px);  -webkit-backdrop-filter: blur(6px); }
+      62.8%  { backdrop-filter: blur(6px);  -webkit-backdrop-filter: blur(6px); }
+      66.7%  { backdrop-filter: blur(0px);  -webkit-backdrop-filter: blur(0px); }
+      100%   { backdrop-filter: blur(0px);  -webkit-backdrop-filter: blur(0px); }
+    }
+    @keyframes textin {
+      0%     { opacity: 0; transform: translateY(4px); }
+      1.1%   { opacity: 0; transform: translateY(4px); }
+      4.4%   { opacity: 1; transform: translateY(0); }
+      61.1%  { opacity: 1; transform: translateY(0); }
+      64.4%  { opacity: 0; transform: translateY(0); }
+      100%   { opacity: 0; transform: translateY(0); }
+    }
+
+    .tl { display: flex; flex-direction: column; gap: 14px; }
+    .tlhd { font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: #636363; }
+    .track { position: relative; height: 34px; }
+    .tname { font-size: 11px; color: #f0efed; margin-bottom: 4px; }
+    .rail { position: relative; height: 16px; background: #2a2a2a; border-radius: 3px; }
+    .seg { position: absolute; top: 0; height: 16px; border-radius: 3px; font-size: 9px; color: #0e1a2e; display: flex; align-items: center; justify-content: center; letter-spacing: 0.02em; }
+    .b-blur { background: #5B8DEF; }
+    .b-text { background: #6fcf97; color: #0e2416; }
+    .b-car { background: #C97350; color: #2a150c; }
+    .scale { position: relative; height: 14px; margin-top: 2px; }
+    .tick { position: absolute; font-size: 9px; color: #636363; transform: translateX(-50%); }
+    .lede { font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .lede strong { color: #f0efed; }
+    .verdict { display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; background: #2a2a2a; border-radius: 6px; padding: 12px 14px; }
+    .bar { width: 2px; align-self: stretch; background: #5B8DEF; border-radius: 1px; flex: none; }
+    .verdict strong { color: #f0efed; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Motion — summon (⌘T)</div>
+    <div class="ttl">140ms of blur is the entire "a mode opened" signal</div>
+    <div class="sub">Today the composer cuts in with no animation at all — the card's sudden presence is the announcement. Remove the card and nothing announces anything, so the blur ramp has to. It is short enough to feel instant and long enough to be perceived as a change of state rather than a redraw.</div>
+  </div>
+
+  <div class="cols">
+    <div class="term">
+      <div class="bd">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment
+d32fb32  fix(session): drop back to a shell
+ef1267e  Merge pull request #163 from docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+      <div class="bl"></div>
+      <div class="st">
+        <div class="q"><span class="car"></span><span class="g">ghostties &gt; main &gt; claude</span></div>
+      </div>
+    </div>
+
+    <div class="tl">
+      <div class="tlhd">Choreography · 0–300ms</div>
+
+      <div class="track">
+        <div class="tname">Backdrop blur &nbsp;<span style="color:#636363">0 → 6px, ease-out</span></div>
+        <div class="rail"><div class="seg b-blur" style="left: 0%; width: 46.7%;">140ms</div></div>
+      </div>
+
+      <div class="track">
+        <div class="tname">Caret morph &nbsp;<span style="color:#636363">block → 1.5px bar</span></div>
+        <div class="rail"><div class="seg b-car" style="left: 6.7%; width: 26.7%;">80ms</div></div>
+      </div>
+
+      <div class="track">
+        <div class="tname">Text block &nbsp;<span style="color:#636363">opacity 0→1, y 4→0</span></div>
+        <div class="rail"><div class="seg b-text" style="left: 13.3%; width: 40%;">120ms</div></div>
+      </div>
+
+      <div class="scale">
+        <span class="tick" style="left:0%">0</span>
+        <span class="tick" style="left:33.3%">100</span>
+        <span class="tick" style="left:66.7%">200</span>
+        <span class="tick" style="left:100%">300ms</span>
+      </div>
+
+      <div class="lede"><strong>The overlap is the point.</strong> Text starts before the blur finishes, so the two read as one gesture instead of a queue. Land them simultaneously and it feels mechanical; separate them and it feels slow.</div>
+    </div>
+  </div>
+
+  <div class="verdict"><div class="bar"></div><div><strong>Cost to build:</strong> the caret morph is the only piece that is not a stock SwiftUI transition, and it may not be reachable — the field cannot tint sub-ranges at the macOS 13 floor, and the caret is drawn by AppKit. If it turns out to be unavailable, the blur ramp alone still carries the state change; the caret is an amplifier, not the mechanism.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Timing.dc.html
+++ b/docs/design/composer/zero-chrome/Timing.dc.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 660px; line-height: 1.5; }
+    .tbl { display: grid; grid-template-columns: 108px 1fr 54px 84px; gap: 0; }
+    .th { font-size: 9px; letter-spacing: 0.07em; text-transform: uppercase; color: #636363; padding: 0 10px 8px 0; border-bottom: 1px solid #2a2a2a; }
+    .td { font-size: 11px; color: #9a9a9a; line-height: 1.45; padding: 9px 10px 9px 0; border-bottom: 1px solid #2a2a2a; }
+    .td.t { color: #f0efed; font-weight: 500; }
+    .td.n { color: #5B8DEF; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; }
+    .td.e { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; color: #636363; }
+    .grp { grid-column: 1 / -1; font-size: 9px; letter-spacing: 0.07em; text-transform: uppercase; color: #C97350; padding: 14px 0 6px; }
+    .laws { display: flex; flex-direction: column; gap: 10px; }
+    .law { display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .num { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 10px; color: #5B8DEF; flex: none; width: 16px; padding-top: 1px; }
+    .law strong { color: #f0efed; }
+    .box { background: #2a2a2a; border-radius: 6px; padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
+    .boxhd { font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: #636363; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Motion — full spec</div>
+    <div class="ttl">Every transition, in one place</div>
+    <div class="sub">Current state: two <code>withAnimation(.linear(0.25))</code> calls in 3,401 lines of <code>SessionComposerPalette.swift</code>, neither on present or dismiss. Everything below is new.</div>
+  </div>
+
+  <div class="tbl">
+    <div class="th">Trigger</div><div class="th">What moves</div><div class="th">Dur</div><div class="th">Curve · delay</div>
+
+    <div class="grp">Entering</div>
+    <div class="td t">⌘T summon</div><div class="td">Backdrop blur 0 → 6px</div><div class="td n">140ms</div><div class="td e">easeOut · 0</div>
+    <div class="td t"></div><div class="td">Caret block → 1.5px bar</div><div class="td n">80ms</div><div class="td e">easeOut · 20ms</div>
+    <div class="td t"></div><div class="td">Text block opacity 0→1, y 4→0</div><div class="td n">120ms</div><div class="td e">easeOut · 40ms</div>
+
+    <div class="grp">While typing</div>
+    <div class="td t">First keystroke <span style="color:#636363">or ↓</span></div><div class="td">Rows opacity 0→1, y 3→0</div><div class="td n">90ms</div><div class="td e">easeOut · 20ms stagger</div>
+    <div class="td t">Typed <code>&gt;</code></div><div class="td">Branch segment → #5B8DEF, no layout shift</div><div class="td n">100ms</div><div class="td e">easeInOut · 0</div>
+    <div class="td t">Query emptied</div><div class="td">Rows dissolve, no stagger</div><div class="td n">180ms</div><div class="td e">easeIn · 0</div>
+    <div class="td t">Result set changes</div><div class="td">Rows crossfade in place — never reflow</div><div class="td n">80ms</div><div class="td e">linear · 0</div>
+
+    <div class="grp">Leaving</div>
+    <div class="td t">⏎ commit</div><div class="td">Text lift y 0→−6, opacity 1→0</div><div class="td n">100ms</div><div class="td e">easeIn · 0</div>
+    <div class="td t"></div><div class="td">Blur 6 → 0</div><div class="td n">160ms</div><div class="td e">easeOut · 40ms</div>
+    <div class="td t">esc dismiss</div><div class="td">Text opacity 1→0, no lift</div><div class="td n">120ms</div><div class="td e">easeIn · 0</div>
+    <div class="td t"></div><div class="td">Blur 6 → 0</div><div class="td n">140ms</div><div class="td e">easeOut · 20ms</div>
+    <div class="td t">Click outside</div><div class="td">Identical to esc</div><div class="td n">—</div><div class="td e">—</div>
+
+    <div class="grp">Failure</div>
+    <div class="td t">Branch not found</div><div class="td">Status strip opacity 0→1</div><div class="td n">60ms</div><div class="td e">easeOut · 0</div>
+    <div class="td t">Write error</div><div class="td">Replaces strip contents, no re-animate</div><div class="td n">—</div><div class="td e">—</div>
+  </div>
+
+  <div class="box">
+    <div class="boxhd">Three rules that make the numbers work</div>
+    <div class="laws">
+      <div class="law"><span class="num">01</span><div><strong>Blur lags text on the way out, leads it on the way in.</strong> In: blur starts first, text lands before blur finishes. Out: text goes first, blur resolves behind it. This ordering is what separates "a mode" from "a popup" — get it backwards and every duration above stops helping.</div></div>
+      <div class="law"><span class="num">02</span><div><strong>Nothing above 180ms.</strong> The composer is on the keystroke path; Sean opens it, types four characters and commits. Anything slower than a fast blink becomes something to wait through on the fiftieth use of the day.</div></div>
+      <div class="law"><span class="num">03</span><div><strong>Rows crossfade, they never reflow.</strong> With no card bounding them, a row list that changes height pushes text around on a background it does not own. Fixed slot count, fade contents in place.</div></div>
+    </div>
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Typing.dc.html
+++ b/docs/design/composer/zero-chrome/Typing.dc.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 620px; line-height: 1.5; }
+    .term { position: relative; width: 672px; height: 336px; border-radius: 12px; overflow: hidden; background: #2D2D2D; }
+    .backdrop { position: absolute; inset: 0; padding: 16px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; line-height: 17px; color: #f0efed; opacity: 0.62; white-space: pre; }
+    .dim { color: #9a9a9a; }
+    .wash { position: absolute; inset: 0; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+    .stack { position: absolute; top: 88px; left: 50%; transform: translateX(-50%); width: 360px; display: flex; flex-direction: column; gap: 16px; align-items: center; }
+    .query { font-size: 15px; font-weight: 400; color: #f0efed; display: flex; align-items: center; }
+    .ghost { color: #f0efed; opacity: 0.50; }
+    .caret { display: inline-block; width: 1.5px; height: 17px; background: #f0efed; }
+    .rows { display: flex; flex-direction: column; gap: 8px; width: 100%; }
+    .row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; font-size: 13px; font-weight: 500; color: #f0efed; opacity: 0.55; }
+    .row.on { opacity: 1; color: #5B8DEF; }
+    .meta { font-size: 11px; font-weight: 400; color: #9a9a9a; }
+    .row.on .meta { color: #5B8DEF; opacity: 0.7; }
+    .newt { font-size: 13px; font-weight: 400; color: #f0efed; opacity: 0.35; }
+    .note { display: flex; gap: 8px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.5; max-width: 672px; }
+    .pin { width: 4px; height: 4px; border-radius: 50%; background: #5B8DEF; margin-top: 6px; flex: none; }
+    .warn { background: #C97350; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">02 · Typing — structure revealed</div>
+    <div class="ttl">Rows have no background, so weight and colour do all the work</div>
+    <div class="sub">Typed <code>ghos</code>; the remainder ghost completes to <code>ghostties</code> and Tab takes it plus a space. Rows carry selection with the accent alone — 100% + #5B8DEF selected, 55% opacity otherwise. Trailing meta survives because it is text, not chrome.</div>
+  </div>
+  <div class="term">
+    <div class="backdrop">$ git log --oneline -3
+<span class="dim">a0297a9  fix(composer): Tab inserts a segment and a space
+d32fb32  fix(session): drop back to a shell instead of closing
+ef1267e  Merge pull request #163 from seansmithworks/docs</span>
+$ zig build run -Doptimize=ReleaseFast
+<span class="dim">  compiling GhosttyKit ... 1.2s
+  linking Ghostties.app ... ok</span>
+$ </div>
+    <div class="wash"></div>
+    <div class="stack">
+      <div class="query">ghos<span class="ghost">ties</span><span class="caret"></span></div>
+      <div class="rows">
+        <div class="row on"><span>ghostties</span><span class="meta">pinned</span></div>
+        <div class="row"><span>ghostties-web</span><span class="meta">recent</span></div>
+        <div class="row"><span>ghost-physics</span><span class="meta">recent</span></div>
+        <div class="newt">New template</div>
+      </div>
+    </div>
+  </div>
+  <div class="note"><div class="pin"></div><div>Grammar is untouched by this direction. Tab still inserts a segment plus a space; only a user-typed <code>&gt;</code> arms a branch. Zero-chrome changes the surface, never the parse.</div></div>
+  <div class="note"><div class="pin warn"></div><div><strong style="color:#C97350">Fork to settle:</strong> centred vs. left-aligned at the caret. Centring is prettier at rest, but with no card the rows lose their shared left edge — the one alignment cue that used to say "these belong together." Left-aligning the whole stack to the caret restores grouping for free.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/Unsolved.dc.html
+++ b/docs/design/composer/zero-chrome/Unsolved.dc.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, "SF Pro Text", system-ui, sans-serif; background: #242424; }
+    a { color: #5B8DEF; } a:hover { color: #7BA5F2; }
+    .wrap { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .hdr { display: flex; flex-direction: column; gap: 4px; }
+    .step { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: #9a9a9a; }
+    .ttl { font-size: 15px; font-weight: 600; color: #f0efed; }
+    .sub { font-size: 11px; color: #9a9a9a; max-width: 720px; line-height: 1.5; }
+    .list { display: flex; flex-direction: column; }
+    .it { display: grid; grid-template-columns: 22px 1fr 128px; gap: 14px; padding: 13px 0; border-top: 1px solid #2a2a2a; align-items: start; }
+    .n { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11px; color: #636363; padding-top: 2px; }
+    .bd { display: flex; flex-direction: column; gap: 4px; }
+    .h { font-size: 12px; font-weight: 600; color: #f0efed; line-height: 1.4; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .p { font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .p b { color: #f0efed; font-weight: 500; }
+    .sv { font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 5px; border-radius: 3px; }
+    .s1 { background: #3a1f1f; color: #FF6B6B; }
+    .s2 { background: #3a2a1f; color: #C97350; }
+    .s3 { background: #1f2f4a; color: #5B8DEF; }
+    .set { font-size: 10px; color: #636363; line-height: 1.5; padding-top: 2px; }
+    .set b { color: #9a9a9a; font-weight: 500; display: block; margin-bottom: 2px; }
+    .box { background: #2a2a2a; border-radius: 6px; padding: 14px 16px; display: flex; gap: 10px; align-items: flex-start; font-size: 11px; color: #9a9a9a; line-height: 1.55; }
+    .bar { width: 2px; align-self: stretch; background: #C97350; border-radius: 1px; flex: none; }
+    .box strong { color: #f0efed; }
+  </style>
+</helmet>
+<div class="wrap">
+  <div class="hdr">
+    <div class="step">Unsolved — what the first canvas did not answer</div>
+    <div class="ttl">Ten open details, worst first</div>
+    <div class="sub">You said the detail has to be crisp. These are the places it currently is not. Numbers 1 and 2 can each sink the direction on their own; the rest are work, not risk.</div>
+  </div>
+
+  <div class="list">
+
+    <div class="it"><div class="n">01</div><div class="bd">
+      <div class="h">Where it sits <span class="sv s1">Blocking</span></div>
+      <div class="p">Centre-float vs. docked band. <b>Everything else on this list changes depending on the answer</b> — pick the docked band and items 03, 04 and 05 stop existing. Drawn on the previous board.</div>
+    </div><div class="set"><b>Settled by</b> Your call. Nothing to build first.</div></div>
+
+    <div class="it"><div class="n">02</div><div class="bd">
+      <div class="h">Reduce Motion deletes the interface <span class="sv s1">Blocking</span></div>
+      <div class="p">The whole direction rests on motion carrying the mode signal, because nothing else is left to carry it. <b>Turn on Reduce Motion and there is no blur ramp, no lift, no stagger — and no card either.</b> Text simply exists, with nothing to say a mode opened. Every other direction in the set degrades gracefully here; this one has no floor.</div>
+    </div><div class="set"><b>Settled by</b> Designing the static fallback. If it needs a surface, the direction has a surface.</div></div>
+
+    <div class="it"><div class="n">03</div><div class="bd">
+      <div class="h">Live output scrolling underneath <span class="sv s2">High</span></div>
+      <div class="p">A build is running; lines move behind stationary text. The card hid this completely. <b>Nobody has seen what it looks like</b> — and moving content under fixed type is the classic way an overlay reads as broken rather than deliberate.</div>
+    </div><div class="set"><b>Settled by</b> A 10-second capture with <code>npm run build</code> going. Cheap, and it may kill the direction outright.</div></div>
+
+    <div class="it"><div class="n">04</div><div class="bd">
+      <div class="h">Other people's terminal themes <span class="sv s2">High</span></div>
+      <div class="p">Every value on the first canvas assumes canvas <code>#2D2D2D</code> / <code>#FAF7F3</code>. <b>Ghostty users theme their terminals heavily</b> — solarized, high-contrast, bright custom backgrounds. Contrast is computed against a background you do not control and cannot predict.</div>
+    </div><div class="set"><b>Settled by</b> Deriving the wash and ghost opacity from the live theme, not from DESIGN.md constants.</div></div>
+
+    <div class="it"><div class="n">05</div><div class="bd">
+      <div class="h">Blur depth is a guess <span class="sv s2">High</span></div>
+      <div class="p">6px was picked to look right in a static mock. Raycast v2 ships 48px. <b>Eight times</b> is not a tuning difference, it is a different idea of what blur is for.</div>
+    </div><div class="set"><b>Settled by</b> Measuring against real scrollback, not a fixture.</div></div>
+
+    <div class="it"><div class="n">06</div><div class="bd">
+      <div class="h">Hover has no shape <span class="sv s3">Medium</span></div>
+      <div class="p">Rows have no background, so there is nothing to highlight on mouse-over. Since PR #155 removed the picker controls, <b>the list is the only mouse surface left in the composer</b> — and this direction gives it no hover state at all.</div>
+    </div><div class="set"><b>Settled by</b> Deciding whether hover tints the glyphs, or the composer goes keyboard-only.</div></div>
+
+    <div class="it"><div class="n">07</div><div class="bd">
+      <div class="h">Nothing bounds the width <span class="sv s3">Medium</span></div>
+      <div class="p">The card capped at 360pt and truncated the ghost path to one line. Remove it and a long project path has no edge to hit. <b>Wrap, truncate, or run the full width of the terminal</b> — all three look wrong for different reasons.</div>
+    </div><div class="set"><b>Settled by</b> Keeping the 360pt measure as an invisible constraint.</div></div>
+
+    <div class="it"><div class="n">08</div><div class="bd">
+      <div class="h">Nothing bounds the row count <span class="sv s3">Medium</span></div>
+      <div class="p">The card gave the list a visual stop. Floating text does not have one — twelve results become a column of free-standing type down the middle of a terminal.</div>
+    </div><div class="set"><b>Settled by</b> A hard cap, probably 5, with no "more" affordance to draw.</div></div>
+
+    <div class="it"><div class="n">09</div><div class="bd">
+      <div class="h">VoiceOver loses its container <span class="sv s3">Medium</span></div>
+      <div class="p">The card was the thing that got announced as a group. The lanes already carry <code>accessibilityLabel</code>s, but the outer grouping element goes away with the surface.</div>
+    </div><div class="set"><b>Settled by</b> An explicit accessibility container that renders nothing.</div></div>
+
+    <div class="it"><div class="n">10</div><div class="bd">
+      <div class="h">The armed-segment tint may not be buildable <span class="sv s3">Medium</span></div>
+      <div class="p">Already flagged on the Flow page — <code>reference_composer-field-cannot-tint-subranges</code> says the field cannot colour sub-ranges at the macOS 13 floor. It needs the ghost-subview trick, or it degrades to no tint.</div>
+    </div><div class="set"><b>Settled by</b> A spike, or accepting the degrade.</div></div>
+
+  </div>
+
+  <div class="box"><div class="bar"></div><div><strong>The cheapest next move is 03.</strong> Ten seconds of capture with a build running answers the one question that no amount of static mockery can, and it is the failure mode most likely to make this direction feel wrong in a way that is hard to argue with afterwards. Everything else on this list is worth doing only if that looks acceptable.</div></div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/docs/design/composer/zero-chrome/canvas.json
+++ b/docs/design/composer/zero-chrome/canvas.json
@@ -1,0 +1,38 @@
+{
+  "pages": [
+    { "id": "page-4", "name": "Prior art" },
+    { "id": "page-5", "name": "Unsolved" },
+    { "id": "page-1", "name": "Flow" },
+    { "id": "page-2", "name": "Hints" },
+    { "id": "page-3", "name": "Motion" }
+  ],
+  "artboards": [
+    { "file": "PriorArt.dc.html",    "page": "page-4", "x": 0,    "y": 0,   "w": 940, "h": 800, "title": "What the field does" },
+    { "file": "Placement.dc.html",   "page": "page-4", "x": 1020, "y": 0,   "w": 940, "h": 600, "title": "Where it sits" },
+
+    { "file": "Unsolved.dc.html",    "page": "page-5", "x": 0,    "y": 0,   "w": 900, "h": 1100, "title": "Ten open details" },
+
+    { "file": "Main.dc.html",        "page": "page-1", "x": 0,    "y": 0,   "w": 720, "h": 600, "title": "01 · Summoned" },
+    { "file": "Typing.dc.html",      "page": "page-1", "x": 800,  "y": 0,   "w": 720, "h": 620, "title": "02 · Typing" },
+    { "file": "Branch.dc.html",      "page": "page-1", "x": 1600, "y": 0,   "w": 720, "h": 560, "title": "03 · Branch armed" },
+    { "file": "Commit.dc.html",      "page": "page-1", "x": 0,    "y": 740, "w": 720, "h": 580, "title": "04 · Commit" },
+    { "file": "Error.dc.html",       "page": "page-1", "x": 800,  "y": 740, "w": 720, "h": 600, "title": "05 · Not found" },
+
+    { "file": "HintLadder.dc.html",  "page": "page-2", "x": 0,    "y": 0,   "w": 900, "h": 740, "title": "The affordance ladder" },
+    { "file": "JobsHandoff.dc.html", "page": "page-2", "x": 980,  "y": 0,   "w": 900, "h": 680, "title": "What the card was doing" },
+    { "file": "Contrast.dc.html",    "page": "page-2", "x": 0,    "y": 860, "w": 940, "h": 700, "title": "The legibility cost" },
+
+    { "file": "Summon.dc.html",      "page": "page-3", "x": 0,    "y": 0,   "w": 900, "h": 540, "title": "Summon · ⌘T" },
+    { "file": "Reveal.dc.html",      "page": "page-3", "x": 980,  "y": 0,   "w": 900, "h": 580, "title": "Type-to-reveal" },
+    { "file": "Exit.dc.html",        "page": "page-3", "x": 1960, "y": 0,   "w": 900, "h": 620, "title": "Commit vs dismiss" },
+    { "file": "Timing.dc.html",      "page": "page-3", "x": 0,    "y": 740, "w": 820, "h": 1060, "title": "Full timing spec" }
+  ],
+  "annotations": [
+    { "id": "nt-prior", "page": "page-4", "x": 1020, "y": 680, "w": 320, "text": "Sourced from Mobbin's command-palette pattern set, Raycast's 2026 rebuild, Fig's terminal overlay, and the terminal-native pickers.\n\nHeadline: nobody ships a chromeless command palette. Mobbin studied 120+ and not one is borderless.\n\nThe placement board on the right is the one that changes the plan." },
+    { "id": "nt-open",  "page": "page-5", "x": 980, "y": 0,   "w": 320, "text": "Worst first.\n\n01 and 02 can each sink the direction on their own. 02 is the one that surprised me — if motion is the chrome, Reduce Motion leaves nothing at all.\n\nEverything from 03 down is work, not risk.\n\nCheapest next move is 03: ten seconds of capture with a build running." },
+    { "id": "nt-flow",  "page": "page-1", "x": 2400, "y": 0,   "w": 300, "text": "Five states, all over live terminal output.\n\nThe thing to judge here is not whether it looks clean — it will. It is whether you can tell, at a glance, that you are in a mode at all.\n\nTwo forks are called out inline: centred vs. left-aligned at the caret (02), and sub-range tinting at the macOS 13 floor (03)." },
+    { "id": "nt-hints", "page": "page-2", "x": 980,  "y": 740, "w": 300, "text": "Your question was what hints someone gets.\n\nAnswer: three of the four already ship, and the ghost placeholder is the strongest hint in the product — it renders the exact path Return would commit.\n\nThe one real hole is rung 2, and PR #155 opened it, not this direction. Fix is one keystroke: ↓ reveals the list." },
+    { "id": "nt-motion","page": "page-3", "x": 860,  "y": 740, "w": 300, "text": "Three boards animate; let them loop a few times.\n\nThe governing rule is on the spec sheet: blur leads text going in, trails it coming out. That single ordering is what makes this read as a mode rather than a popup.\n\nNothing here exceeds 180ms." }
+  ],
+  "launch": { "view": "canvas", "page": "page-4" }
+}


### PR DESCRIPTION
Docs only: canvas sources for the zero-chrome composer direction (`docs/design/composer/zero-chrome/`) plus a new dated backlog entry tracking PR #165/#168 merges, the zero-chrome composer spike (draft PR #169), and the beta.25 tag hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sot24aQ1SoMg17sZMFJfj