### PR TITLE
feat(workspace): GHOSTTIES_STATE_DIR override for the state directory

### DIFF
--- a/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
+++ b/macos/Sources/Features/Ghostties/WorkspacePersistence.swift
@@ -23,9 +23,28 @@ struct WorkspacePersistence {
         return "Ghostties"
     }
 
-    /// The directory where workspace data is stored.
-    private static var directory: URL {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    /// The directory where workspace data is stored. Honors
+    /// `GHOSTTIES_STATE_DIR` when set to a non-empty value, so a UI test or
+    /// lab launch can isolate `workspace.json` from the real user's state
+    /// without touching the shipping path. Unset/empty → unaffected, exactly
+    /// today's bundle-ID-derived Application Support path.
+    static var directory: URL {
+        if let raw = ProcessInfo.processInfo.environment["GHOSTTIES_STATE_DIR"],
+           !raw.isEmpty {
+            let expanded = (raw as NSString).expandingTildeInPath
+            let overrideURL = URL(fileURLWithPath: expanded, isDirectory: true)
+            do {
+                try FileManager.default.createDirectory(
+                    at: overrideURL,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o700]
+                )
+                return overrideURL
+            } catch {
+                logger.error("GHOSTTIES_STATE_DIR override (\(expanded, privacy: .public)) unusable: \(error.localizedDescription) — falling back to default state directory")
+            }
+        }
+        return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent(directoryName, isDirectory: true)
     }
 

--- a/macos/Tests/Workspace/WorkspacePersistenceTests.swift
+++ b/macos/Tests/Workspace/WorkspacePersistenceTests.swift
@@ -567,6 +567,29 @@ struct WorkspacePersistenceTests {
         #expect(toastVisible == false)
     }
 
+    // MARK: - GHOSTTIES_STATE_DIR Override
+
+    @Test func stateDirOverrideIsUsedWhenSet() {
+        let overridePath = NSTemporaryDirectory().appending("ghostties-state-dir-override-test-\(UUID().uuidString)")
+        setenv("GHOSTTIES_STATE_DIR", overridePath, 1)
+        defer {
+            unsetenv("GHOSTTIES_STATE_DIR")
+            try? FileManager.default.removeItem(atPath: overridePath)
+        }
+
+        let resolved = WorkspacePersistence.directory
+        #expect(resolved.path == overridePath)
+    }
+
+    @Test func stateDirOverrideUnsetUsesBundleDerivedDirectory() {
+        unsetenv("GHOSTTIES_STATE_DIR")
+
+        let resolved = WorkspacePersistence.directory
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        #expect(resolved.deletingLastPathComponent().path == appSupport.path)
+        #expect(resolved.lastPathComponent == "Ghostties" || resolved.lastPathComponent == "Ghostties Dev")
+    }
+
     @Test func decodingCorruptMigrationFlagDefaultsToNotMigrated() throws {
         // A non-bool value where the flag should be → safe default `false`
         // (treat as not-yet-migrated). This is intentional: the migration


### PR DESCRIPTION
`WorkspacePersistence` derives its state directory from the bundle identifier, with no way to point it elsewhere. That means any lab launch, UI test, or capture run shares `workspace.json` with the real user — and prunes their session list as a side effect.

This adds a single environment override at the one resolution point. When `GHOSTTIES_STATE_DIR` is set and non-empty, it becomes the state directory (leading `~` expanded, directory created if absent, falling back with a logged error if unusable). Unset or empty behaves exactly as before, so the shipping app is unaffected.

The only visibility change is `directory` going from `private static` to `static`, as the seam that makes the resolution point testable.

## Why

Unblocks pointing `MarketingCaptureUITests` at the seeded demo workspace instead of the hardcoded fixture cast, and fixes lab launches pruning the real session list.

## Verification

- Full suite: 1077 total, 1071 passed, 5 failed, 1 skipped. All five failures are the known pre-existing timing-sensitive cases on `main` (`GitWorktreeCreationTests.raceReturnsTimedOutWhenTheUnderlyingTaskNeverCompletes` plus four `SessionComposerWorktreeLaunchTests`). Zero new failures.
- Both new tests mutation-proved: guard forced false → red; fallback path component changed → red; each green after restore.

Non-visual change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Z9rKHtTP8WQADnfgHogtL